### PR TITLE
feat: 大会ルール設定コンポーネント抽出とダッシュボード編集機能

### DIFF
--- a/src/components/features/CompetitionForm.tsx
+++ b/src/components/features/CompetitionForm.tsx
@@ -4,6 +4,7 @@ import { DEFAULT_COMPETITION_SETTINGS } from '../../utils/competitionDefaults';
 import { Button } from '../ui/Button';
 import { Input } from '../ui/Input';
 import { Switch } from '../ui/Switch';
+import { CompetitionRuleSettings } from './CompetitionRuleSettings';
 import styles from './CompetitionForm.module.css';
 
 interface CompetitionFormProps {
@@ -25,22 +26,6 @@ export const CompetitionForm: React.FC<CompetitionFormProps> = ({ onSubmit, load
   const [settings, setSettings] = useState<CompetitionSettings>({
     ...DEFAULT_COMPETITION_SETTINGS,
   });
-
-  const [umaPreset, setUmaPreset] = useState<'5-10' | '10-20' | '10-30' | 'custom'>('10-30');
-
-  const handleChange = <K extends keyof CompetitionSettings>(
-    key: K,
-    value: CompetitionSettings[K],
-  ) => {
-    setSettings((prev) => ({ ...prev, [key]: value }));
-  };
-
-  const applyUmaPreset = (preset: '5-10' | '10-20' | '10-30' | 'custom') => {
-    setUmaPreset(preset);
-    if (preset === '5-10') handleChange('uma', [5, 10]);
-    else if (preset === '10-20') handleChange('uma', [10, 20]);
-    else if (preset === '10-30') handleChange('uma', [10, 30]);
-  };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -90,175 +75,7 @@ export const CompetitionForm: React.FC<CompetitionFormProps> = ({ onSubmit, load
 
       <hr className={styles.divider} />
 
-      {/* ルール設定 */}
-      <div className={styles.fieldGroup}>
-        <label className={styles.label}>対局形式</label>
-        <div className={styles.buttonRow}>
-          <Button
-            type="button"
-            variant={settings.length === 'Hanchan' ? 'primary' : 'secondary'}
-            onClick={() => handleChange('length', 'Hanchan')}
-            style={{ flex: 1 }}
-          >
-            半荘
-          </Button>
-          <Button
-            type="button"
-            variant={settings.length === 'Tonpu' ? 'primary' : 'secondary'}
-            onClick={() => handleChange('length', 'Tonpu')}
-            style={{ flex: 1 }}
-          >
-            東風
-          </Button>
-        </div>
-      </div>
-
-      {/* 原点 */}
-      <div className={styles.fieldGroup}>
-        <label className={styles.label}>配給原点</label>
-        <div className={styles.gridRow}>
-          <div>
-            <span className={styles.subLabel}>4麻</span>
-            <Input
-              type="number"
-              value={settings.startPoint4ma}
-              onChange={(e) => handleChange('startPoint4ma', Number(e.target.value))}
-              fullWidth
-            />
-          </div>
-          <div>
-            <span className={styles.subLabel}>3麻</span>
-            <Input
-              type="number"
-              value={settings.startPoint3ma}
-              onChange={(e) => handleChange('startPoint3ma', Number(e.target.value))}
-              fullWidth
-            />
-          </div>
-        </div>
-      </div>
-
-      {/* 返し点 */}
-      <div className={styles.fieldGroup}>
-        <label className={styles.label}>返し点</label>
-        <div className={styles.gridRow}>
-          <div>
-            <span className={styles.subLabel}>4麻</span>
-            <Input
-              type="number"
-              value={settings.returnPoint4ma}
-              onChange={(e) => handleChange('returnPoint4ma', Number(e.target.value))}
-              fullWidth
-            />
-          </div>
-          <div>
-            <span className={styles.subLabel}>3麻</span>
-            <Input
-              type="number"
-              value={settings.returnPoint3ma}
-              onChange={(e) => handleChange('returnPoint3ma', Number(e.target.value))}
-              fullWidth
-            />
-          </div>
-        </div>
-      </div>
-
-      {/* ウマ */}
-      <div className={styles.fieldGroup}>
-        <label className={styles.label}>ウマ (順位点)</label>
-        <div className={styles.presetRow}>
-          <Button
-            type="button"
-            size="small"
-            variant={umaPreset === '5-10' ? 'primary' : 'secondary'}
-            onClick={() => applyUmaPreset('5-10')}
-          >
-            ゴットー (5-10)
-          </Button>
-          <Button
-            type="button"
-            size="small"
-            variant={umaPreset === '10-20' ? 'primary' : 'secondary'}
-            onClick={() => applyUmaPreset('10-20')}
-          >
-            ワンツー (10-20)
-          </Button>
-          <Button
-            type="button"
-            size="small"
-            variant={umaPreset === '10-30' ? 'primary' : 'secondary'}
-            onClick={() => applyUmaPreset('10-30')}
-          >
-            ワンスリー (10-30)
-          </Button>
-          <Button
-            type="button"
-            size="small"
-            variant={umaPreset === 'custom' ? 'primary' : 'secondary'}
-            onClick={() => applyUmaPreset('custom')}
-          >
-            カスタム
-          </Button>
-        </div>
-        {umaPreset === 'custom' && (
-          <div className={styles.gridRow}>
-            <div>
-              <span className={styles.subLabel}>2着/3着</span>
-              <Input
-                type="number"
-                value={settings.uma[0]}
-                onChange={(e) => handleChange('uma', [Number(e.target.value), settings.uma[1]])}
-                fullWidth
-              />
-            </div>
-            <div>
-              <span className={styles.subLabel}>1着/4着</span>
-              <Input
-                type="number"
-                value={settings.uma[1]}
-                onChange={(e) => handleChange('uma', [settings.uma[0], Number(e.target.value)])}
-                fullWidth
-              />
-            </div>
-          </div>
-        )}
-      </div>
-
-      <hr className={styles.divider} />
-
-      {/* Switch 設定群 */}
-      <div className={styles.switchGroup}>
-        <Switch
-          checked={settings.tenpaiRenchan}
-          onChange={(checked) => handleChange('tenpaiRenchan', checked)}
-          label="テンパイ連荘"
-        />
-        <Switch
-          checked={settings.useTobi}
-          onChange={(checked) => handleChange('useTobi', checked)}
-          label="トビ (ハコ割れ終了)"
-        />
-        <Switch
-          checked={settings.useChip}
-          onChange={(checked) => handleChange('useChip', checked)}
-          label="チップ"
-        />
-        <Switch
-          checked={settings.useOka}
-          onChange={(checked) => handleChange('useOka', checked)}
-          label="オカ"
-        />
-        <Switch
-          checked={settings.useFuCalculation}
-          onChange={(checked) => handleChange('useFuCalculation', checked)}
-          label="符計算あり"
-        />
-        <Switch
-          checked={settings.westExtension}
-          onChange={(checked) => handleChange('westExtension', checked)}
-          label="西入 (延長)"
-        />
-      </div>
+      <CompetitionRuleSettings settings={settings} onChange={setSettings} />
 
       <Button type="submit" variant="primary" fullWidth disabled={!name.trim() || loading}>
         {loading ? '作成中...' : '大会を作成'}

--- a/src/components/features/CompetitionRuleSettings.module.css
+++ b/src/components/features/CompetitionRuleSettings.module.css
@@ -1,0 +1,106 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-l);
+}
+
+.fieldGroup {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-s);
+}
+
+.label {
+  display: block;
+  margin-bottom: var(--spacing-xs);
+  font-weight: var(--font-weight-bold);
+}
+
+.subLabel {
+  display: block;
+  font-size: var(--font-size-s);
+  color: var(--color-text-secondary);
+  margin-bottom: var(--spacing-xs);
+}
+
+.buttonRow {
+  display: flex;
+  gap: var(--spacing-s);
+}
+
+.presetRow {
+  display: flex;
+  gap: var(--spacing-s);
+  flex-wrap: wrap;
+}
+
+.gridRow {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--spacing-s);
+}
+
+.divider {
+  width: 100%;
+  border: none;
+  border-top: 1px solid var(--color-bg-card);
+}
+
+.switchGroup {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-m);
+}
+
+.conditionalSection {
+  margin-top: var(--spacing-s);
+  padding: var(--spacing-m);
+  background-color: rgba(0, 0, 0, 0.2);
+  border-radius: var(--border-radius-m);
+}
+
+.stepperRow {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-s);
+}
+
+.stepperValue {
+  min-width: 40px;
+  text-align: center;
+}
+
+.fixedPointTable {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-s);
+}
+
+.fixedPointRow {
+  display: grid;
+  grid-template-columns: 72px 1fr 1fr;
+  gap: var(--spacing-s);
+  align-items: center;
+}
+
+.fixedPointCell {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-s);
+}
+
+.fixedPointCellLabel {
+  min-width: 24px;
+}
+
+.fixedPointCellValue {
+  min-width: 56px;
+  text-align: center;
+}
+
+.rateSection {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-s);
+}

