### PR TITLE
feat: Implement 3-player specific Tsumo scoring logic

### DIFF
--- a/src/components/features/ScoringModal.tsx
+++ b/src/components/features/ScoringModal.tsx
@@ -113,7 +113,8 @@ export const ScoringModal = ({ isOpen, onClose, players, dealerId, initialWinner
     // Logic to force Mangan+ if han >= 5 is handled by passing correct Han/Fu to calculator
     // But here we rely on calculator lookup.
     // Use calculator
-    const payment = calculateScore(han, fu, isDealer, isTsumo);
+    const is3Player = players.length === 3;
+    const payment = calculateScore(han, fu, isDealer, isTsumo, is3Player);
     
     const newResult: WinResult = { winnerId, han, fu, payment, chips: 0 };
     const nextResults = [...results, newResult];

--- a/src/utils/scoreCalculator.ts
+++ b/src/utils/scoreCalculator.ts
@@ -56,16 +56,28 @@ export const calculateScore = (
   han: number,
   fu: number,
   isDealer: boolean,
-  isTsumo: boolean
+  isTsumo: boolean,
+  is3Player: boolean = false
 ): ScorePayment => {
   const { points: base, name } = calculateBasePoints(han, fu);
 
   if (isDealer) {
     if (isTsumo) {
-      // Dealer Tsumo: All Ko pay ceil100(base * 2)
-      const pay = ceil100(base * 2);
+      // Dealer Tsumo
+      // 4ma: All Ko pay ceil100(base * 2)
+      const basePay = ceil100(base * 2);
+
+      let finalPay = basePay;
+      if (is3Player) {
+        // 3ma: Phantom (North) would pay basePay.
+        // Split this phantom payment between 2 remaining players.
+        const phantomPayment = basePay;
+        const splitPart = ceil100(phantomPayment / 2);
+        finalPay += splitPart;
+      }
+
       return {
-        tsumoAll: pay,
+        tsumoAll: finalPay,
         basePoints: base,
         name
       };
@@ -81,12 +93,26 @@ export const calculateScore = (
   } else {
     // Non-Dealer
     if (isTsumo) {
-      // Kid Tsumo: Dealer pays ceil100(base * 2), Kid pays ceil100(base)
-      const payOya = ceil100(base * 2);
-      const payKo = ceil100(base);
+      // Kid Tsumo
+      // 4ma: Dealer pays ceil100(base * 2), Kid pays ceil100(base)
+      const basePayOya = ceil100(base * 2);
+      const basePayKo = ceil100(base);
+
+      let finalPayOya = basePayOya;
+      let finalPayKo = basePayKo;
+
+      if (is3Player) {
+        // 3ma: Phantom (North) would pay basePayKo (since North is Treated as Ko).
+        const phantomPayment = basePayKo;
+        const splitPart = ceil100(phantomPayment / 2);
+
+        finalPayOya += splitPart;
+        finalPayKo += splitPart;
+      }
+
       return {
-        tsumoOya: payOya,
-        tsumoKo: payKo,
+        tsumoOya: finalPayOya,
+        tsumoKo: finalPayKo,
         basePoints: base,
         name
       };


### PR DESCRIPTION
Implement specific scoring rules for 3-player Mahjong (Sanma) Tsumo.
- Phantom payment from North player is calculated and split between remaining players.
- Split amount is rounded up to nearest 100.
- Verified with unit tests covering Child Mangan, Child 2 Han, and Dealer Mangan cases.