### PR TITLE
feat: 参加者登録機能 — アカウント/ゲスト登録・共同主催者管理

### DIFF
--- a/src/components/features/AddGuestModal.tsx
+++ b/src/components/features/AddGuestModal.tsx
@@ -1,0 +1,64 @@
+import { useState } from 'react';
+import { Button } from '../ui/Button';
+import { Input } from '../ui/Input';
+import { Modal } from '../ui/Modal';
+
+interface AddGuestModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onAdd: (name: string) => Promise<void>;
+}
+
+export const AddGuestModal = ({ isOpen, onClose, onAdd }: AddGuestModalProps) => {
+  const [name, setName] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async () => {
+    const trimmed = name.trim();
+    if (!trimmed || loading) return;
+
+    setLoading(true);
+    try {
+      await onAdd(trimmed);
+      setName('');
+      onClose();
+    } catch {
+      // Error handling is delegated to callers via snackbar
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleClose = () => {
+    if (loading) return;
+    setName('');
+    onClose();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose} title="ゲストを追加">
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-m)' }}>
+        <Input
+          fullWidth
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="ゲスト名"
+          required
+          maxLength={30}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') handleSubmit();
+          }}
+        />
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 'var(--spacing-s)' }}>
+          <Button variant="secondary" onClick={handleClose} disabled={loading}>
+            キャンセル
+          </Button>
+          <Button variant="primary" onClick={handleSubmit} disabled={!name.trim() || loading}>
+            {loading ? '追加中...' : '追加'}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+};

--- a/src/components/features/ParticipantList.module.css
+++ b/src/components/features/ParticipantList.module.css
@@ -1,0 +1,62 @@
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.item {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-s);
+  padding: var(--spacing-s) var(--spacing-m);
+  background: var(--color-bg-card);
+  border-radius: var(--border-radius-m);
+}
+
+.info {
+  flex: 1;
+  min-width: 0;
+}
+
+.name {
+  font-size: var(--font-size-m);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.guestLabel {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+  margin-left: var(--spacing-xs);
+}
+
+.meta {
+  display: flex;
+  gap: var(--spacing-s);
+  margin-top: var(--spacing-xs);
+}
+
+.roleBadge {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-accent);
+  font-weight: var(--font-weight-bold);
+}
+
+.statusBadge {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+}
+
+.actions {
+  display: flex;
+  gap: var(--spacing-xs);
+  flex-shrink: 0;
+}
+
+.empty {
+  text-align: center;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-s);
+  padding: var(--spacing-m);
+}

