### PR TITLE
feat: オカあり設定のチェックボックスを削除

### DIFF
--- a/src/components/CreateRoomModal.tsx
+++ b/src/components/CreateRoomModal.tsx
@@ -447,21 +447,6 @@ export const CreateRoomModal: React.FC<CreateRoomModalProps> = ({
             />
 
             <Switch
-              checked={settings.useOka}
-              onChange={(checked) => {
-                handleChange('useOka', checked);
-                if (!checked) {
-                  handleChange('returnPoint', settings.startPoint);
-                } else {
-                  if (settings.returnPoint === settings.startPoint) {
-                    handleChange('returnPoint', settings.startPoint + 5000);
-                  }
-                }
-              }}
-              label="オカあり (返し点を設定)"
-            />
-
-            <Switch
               checked={settings.useTobi}
               onChange={(checked) => handleChange('useTobi', checked)}
               label="トビ終了あり"


### PR DESCRIPTION
オカありのチェックボックスを削除しました。オカの有無は配給原点と返し点の設定によって決定されるため、機能的な影響はありません。