--- a/src/components/features/CompetitionRuleSettings.tsx
+++ b/src/components/features/CompetitionRuleSettings.tsx
@@ -1,0 +1,399 @@
+import React, { useState } from 'react';
+import type { CompetitionSettings, NoFuFixedPointHan } from '../../types';
+import { cloneNoFuFixedPoints } from '../../utils/gameSettings';
+import { Button } from '../ui/Button';
+import { Input } from '../ui/Input';
+import { Switch } from '../ui/Switch';
+import styles from './CompetitionRuleSettings.module.css';
+
+const NO_FU_FIXED_POINT_HAN_LIST: NoFuFixedPointHan[] = [1, 2, 3];
+
+const UMA_PRESETS = {
+  '5-10': [5, 10] as [number, number],
+  '10-20': [10, 20] as [number, number],
+  '10-30': [10, 30] as [number, number],
+};
+
+type UmaPreset = keyof typeof UMA_PRESETS | 'custom';
+
+const detectUmaPreset = (uma: [number, number]): UmaPreset => {
+  for (const [key, value] of Object.entries(UMA_PRESETS)) {
+    if (uma[0] === value[0] && uma[1] === value[1]) return key as keyof typeof UMA_PRESETS;
+  }
+  return 'custom';
+};
+
+interface CompetitionRuleSettingsProps {
+  settings: CompetitionSettings;
+  onChange: (settings: CompetitionSettings) => void;
+  disabled?: boolean;
+}
+
+export const CompetitionRuleSettings: React.FC<CompetitionRuleSettingsProps> = ({
+  settings,
+  onChange,
+  disabled = false,
+}) => {
+  const [umaPreset, setUmaPreset] = useState<UmaPreset>(() => detectUmaPreset(settings.uma));
+
+  const handleChange = <K extends keyof CompetitionSettings>(
+    key: K,
+    value: CompetitionSettings[K],
+  ) => {
+    onChange({ ...settings, [key]: value });
+  };
+
+  const applyUmaPreset = (preset: UmaPreset) => {
+    setUmaPreset(preset);
+    if (preset !== 'custom') {
+      handleChange('uma', UMA_PRESETS[preset]);
+    }
+  };
+
+  const handleNoFuFixedPointChange = (
+    han: NoFuFixedPointHan,
+    target: 'child' | 'dealer',
+    delta: number,
+  ) => {
+    const nextNoFuFixedPoints = cloneNoFuFixedPoints(settings.noFuFixedPoints);
+    nextNoFuFixedPoints[han] = {
+      ...nextNoFuFixedPoints[han],
+      [target]: Math.max(100, nextNoFuFixedPoints[han][target] + delta),
+    };
+    onChange({ ...settings, noFuFixedPoints: nextNoFuFixedPoints });
+  };
+
+  const noFuFixedPoints = settings.noFuFixedPoints ?? cloneNoFuFixedPoints();
+
+  return (
+    <div className={styles.container}>
+      {/* 対局形式 */}
+      <div className={styles.fieldGroup}>
+        <label className={styles.label}>対局形式</label>
+        <div className={styles.buttonRow}>
+          <Button
+            type="button"
+            variant={settings.length === 'Hanchan' ? 'primary' : 'secondary'}
+            onClick={() => handleChange('length', 'Hanchan')}
+            disabled={disabled}
+            style={{ flex: 1 }}
+          >
+            半荘
+          </Button>
+          <Button
+            type="button"
+            variant={settings.length === 'Tonpu' ? 'primary' : 'secondary'}
+            onClick={() => handleChange('length', 'Tonpu')}
+            disabled={disabled}
+            style={{ flex: 1 }}
+          >
+            東風
+          </Button>
+        </div>
+      </div>
+
+      {/* 配給原点 */}
+      <div className={styles.fieldGroup}>
+        <label className={styles.label}>配給原点</label>
+        <div className={styles.gridRow}>
+          <div>
+            <span className={styles.subLabel}>4麻</span>
+            <Input
+              type="number"
+              value={settings.startPoint4ma}
+              onChange={(e) => handleChange('startPoint4ma', Number(e.target.value))}
+              disabled={disabled}
+              fullWidth
+            />
+          </div>
+          <div>
+            <span className={styles.subLabel}>3麻</span>
+            <Input
+              type="number"
+              value={settings.startPoint3ma}
+              onChange={(e) => handleChange('startPoint3ma', Number(e.target.value))}
+              disabled={disabled}
+              fullWidth
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* 返し点 */}
+      <div className={styles.fieldGroup}>
+        <label className={styles.label}>返し点</label>
+        <div className={styles.gridRow}>
+          <div>
+            <span className={styles.subLabel}>4麻</span>
+            <Input
+              type="number"
+              value={settings.returnPoint4ma}
+              onChange={(e) => handleChange('returnPoint4ma', Number(e.target.value))}
+              disabled={disabled}
+              fullWidth
+            />
+          </div>
+          <div>
+            <span className={styles.subLabel}>3麻</span>
+            <Input
+              type="number"
+              value={settings.returnPoint3ma}
+              onChange={(e) => handleChange('returnPoint3ma', Number(e.target.value))}
+              disabled={disabled}
+              fullWidth
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* ウマ */}
+      <div className={styles.fieldGroup}>
+        <label className={styles.label}>ウマ (順位点)</label>
+        <div className={styles.presetRow}>
+          <Button
+            type="button"
+            size="small"
+            variant={umaPreset === '5-10' ? 'primary' : 'secondary'}
+            onClick={() => applyUmaPreset('5-10')}
+            disabled={disabled}
+          >
+            ゴットー (5-10)
+          </Button>
+          <Button
+            type="button"
+            size="small"
+            variant={umaPreset === '10-20' ? 'primary' : 'secondary'}
+            onClick={() => applyUmaPreset('10-20')}
+            disabled={disabled}
+          >
+            ワンツー (10-20)
+          </Button>
+          <Button
+            type="button"
+            size="small"
+            variant={umaPreset === '10-30' ? 'primary' : 'secondary'}
+            onClick={() => applyUmaPreset('10-30')}
+            disabled={disabled}
+          >
+            ワンスリー (10-30)
+          </Button>
+          <Button
+            type="button"
+            size="small"
+            variant={umaPreset === 'custom' ? 'primary' : 'secondary'}
+            onClick={() => applyUmaPreset('custom')}
+            disabled={disabled}
+          >
+            カスタム
+          </Button>
+        </div>
+        {umaPreset === 'custom' && (
+          <div className={styles.gridRow}>
+            <div>
+              <span className={styles.subLabel}>2着/3着</span>
+              <Input
+                type="number"
+                value={settings.uma[0]}
+                onChange={(e) => handleChange('uma', [Number(e.target.value), settings.uma[1]])}
+                disabled={disabled}
+                fullWidth
+              />
+            </div>
+            <div>
+              <span className={styles.subLabel}>1着/4着</span>
+              <Input
+                type="number"
+                value={settings.uma[1]}
+                onChange={(e) => handleChange('uma', [settings.uma[0], Number(e.target.value)])}
+                disabled={disabled}
+                fullWidth
+              />
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* レート */}
+      <div className={styles.fieldGroup}>
+        <label className={styles.label}>レート</label>
+        <div className={styles.rateSection}>
+          <div className={styles.presetRow}>
+            {[0, 30, 50, 100].map((r) => (
+              <Button
+                key={r}
+                type="button"
+                size="small"
+                variant={settings.rate === r ? 'primary' : 'secondary'}
+                onClick={() => handleChange('rate', r)}
+                disabled={disabled}
+              >
+                {r === 0 ? 'なし' : r}
+              </Button>
+            ))}
+          </div>
+          {![0, 30, 50, 100].includes(settings.rate) && (
+            <Input
+              type="number"
+              value={settings.rate}
+              onChange={(e) => handleChange('rate', Math.max(0, Number(e.target.value)))}
+              disabled={disabled}
+              fullWidth
+            />
+          )}
+        </div>
+      </div>
+
+      <hr className={styles.divider} />
+
+      {/* Switch 設定群 */}
+      <div className={styles.switchGroup}>
+        <Switch
+          checked={settings.tenpaiRenchan}
+          onChange={(checked) => handleChange('tenpaiRenchan', checked)}
+          label="テンパイ連荘"
+          disabled={disabled}
+        />
+        <Switch
+          checked={settings.useTobi}
+          onChange={(checked) => handleChange('useTobi', checked)}
+          label="トビ (ハコ割れ終了)"
+          disabled={disabled}
+        />
+        <Switch
+          checked={settings.useOka}
+          onChange={(checked) => handleChange('useOka', checked)}
+          label="オカ"
+          disabled={disabled}
+        />
+        <Switch
+          checked={settings.westExtension}
+          onChange={(checked) => handleChange('westExtension', checked)}
+          label="西入 (延長)"
+          disabled={disabled}
+        />
+
+        {/* 本場 */}
+        <Switch
+          checked={settings.hasHonba}
+          onChange={(checked) => handleChange('hasHonba', checked)}
+          label="本場あり"
+          disabled={disabled}
+        />
+        {settings.hasHonba && (
+          <div className={styles.conditionalSection}>
+            <div className={styles.stepperRow}>
+              <span>1本場:</span>
+              <Button
+                type="button"
+                size="small"
+                variant="secondary"
+                onClick={() => handleChange('honbaPoints', Math.max(0, settings.honbaPoints - 100))}
+                disabled={disabled}
+                style={{ padding: '2px 8px', minWidth: '30px' }}
+              >
+                -
+              </Button>
+              <span className={styles.stepperValue}>{settings.honbaPoints}</span>
+              <Button
+                type="button"
+                size="small"
+                variant="secondary"
+                onClick={() => handleChange('honbaPoints', settings.honbaPoints + 100)}
+                disabled={disabled}
+                style={{ padding: '2px 8px', minWidth: '30px' }}
+              >
+                +
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* チップ */}
+        <Switch
+          checked={settings.useChip}
+          onChange={(checked) => handleChange('useChip', checked)}
+          label="チップ"
+          disabled={disabled}
+        />
+        {settings.useChip && (
+          <div className={styles.conditionalSection}>
+            <div className={styles.stepperRow}>
+              <span>チップレート:</span>
+              <Button
+                type="button"
+                size="small"
+                variant="secondary"
+                onClick={() => handleChange('chipRate', Math.max(0, (settings.chipRate ?? 0) - 10))}
+                disabled={disabled}
+                style={{ padding: '2px 8px', minWidth: '30px' }}
+              >
+                -
+              </Button>
+              <span className={styles.stepperValue}>{settings.chipRate ?? 0}</span>
+              <Button
+                type="button"
+                size="small"
+                variant="secondary"
+                onClick={() => handleChange('chipRate', (settings.chipRate ?? 0) + 10)}
+                disabled={disabled}
+                style={{ padding: '2px 8px', minWidth: '30px' }}
+              >
+                +
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* 符計算 */}
+        <Switch
+          checked={settings.useFuCalculation}
+          onChange={(checked) => handleChange('useFuCalculation', checked)}
+          label="符計算あり"
+          disabled={disabled}
+        />
+        {!settings.useFuCalculation && (
+          <div className={styles.conditionalSection}>
+            <div className={styles.fixedPointTable}>
+              <div style={{ fontWeight: 'var(--font-weight-bold)' }}>1〜3翻 固定点</div>
+              {NO_FU_FIXED_POINT_HAN_LIST.map((han) => (
+                <div key={han} className={styles.fixedPointRow}>
+                  <span>{han}翻</span>
+                  {(['child', 'dealer'] as const).map((target) => (
+                    <div key={target} className={styles.fixedPointCell}>
+                      <span className={styles.fixedPointCellLabel}>
+                        {target === 'child' ? '子' : '親'}
+                      </span>
+                      <Button
+                        type="button"
+                        size="small"
+                        variant="secondary"
+                        onClick={() => handleNoFuFixedPointChange(han, target, -100)}
+                        disabled={disabled}
+                        style={{ padding: '2px 8px', minWidth: '30px' }}
+                      >
+                        -
+                      </Button>
+                      <span className={styles.fixedPointCellValue}>
+                        {noFuFixedPoints[han][target]}
+                      </span>
+                      <Button
+                        type="button"
+                        size="small"
+                        variant="secondary"
+                        onClick={() => handleNoFuFixedPointChange(han, target, 100)}
+                        disabled={disabled}
+                        style={{ padding: '2px 8px', minWidth: '30px' }}
+                      >
+                        +
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/pages/CompetitionDashboardPage.module.css
+++ b/src/pages/CompetitionDashboardPage.module.css
@@ -73,3 +73,32 @@
   font-size: var(--font-size-s);
   color: var(--color-text-secondary);
 }
+
+.sectionHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--spacing-s);
+}
+
+.sectionHeader .sectionTitle {
+  margin-bottom: 0;
+}
+
+.ruleGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--spacing-s);
+}
+
+.editSection {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-l);
+}
+
+.editActions {
+  display: flex;
+  gap: var(--spacing-s);
+  justify-content: flex-end;
+}

--- a/src/pages/CompetitionDashboardPage.tsx
+++ b/src/pages/CompetitionDashboardPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
+import { CompetitionRuleSettings } from '../components/features/CompetitionRuleSettings';
 import { CompetitionStatusBadge } from '../components/features/CompetitionStatusBadge';
 import { ShareCompetitionModal } from '../components/features/ShareCompetitionModal';
 import { Button } from '../components/ui/Button';
@@ -8,7 +9,7 @@ import { useSnackbar } from '../contexts/SnackbarContext';
 import { useCompetition } from '../hooks/useCompetition';
 import { updateCompetition } from '../services/competitionService';
 import { auth } from '../services/firebase';
-import type { CompetitionStatus } from '../types';
+import type { CompetitionSettings, CompetitionStatus } from '../types';
 import styles from './CompetitionDashboardPage.module.css';
 
 const NEXT_STATUS: Partial<Record<CompetitionStatus, CompetitionStatus>> = {
@@ -33,6 +34,8 @@ export const CompetitionDashboardPage = () => {
   const [isShareOpen, setIsShareOpen] = useState(false);
   const [isConfirmOpen, setIsConfirmOpen] = useState(false);
   const [updating, setUpdating] = useState(false);
+  const [isEditingRules, setIsEditingRules] = useState(false);
+  const [editSettings, setEditSettings] = useState<CompetitionSettings | null>(null);
 
   const currentUserId = auth.currentUser?.uid;
   const isOrganizer = competition?.organizerId === currentUserId;
@@ -58,6 +61,33 @@ export const CompetitionDashboardPage = () => {
     } catch (error) {
       console.error('Failed to update status:', error);
       showSnackbar('ステータスの更新に失敗しました');
+    } finally {
+      setUpdating(false);
+    }
+  };
+
+  const handleStartEditRules = () => {
+    if (!competition) return;
+    setEditSettings({ ...competition.settings });
+    setIsEditingRules(true);
+  };
+
+  const handleCancelEditRules = () => {
+    setIsEditingRules(false);
+    setEditSettings(null);
+  };
+
+  const handleSaveRules = async () => {
+    if (!id || !editSettings) return;
+    setUpdating(true);
+    try {
+      await updateCompetition(id, { settings: editSettings });
+      setIsEditingRules(false);
+      setEditSettings(null);
+      showSnackbar('ルール設定を保存しました');
+    } catch (error) {
+      console.error('Failed to save rules:', error);
+      showSnackbar('ルール設定の保存に失敗しました');
     } finally {
       setUpdating(false);
     }
@@ -125,35 +155,85 @@ export const CompetitionDashboardPage = () => {
       </div>
 
       <div className={styles.section}>
-        <h2 className={styles.sectionTitle}>ルール設定</h2>
-        <div className={styles.infoCard}>
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 'var(--spacing-s)' }}>
-            <div>
-              <div className={styles.infoLabel}>対局形式</div>
-              <div className={styles.infoValue}>
-                {competition.settings.length === 'Hanchan' ? '半荘' : '東風'}
-              </div>
-            </div>
-            <div>
-              <div className={styles.infoLabel}>ウマ</div>
-              <div className={styles.infoValue}>
-                {competition.settings.uma[0]}-{competition.settings.uma[1]}
-              </div>
-            </div>
-            <div>
-              <div className={styles.infoLabel}>原点 (4麻)</div>
-              <div className={styles.infoValue}>
-                {competition.settings.startPoint4ma.toLocaleString()}
-              </div>
-            </div>
-            <div>
-              <div className={styles.infoLabel}>原点 (3麻)</div>
-              <div className={styles.infoValue}>
-                {competition.settings.startPoint3ma.toLocaleString()}
-              </div>
+        <div className={styles.sectionHeader}>
+          <h2 className={styles.sectionTitle}>ルール設定</h2>
+          {isOrganizer && competition.status === 'recruiting' && !isEditingRules && (
+            <Button size="small" variant="secondary" onClick={handleStartEditRules}>
+              編集
+            </Button>
+          )}
+        </div>
+        {isEditingRules && editSettings ? (
+          <div className={styles.editSection}>
+            <CompetitionRuleSettings settings={editSettings} onChange={setEditSettings} />
+            <div className={styles.editActions}>
+              <Button
+                size="small"
+                variant="secondary"
+                onClick={handleCancelEditRules}
+                disabled={updating}
+              >
+                キャンセル
+              </Button>
+              <Button size="small" variant="primary" onClick={handleSaveRules} disabled={updating}>
+                {updating ? '保存中...' : '保存'}
+              </Button>
             </div>
           </div>
-        </div>
+        ) : (
+          <div className={styles.infoCard}>
+            <div className={styles.ruleGrid}>
+              <div>
+                <div className={styles.infoLabel}>対局形式</div>
+                <div className={styles.infoValue}>
+                  {competition.settings.length === 'Hanchan' ? '半荘' : '東風'}
+                </div>
+              </div>
+              <div>
+                <div className={styles.infoLabel}>ウマ</div>
+                <div className={styles.infoValue}>
+                  {competition.settings.uma[0]}-{competition.settings.uma[1]}
+                </div>
+              </div>
+              <div>
+                <div className={styles.infoLabel}>原点 (4麻)</div>
+                <div className={styles.infoValue}>
+                  {competition.settings.startPoint4ma.toLocaleString()}
+                </div>
+              </div>
+              <div>
+                <div className={styles.infoLabel}>原点 (3麻)</div>
+                <div className={styles.infoValue}>
+                  {competition.settings.startPoint3ma.toLocaleString()}
+                </div>
+              </div>
+              <div>
+                <div className={styles.infoLabel}>返し点 (4麻)</div>
+                <div className={styles.infoValue}>
+                  {competition.settings.returnPoint4ma.toLocaleString()}
+                </div>
+              </div>
+              <div>
+                <div className={styles.infoLabel}>返し点 (3麻)</div>
+                <div className={styles.infoValue}>
+                  {competition.settings.returnPoint3ma.toLocaleString()}
+                </div>
+              </div>
+              <div>
+                <div className={styles.infoLabel}>レート</div>
+                <div className={styles.infoValue}>
+                  {competition.settings.rate === 0 ? 'なし' : competition.settings.rate}
+                </div>
+              </div>
+              {competition.settings.useChip && (
+                <div>
+                  <div className={styles.infoLabel}>チップレート</div>
+                  <div className={styles.infoValue}>{competition.settings.chipRate ?? 0}</div>
+                </div>
+              )}
+            </div>
+          </div>
+        )}
       </div>
 
       {/* 共有モーダル */}

--- a/src/utils/competitionDefaults.test.ts
+++ b/src/utils/competitionDefaults.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { CompetitionSettings } from '../types';
+import { DEFAULT_NO_FU_FIXED_POINTS } from './gameSettings';
 import {
   buildGameSettingsFromCompetition,
   DEFAULT_COMPETITION_SETTINGS,
@@ -19,11 +20,29 @@ describe('DEFAULT_COMPETITION_SETTINGS', () => {
       tenpaiRenchan: true,
       useTobi: true,
       useChip: false,
+      chipRate: 0,
       useOka: true,
       useFuCalculation: true,
+      noFuFixedPoints: DEFAULT_NO_FU_FIXED_POINTS,
       westExtension: false,
       rate: 0,
     });
+  });
+
+  it('should include chipRate field with default 0', () => {
+    expect(DEFAULT_COMPETITION_SETTINGS.chipRate).toBe(0);
+  });
+
+  it('should include noFuFixedPoints with default values', () => {
+    expect(DEFAULT_COMPETITION_SETTINGS.noFuFixedPoints).toEqual({
+      1: { child: 1000, dealer: 1500 },
+      2: { child: 2000, dealer: 3000 },
+      3: { child: 4000, dealer: 6000 },
+    });
+  });
+
+  it('should have its own copy of noFuFixedPoints (not shared reference)', () => {
+    expect(DEFAULT_COMPETITION_SETTINGS.noFuFixedPoints).not.toBe(DEFAULT_NO_FU_FIXED_POINTS);
   });
 });
 
@@ -40,8 +59,14 @@ describe('buildGameSettingsFromCompetition', () => {
     tenpaiRenchan: true,
     useTobi: true,
     useChip: false,
+    chipRate: 0,
     useOka: true,
     useFuCalculation: true,
+    noFuFixedPoints: {
+      1: { child: 1000, dealer: 1500 },
+      2: { child: 2000, dealer: 3000 },
+      3: { child: 4000, dealer: 6000 },
+    },
     westExtension: false,
     rate: 0,
   };
@@ -68,5 +93,37 @@ describe('buildGameSettingsFromCompetition', () => {
     expect(result.returnPoint).toBe(40000);
     expect(result.length).toBe('Hanchan');
     expect(result.uma).toEqual([10, 30]);
+  });
+
+  it('should propagate chipRate when useChip is true', () => {
+    const chipSettings: CompetitionSettings = {
+      ...settings,
+      useChip: true,
+      chipRate: 100,
+    };
+    const result = buildGameSettingsFromCompetition(chipSettings, '4ma');
+
+    expect(result.useChip).toBe(true);
+    expect(result.chipRate).toBe(100);
+  });
+
+  it('should propagate noFuFixedPoints when useFuCalculation is false', () => {
+    const customNoFu: CompetitionSettings = {
+      ...settings,
+      useFuCalculation: false,
+      noFuFixedPoints: {
+        1: { child: 1500, dealer: 2000 },
+        2: { child: 3000, dealer: 4000 },
+        3: { child: 6000, dealer: 8000 },
+      },
+    };
+    const result = buildGameSettingsFromCompetition(customNoFu, '3ma');
+
+    expect(result.useFuCalculation).toBe(false);
+    expect(result.noFuFixedPoints).toEqual({
+      1: { child: 1500, dealer: 2000 },
+      2: { child: 3000, dealer: 4000 },
+      3: { child: 6000, dealer: 8000 },
+    });
   });
 });

--- a/src/utils/competitionDefaults.ts
+++ b/src/utils/competitionDefaults.ts
@@ -1,4 +1,5 @@
 import type { CompetitionSettings, GameSettings } from '../types';
+import { cloneNoFuFixedPoints } from './gameSettings';
 
 export const DEFAULT_COMPETITION_SETTINGS: CompetitionSettings = {
   length: 'Hanchan',
@@ -12,8 +13,10 @@ export const DEFAULT_COMPETITION_SETTINGS: CompetitionSettings = {
   tenpaiRenchan: true,
   useTobi: true,
   useChip: false,
+  chipRate: 0,
   useOka: true,
   useFuCalculation: true,
+  noFuFixedPoints: cloneNoFuFixedPoints(),
   westExtension: false,
   rate: 0,
 };


### PR DESCRIPTION
## 概要

大会ルール設定UIを専用コンポーネント `CompetitionRuleSettings` に抽出し、ダッシュボードからのルール編集機能を追加。

### 主な変更

- **CompetitionRuleSettings コンポーネント新規作成** — 本場点 stepper / チップレート / 符なし固定点テーブル / レートプリセットを含む全ルール設定UI
- **CompetitionForm のリファクタリング** — ルール設定部分を CompetitionRuleSettings に委譲し、フォーム本体を簡素化
- **CompetitionDashboardPage にルール編集モード追加** — 主催者かつ recruiting 状態の大会でルール編集が可能
- **competitionDefaults に chipRate / noFuFixedPoints のデフォルト値追加**
- **テスト追加** — chipRate / noFuFixedPoints の伝播テスト

## 変更ファイル (7 files, +700 / -209)

### 新規
- `src/components/features/CompetitionRuleSettings.tsx` — ルール設定コンポーネント
- `src/components/features/CompetitionRuleSettings.module.css` — スタイル

### 修正
- `src/components/features/CompetitionForm.tsx` — ルール設定を CompetitionRuleSettings に抽出
- `src/pages/CompetitionDashboardPage.tsx` — ルール編集モード追加
- `src/pages/CompetitionDashboardPage.module.css` — 編集モード用スタイル
- `src/utils/competitionDefaults.ts` — デフォルト値追加
- `src/utils/competitionDefaults.test.ts` — テスト追加

## テスト計画

- [x] 全 153 テストパス
- [x] lint パス
- [x] build パス

## 関連

Part of #71
Closes #64
