### PR TITLE
fix: score animation bug

### DIFF
--- a/src/components/features/ScoreBoard.tsx
+++ b/src/components/features/ScoreBoard.tsx
@@ -106,6 +106,17 @@ const PlayerRow = ({ player, lastEvent, onClick, onRiichi, useChip, isDealer }: 
       if (myDelta) {
          // Trigger 2-stage animation
          const totalDelta = myDelta.hand + myDelta.sticks;
+
+         // Sanity Check for invalid/astronomical deltas
+         // Prevents animation bugs where startScore becomes huge (e.g. -5e31)
+         if (!Number.isFinite(totalDelta) || Math.abs(totalDelta) > 500000) {
+             console.warn('ScoreBoard: Detected astronomical delta, skipping animation.', totalDelta);
+             setDisplayScore(player.score);
+             prevEventIdRef.current = lastEvent.id;
+             prevScoreRef.current = player.score;
+             return;
+         }
+
          const startScore = player.score - totalDelta; // Reconstruct start
          
          // Setup
@@ -127,7 +138,7 @@ const PlayerRow = ({ player, lastEvent, onClick, onRiichi, useChip, isDealer }: 
          else if (myDelta.sticks !== 0) setDelta({ value: myDelta.sticks, type: 'stick' });
          
          // Animation Loop
-         const startTime = Date.now();
+         const startTime = performance.now();
          
          const animate = (now: number) => {
              const elapsed = now - startTime;

--- a/src/pages/MatchPage.tsx
+++ b/src/pages/MatchPage.tsx
@@ -208,9 +208,9 @@ export const MatchPage = () => {
     const finalDeltas = new Map<string, { total: number, hand: number, sticks: number, chips: number }>();
     playerIds.forEach(id => finalDeltas.set(id, { total: 0, hand: 0, sticks: 0, chips: 0 }));
 
-    let remainingRiichi = round.riichiSticks;
+    let remainingRiichi = Number(round.riichiSticks) || 0;
     // eslint-disable-next-line prefer-const
-    let remainingHonba = round.honba;
+    let remainingHonba = Number(round.honba) || 0;
 
     results.forEach((res, index) => {
         const sticksToTake = index === 0 ? remainingRiichi : 0;


### PR DESCRIPTION
Fixed score animation bug where astronomical numbers were displayed due to timestamp mismatch between Date.now() and performance.now(). Also added sanity checks for delta values and input validation for score calculation.