--- a/src/components/features/ParticipantList.tsx
+++ b/src/components/features/ParticipantList.tsx
@@ -1,0 +1,101 @@
+import { Button } from '../ui/Button';
+import type { CompetitionParticipant } from '../../types';
+import styles from './ParticipantList.module.css';
+
+interface ParticipantListProps {
+  participants: CompetitionParticipant[];
+  currentUserId?: string;
+  isOrganizer: boolean;
+  onAppointCoOrganizer?: (participant: CompetitionParticipant) => void;
+  onRemoveCoOrganizer?: (participant: CompetitionParticipant) => void;
+  onRemoveParticipant?: (participant: CompetitionParticipant) => void;
+}
+
+const ROLE_ORDER: Record<string, number> = {
+  organizer: 0,
+  co_organizer: 1,
+  player: 2,
+};
+
+const ROLE_LABELS: Partial<Record<string, string>> = {
+  organizer: '主催者',
+  co_organizer: '共同主催者',
+};
+
+const STATUS_LABELS: Record<string, string> = {
+  idle: '待機中',
+  assigned: '配席済み',
+  playing: '対局中',
+};
+
+const sortParticipants = (
+  participants: readonly CompetitionParticipant[],
+): CompetitionParticipant[] =>
+  [...participants].sort((a, b) => {
+    const roleDiff = (ROLE_ORDER[a.role] ?? 99) - (ROLE_ORDER[b.role] ?? 99);
+    if (roleDiff !== 0) return roleDiff;
+    return (a.joinedAt ?? 0) - (b.joinedAt ?? 0);
+  });
+
+export const ParticipantList = ({
+  participants,
+  currentUserId,
+  isOrganizer,
+  onAppointCoOrganizer,
+  onRemoveCoOrganizer,
+  onRemoveParticipant,
+}: ParticipantListProps) => {
+  const sorted = sortParticipants(participants);
+
+  if (sorted.length === 0) {
+    return <div className={styles.empty}>参加者がいません</div>;
+  }
+
+  return (
+    <div className={styles.list}>
+      {sorted.map((p) => {
+        const roleLabel = ROLE_LABELS[p.role];
+        const statusLabel = STATUS_LABELS[p.status] ?? p.status;
+        const isSelf = p.userId === currentUserId || p.id === currentUserId;
+
+        const canAppoint = isOrganizer && !p.isGuest && p.userId && p.role === 'player' && !isSelf;
+        const canDemote = isOrganizer && p.role === 'co_organizer';
+        const canRemove = isOrganizer && p.role !== 'organizer' && !isSelf;
+
+        return (
+          <div key={p.id} className={styles.item}>
+            <div className={styles.info}>
+              <div className={styles.name}>
+                {p.name}
+                {p.isGuest && <span className={styles.guestLabel}>(ゲスト)</span>}
+              </div>
+              <div className={styles.meta}>
+                {roleLabel && <span className={styles.roleBadge}>{roleLabel}</span>}
+                <span className={styles.statusBadge}>{statusLabel}</span>
+              </div>
+            </div>
+            {isOrganizer && (
+              <div className={styles.actions}>
+                {canAppoint && onAppointCoOrganizer && (
+                  <Button size="small" variant="secondary" onClick={() => onAppointCoOrganizer(p)}>
+                    共同主催者に任命
+                  </Button>
+                )}
+                {canDemote && onRemoveCoOrganizer && (
+                  <Button size="small" variant="secondary" onClick={() => onRemoveCoOrganizer(p)}>
+                    解除
+                  </Button>
+                )}
+                {canRemove && onRemoveParticipant && (
+                  <Button size="small" variant="danger" onClick={() => onRemoveParticipant(p)}>
+                    削除
+                  </Button>
+                )}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/pages/CompetitionDashboardPage.tsx
+++ b/src/pages/CompetitionDashboardPage.tsx
@@ -1,15 +1,23 @@
 import { useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
+import { AddGuestModal } from '../components/features/AddGuestModal';
 import { CompetitionRuleSettings } from '../components/features/CompetitionRuleSettings';
 import { CompetitionStatusBadge } from '../components/features/CompetitionStatusBadge';
+import { ParticipantList } from '../components/features/ParticipantList';
 import { ShareCompetitionModal } from '../components/features/ShareCompetitionModal';
 import { Button } from '../components/ui/Button';
 import { ConfirmationDialog } from '../components/ui/ConfirmationDialog';
 import { useSnackbar } from '../contexts/SnackbarContext';
 import { useCompetition } from '../hooks/useCompetition';
-import { updateCompetition } from '../services/competitionService';
+import {
+  addGuestParticipant,
+  appointCoOrganizer,
+  removeCoOrganizer,
+  removeParticipant,
+  updateCompetition,
+} from '../services/competitionService';
 import { auth } from '../services/firebase';
-import type { CompetitionSettings, CompetitionStatus } from '../types';
+import type { CompetitionParticipant, CompetitionSettings, CompetitionStatus } from '../types';
 import styles from './CompetitionDashboardPage.module.css';
 
 const NEXT_STATUS: Partial<Record<CompetitionStatus, CompetitionStatus>> = {
@@ -36,9 +44,13 @@ export const CompetitionDashboardPage = () => {
   const [updating, setUpdating] = useState(false);
   const [isEditingRules, setIsEditingRules] = useState(false);
   const [editSettings, setEditSettings] = useState<CompetitionSettings | null>(null);
+  const [isGuestModalOpen, setIsGuestModalOpen] = useState(false);
+  const [removeTarget, setRemoveTarget] = useState<CompetitionParticipant | null>(null);
 
   const currentUserId = auth.currentUser?.uid;
   const isOrganizer = competition?.organizerId === currentUserId;
+  const isCoOrganizer = competition?.coOrganizerIds.includes(currentUserId ?? '') ?? false;
+  const canManage = isOrganizer || isCoOrganizer;
 
   const handleStatusChange = async () => {
     if (!id || !competition) return;
@@ -93,6 +105,55 @@ export const CompetitionDashboardPage = () => {
     }
   };
 
+  const handleAppointCoOrganizer = async (participant: CompetitionParticipant) => {
+    if (!id || !participant.userId) return;
+    try {
+      await appointCoOrganizer(id, participant.id, participant.userId);
+      showSnackbar(`${participant.name} を共同主催者に任命しました`);
+    } catch (error) {
+      console.error('Failed to appoint co-organizer:', error);
+      showSnackbar('共同主催者の任命に失敗しました');
+    }
+  };
+
+  const handleRemoveCoOrganizer = async (participant: CompetitionParticipant) => {
+    if (!id || !participant.userId) return;
+    try {
+      await removeCoOrganizer(id, participant.id, participant.userId);
+      showSnackbar(`${participant.name} の共同主催者を解除しました`);
+    } catch (error) {
+      console.error('Failed to remove co-organizer:', error);
+      showSnackbar('共同主催者の解除に失敗しました');
+    }
+  };
+
+  const handleRemoveParticipant = async () => {
+    if (!id || !removeTarget) return;
+    try {
+      if (removeTarget.role === 'co_organizer' && removeTarget.userId) {
+        await removeCoOrganizer(id, removeTarget.id, removeTarget.userId);
+      }
+      await removeParticipant(id, removeTarget.id);
+      showSnackbar(`${removeTarget.name} を削除しました`);
+      setRemoveTarget(null);
+    } catch (error) {
+      console.error('Failed to remove participant:', error);
+      showSnackbar('参加者の削除に失敗しました');
+    }
+  };
+
+  const handleAddGuest = async (name: string) => {
+    if (!id) return;
+    try {
+      await addGuestParticipant(id, name);
+      showSnackbar(`ゲスト「${name}」を追加しました`);
+    } catch (error) {
+      console.error('Failed to add guest:', error);
+      showSnackbar('ゲストの追加に失敗しました');
+      throw error;
+    }
+  };
+
   if (loading) {
     return (
       <div className={styles.container}>
@@ -125,14 +186,14 @@ export const CompetitionDashboardPage = () => {
 
       {competition.description && <p className={styles.description}>{competition.description}</p>}
 
-      {/* 主催者アクション */}
-      {isOrganizer && (
+      {/* 主催者・共同主催者アクション */}
+      {canManage && (
         <div className={styles.section}>
           <div className={styles.actionRow}>
             <Button size="small" variant="secondary" onClick={() => setIsShareOpen(true)}>
               共有
             </Button>
-            {STATUS_ACTION_LABELS[competition.status] && (
+            {isOrganizer && STATUS_ACTION_LABELS[competition.status] && (
               <Button
                 size="small"
                 variant={competition.status === 'in_progress' ? 'danger' : 'primary'}
@@ -146,12 +207,24 @@ export const CompetitionDashboardPage = () => {
         </div>
       )}
 
-      {/* 大会情報 */}
+      {/* 参加者 */}
       <div className={styles.section}>
-        <h2 className={styles.sectionTitle}>参加者</h2>
-        <div className={styles.infoCard}>
-          <div className={styles.participantCount}>{participants.length}名が参加中</div>
+        <div className={styles.sectionHeader}>
+          <h2 className={styles.sectionTitle}>参加者 ({participants.length}名)</h2>
+          {isOrganizer && (
+            <Button size="small" variant="secondary" onClick={() => setIsGuestModalOpen(true)}>
+              ゲストを追加
+            </Button>
+          )}
         </div>
+        <ParticipantList
+          participants={participants}
+          currentUserId={currentUserId}
+          isOrganizer={isOrganizer}
+          onAppointCoOrganizer={handleAppointCoOrganizer}
+          onRemoveCoOrganizer={handleRemoveCoOrganizer}
+          onRemoveParticipant={(p) => setRemoveTarget(p)}
+        />
       </div>
 
       <div className={styles.section}>
@@ -255,6 +328,25 @@ export const CompetitionDashboardPage = () => {
         confirmText="はい"
         cancelText="キャンセル"
         type={competition.status === 'in_progress' ? 'danger' : 'default'}
+      />
+
+      {/* 参加者削除確認 */}
+      <ConfirmationDialog
+        isOpen={!!removeTarget}
+        onConfirm={handleRemoveParticipant}
+        onCancel={() => setRemoveTarget(null)}
+        title="参加者の削除"
+        message={`${removeTarget?.name ?? ''} を大会から削除しますか？`}
+        confirmText="削除"
+        cancelText="キャンセル"
+        type="danger"
+      />
+
+      {/* ゲスト追加モーダル */}
+      <AddGuestModal
+        isOpen={isGuestModalOpen}
+        onClose={() => setIsGuestModalOpen(false)}
+        onAdd={handleAddGuest}
       />
     </div>
   );

--- a/src/pages/CompetitionJoinPage.tsx
+++ b/src/pages/CompetitionJoinPage.tsx
@@ -6,12 +6,11 @@ import { Input } from '../components/ui/Input';
 import { useSnackbar } from '../contexts/SnackbarContext';
 import {
   addParticipant,
+  getParticipant,
   subscribeToCompetition,
   verifyPasscode,
 } from '../services/competitionService';
 import { auth } from '../services/firebase';
-import { doc, getDoc } from 'firebase/firestore';
-import { db } from '../services/firebase';
 import type { Competition } from '../types';
 
 export const CompetitionJoinPage = () => {
@@ -60,9 +59,8 @@ export const CompetitionJoinPage = () => {
       }
 
       // Check if already a participant
-      const participantRef = doc(db, 'competitions', id, 'participants', currentUser.uid);
-      const existingDoc = await getDoc(participantRef);
-      if (existingDoc.exists()) {
+      const existing = await getParticipant(id, currentUser.uid);
+      if (existing) {
         navigate(`/competitions/${id}`);
         return;
       }
@@ -103,7 +101,7 @@ export const CompetitionJoinPage = () => {
     );
   }
 
-  if (competition.status !== 'recruiting') {
+  if (competition.status !== 'recruiting' && competition.status !== 'in_progress') {
     return (
       <div style={{ padding: 'var(--spacing-m)', textAlign: 'center' }}>
         <h2>{competition.name}</h2>

--- a/src/services/competitionService.test.ts
+++ b/src/services/competitionService.test.ts
@@ -2,12 +2,16 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   addGameResult,
+  addGuestParticipant,
   addParticipant,
+  appointCoOrganizer,
   COMPETITION_COLLECTION,
   createCompetition,
   createTable,
   deleteTable,
+  getParticipant,
   getUserCompetitions,
+  removeCoOrganizer,
   removeParticipant,
   subscribeToCompetition,
   subscribeToGameResults,
@@ -38,6 +42,12 @@ const mocks = vi.hoisted(() => ({
   mockGetDocs: vi.fn(),
   mockGetDoc: vi.fn(),
   mockHashPasscode: vi.fn(),
+  mockArrayUnion: vi.fn((...args: any[]) => ({ _arrayUnion: args })),
+  mockArrayRemove: vi.fn((...args: any[]) => ({ _arrayRemove: args })),
+  mockGenerateId: vi.fn(() => 'generated-id'),
+  mockWriteBatch: vi.fn(),
+  mockBatchUpdate: vi.fn(),
+  mockBatchCommit: vi.fn(),
 }));
 
 vi.mock('firebase/firestore', () => ({
@@ -53,10 +63,20 @@ vi.mock('firebase/firestore', () => ({
   where: mocks.mockWhere,
   getDocs: mocks.mockGetDocs,
   getDoc: mocks.mockGetDoc,
+  arrayUnion: mocks.mockArrayUnion,
+  arrayRemove: mocks.mockArrayRemove,
+  writeBatch: (...args: any[]) => {
+    mocks.mockWriteBatch(...args);
+    return { update: mocks.mockBatchUpdate, commit: mocks.mockBatchCommit };
+  },
 }));
 
 vi.mock('../utils/hash', () => ({
   hashPasscode: mocks.mockHashPasscode,
+}));
+
+vi.mock('../utils/id', () => ({
+  generateId: mocks.mockGenerateId,
 }));
 
 vi.mock('./firebase', () => ({
@@ -243,6 +263,36 @@ describe('competitionService', () => {
       expect(mocks.mockDeleteDoc).toHaveBeenCalledWith(
         expect.objectContaining({ id: 'participant-1' }),
       );
+    });
+  });
+
+  describe('getParticipant', () => {
+    it('should return participant data when document exists', async () => {
+      const participantData = {
+        id: 'p-1',
+        name: 'Test',
+        isGuest: false,
+        role: 'player',
+        status: 'idle',
+      };
+      mocks.mockGetDoc.mockResolvedValue({ exists: () => true, data: () => participantData });
+
+      const result = await getParticipant('comp-1', 'p-1');
+      expect(result).toEqual(participantData);
+      expect(mocks.mockDoc).toHaveBeenCalledWith(
+        expect.anything(),
+        'competitions',
+        'comp-1',
+        'participants',
+        'p-1',
+      );
+    });
+
+    it('should return null when document does not exist', async () => {
+      mocks.mockGetDoc.mockResolvedValue({ exists: () => false });
+
+      const result = await getParticipant('comp-1', 'nonexistent');
+      expect(result).toBeNull();
     });
   });
 
@@ -466,6 +516,66 @@ describe('competitionService', () => {
       const result = await verifyPasscode('comp-nonexistent', 'pass');
 
       expect(result).toBe(false);
+    });
+  });
+
+  describe('appointCoOrganizer', () => {
+    it('should atomically add userId to coOrganizerIds and update participant role', async () => {
+      await appointCoOrganizer('comp-1', 'participant-1', 'user-1');
+
+      expect(mocks.mockWriteBatch).toHaveBeenCalled();
+      expect(mocks.mockBatchUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'comp-1' }),
+        expect.objectContaining({ coOrganizerIds: { _arrayUnion: ['user-1'] } }),
+      );
+      expect(mocks.mockBatchUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'participant-1' }),
+        expect.objectContaining({ role: 'co_organizer' }),
+      );
+      expect(mocks.mockBatchCommit).toHaveBeenCalled();
+    });
+  });
+
+  describe('removeCoOrganizer', () => {
+    it('should atomically remove userId from coOrganizerIds and reset participant role', async () => {
+      await removeCoOrganizer('comp-1', 'participant-1', 'user-1');
+
+      expect(mocks.mockWriteBatch).toHaveBeenCalled();
+      expect(mocks.mockBatchUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'comp-1' }),
+        expect.objectContaining({ coOrganizerIds: { _arrayRemove: ['user-1'] } }),
+      );
+      expect(mocks.mockBatchUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'participant-1' }),
+        expect.objectContaining({ role: 'player' }),
+      );
+      expect(mocks.mockBatchCommit).toHaveBeenCalled();
+    });
+  });
+
+  describe('addGuestParticipant', () => {
+    it('should generate an id and add participant with isGuest true', async () => {
+      await addGuestParticipant('comp-1', 'Guest Player');
+
+      expect(mocks.mockGenerateId).toHaveBeenCalled();
+      expect(mocks.mockDoc).toHaveBeenCalledWith(
+        expect.anything(),
+        'competitions',
+        'comp-1',
+        'participants',
+        'generated-id',
+      );
+      expect(mocks.mockSetDoc).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'generated-id' }),
+        expect.objectContaining({
+          id: 'generated-id',
+          name: 'Guest Player',
+          isGuest: true,
+          role: 'player',
+          status: 'idle',
+          joinedAt: 'SERVER_TIMESTAMP',
+        }),
+      );
     });
   });
 });

--- a/src/services/competitionService.ts
+++ b/src/services/competitionService.ts
@@ -1,4 +1,6 @@
 import {
+  arrayRemove,
+  arrayUnion,
   collection,
   deleteDoc,
   doc,
@@ -10,6 +12,7 @@ import {
   setDoc,
   updateDoc,
   where,
+  writeBatch,
 } from 'firebase/firestore';
 import type {
   Competition,
@@ -17,6 +20,7 @@ import type {
   CompetitionParticipant,
   CompetitionTable,
 } from '../types';
+import { generateId } from '../utils/id';
 import { db } from './firebase';
 
 export const COMPETITION_COLLECTION = 'competitions';
@@ -130,6 +134,22 @@ export const removeParticipant = async (
   await deleteDoc(participantRef);
 };
 
+export const getParticipant = async (
+  competitionId: string,
+  participantId: string,
+): Promise<CompetitionParticipant | null> => {
+  const participantRef = doc(
+    db,
+    COMPETITION_COLLECTION,
+    competitionId,
+    'participants',
+    participantId,
+  );
+  const snapshot = await getDoc(participantRef);
+  if (!snapshot.exists()) return null;
+  return snapshot.data() as CompetitionParticipant;
+};
+
 // --- Table operations (subcollection) ---
 
 export const createTable = async (
@@ -228,4 +248,57 @@ export const verifyPasscode = async (
   const { hashPasscode } = await import('../utils/hash');
   const inputHash = await hashPasscode(inputPasscode, competitionId);
   return inputHash === data.passcode;
+};
+
+// --- Co-organizer operations ---
+
+export const appointCoOrganizer = async (
+  competitionId: string,
+  participantId: string,
+  userId: string,
+): Promise<void> => {
+  const batch = writeBatch(db);
+  const competitionRef = doc(db, COMPETITION_COLLECTION, competitionId);
+  const participantRef = doc(
+    db,
+    COMPETITION_COLLECTION,
+    competitionId,
+    'participants',
+    participantId,
+  );
+  batch.update(competitionRef, { coOrganizerIds: arrayUnion(userId) });
+  batch.update(participantRef, { role: 'co_organizer' });
+  await batch.commit();
+};
+
+export const removeCoOrganizer = async (
+  competitionId: string,
+  participantId: string,
+  userId: string,
+): Promise<void> => {
+  const batch = writeBatch(db);
+  const competitionRef = doc(db, COMPETITION_COLLECTION, competitionId);
+  const participantRef = doc(
+    db,
+    COMPETITION_COLLECTION,
+    competitionId,
+    'participants',
+    participantId,
+  );
+  batch.update(competitionRef, { coOrganizerIds: arrayRemove(userId) });
+  batch.update(participantRef, { role: 'player' });
+  await batch.commit();
+};
+
+// --- Guest participant ---
+
+export const addGuestParticipant = async (competitionId: string, name: string): Promise<void> => {
+  const id = generateId();
+  await addParticipant(competitionId, {
+    id,
+    name,
+    isGuest: true,
+    role: 'player',
+    status: 'idle',
+  });
 };


### PR DESCRIPTION
## 概要

Issue #65 の実装。大会への参加者登録（アカウント参加・ゲスト代理登録）と共同主催者管理機能を追加。

Epic #71

## 変更内容

### 新規作成
- `src/components/features/ParticipantList.tsx` + `ParticipantList.module.css` — 参加者一覧コンポーネント（ロール/ステータス表示、管理アクション）
- `src/components/features/AddGuestModal.tsx` — ゲスト代理登録モーダル

### 修正
- `src/services/competitionService.ts` — `appointCoOrganizer` / `removeCoOrganizer`（writeBatch 使用）、`addGuestParticipant`、`getParticipant` 追加
- `src/services/competitionService.test.ts` — writeBatch テスト、getParticipant テスト追加
- `src/pages/CompetitionDashboardPage.tsx` — 参加者一覧統合、共同主催者管理、ゲスト追加
- `src/pages/CompetitionJoinPage.tsx` — in_progress 中の参加許可、getParticipant 使用に変更

## レビュー対応

| ID | 内容 |
|----|------|
| C-1 | writeBatch でアトミック操作に修正 |
| C-2 | 共同主催者削除時に coOrganizerIds クリーンアップ |
| H-1 | handleAddGuest にエラーハンドリング追加 |
| H-2 | Firestore 直接アクセスを getParticipant サービス関数に置換 |

## テスト計画

- [x] 158 テスト全パス
- [x] lint パス
- [x] build パス

Closes #65
