### PR TITLE
chore: ドキュメント更新のみの場合にビルドとデプロイをスキップする

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -20,8 +20,30 @@ jobs:
       VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
     steps:
       - uses: actions/checkout@v4
+      
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            app:
+              - 'src/**'
+              - 'public/**'
+              - 'index.html'
+              - 'vite.config.ts'
+              - 'tsconfig*.json'
+              - 'package*.json'
+              - 'package-lock.json'
+              - 'firebase.json'
+              - '.firebaserc'
+              - 'firestore.rules'
+              - 'firestore.indexes.json'
+              - 'eslint.config.js'
+
       - run: npm ci && npm run build
+        if: steps.changes.outputs.app == 'true'
+
       - uses: FirebaseExtended/action-hosting-deploy@v0
+        if: steps.changes.outputs.app == 'true'
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_MAHJONG_POINT_MANAGER }}


### PR DESCRIPTION
## 概要
ドキュメント更新のみのPull Requestの場合、デプロイやテスト（ビルド）を行わないように変更しました。ただし、Branch Protection RulesのCheckをパスさせるために、ジョブ自体は正常終了するようにしています。

## 変更内容
- `.github/workflows/firebase-hosting-pull-request.yml` に `dorny/paths-filter` を追加
- アプリケーションコード（src, public, configファイル等）に変更がある場合のみ `npm run build` と Firebase Deploy を実行するように修正

## 確認方法
- 本PRが正常にCheckをパスすること
- 今後、READMEのみの更新などでDeployがスキップされること