### PR TITLE
feat: 卓管理機能 — CRUD・アサイン/デアサイン・席順設定

### DIFF
--- a/src/components/features/CreateTableModal.module.css
+++ b/src/components/features/CreateTableModal.module.css
@@ -1,0 +1,57 @@
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-m);
+}
+
+.modeSection {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.modeLabel {
+  font-size: var(--font-size-s);
+  color: var(--color-text-secondary);
+}
+
+.segmentGroup {
+  display: flex;
+  border-radius: var(--border-radius-m);
+  overflow: hidden;
+  border: 1px solid var(--color-primary);
+}
+
+.segment {
+  flex: 1;
+  padding: var(--spacing-s) var(--spacing-m);
+  border: none;
+  background: transparent;
+  color: var(--color-primary);
+  font-size: var(--font-size-s);
+  font-family: var(--font-main);
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    color 0.15s;
+}
+
+.segment:not(:last-child) {
+  border-right: 1px solid var(--color-primary);
+}
+
+.segmentActive {
+  background: var(--color-primary);
+  color: var(--color-text-primary);
+}
+
+.segment:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-s);
+}

--- a/src/components/features/CreateTableModal.tsx
+++ b/src/components/features/CreateTableModal.tsx
@@ -1,0 +1,91 @@
+import { useState } from 'react';
+import { Button } from '../ui/Button';
+import { Input } from '../ui/Input';
+import { Modal } from '../ui/Modal';
+import styles from './CreateTableModal.module.css';
+
+interface CreateTableModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onCreateTable: (name: string, mode: '3ma' | '4ma') => Promise<void>;
+}
+
+export const CreateTableModal = ({ isOpen, onClose, onCreateTable }: CreateTableModalProps) => {
+  const [name, setName] = useState('');
+  const [mode, setMode] = useState<'3ma' | '4ma'>('4ma');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async () => {
+    const trimmed = name.trim();
+    if (!trimmed || loading) return;
+
+    setLoading(true);
+    try {
+      await onCreateTable(trimmed, mode);
+      setName('');
+      setMode('4ma');
+      onClose();
+    } catch {
+      // Error handling delegated to caller via snackbar
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleClose = () => {
+    if (loading) return;
+    setName('');
+    setMode('4ma');
+    onClose();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose} title="卓を作成">
+      <div className={styles.form}>
+        <Input
+          fullWidth
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="卓名（例: A卓）"
+          required
+          maxLength={30}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') handleSubmit();
+          }}
+        />
+
+        <div className={styles.modeSection}>
+          <span className={styles.modeLabel}>対局モード</span>
+          <div className={styles.segmentGroup}>
+            <button
+              type="button"
+              className={`${styles.segment} ${mode === '4ma' ? styles.segmentActive : ''}`}
+              onClick={() => setMode('4ma')}
+              disabled={loading}
+            >
+              4麻
+            </button>
+            <button
+              type="button"
+              className={`${styles.segment} ${mode === '3ma' ? styles.segmentActive : ''}`}
+              onClick={() => setMode('3ma')}
+              disabled={loading}
+            >
+              3麻
+            </button>
+          </div>
+        </div>
+
+        <div className={styles.actions}>
+          <Button variant="secondary" onClick={handleClose} disabled={loading}>
+            キャンセル
+          </Button>
+          <Button variant="primary" onClick={handleSubmit} disabled={!name.trim() || loading}>
+            {loading ? '作成中...' : '作成'}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+};

--- a/src/components/features/TableCard.module.css
+++ b/src/components/features/TableCard.module.css
@@ -1,0 +1,95 @@
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-s);
+  background: var(--color-bg-card);
+  border-radius: var(--border-radius-m);
+  padding: var(--spacing-m);
+  border: none;
+  width: 100%;
+  text-align: left;
+  cursor: pointer;
+  font-family: var(--font-main);
+  color: var(--color-text-primary);
+  transition: opacity 0.15s;
+}
+
+.card:active {
+  opacity: 0.8;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--spacing-s);
+}
+
+.name {
+  font-size: var(--font-size-m);
+  font-weight: var(--font-weight-bold);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.badges {
+  display: flex;
+  gap: var(--spacing-xs);
+  flex-shrink: 0;
+}
+
+.modeBadge {
+  font-size: var(--font-size-xs);
+  padding: 2px var(--spacing-s);
+  border-radius: var(--border-radius-s);
+  background: var(--color-info);
+  color: var(--color-text-primary);
+}
+
+.statusBadge {
+  font-size: var(--font-size-xs);
+  padding: 2px var(--spacing-s);
+  border-radius: var(--border-radius-s);
+}
+
+.open {
+  background: var(--color-primary);
+  color: var(--color-text-primary);
+}
+
+.ready {
+  background: var(--color-info);
+  color: var(--color-text-primary);
+}
+
+.playing {
+  background: #ff9800;
+  color: #000;
+}
+
+.finished {
+  background: var(--color-text-secondary);
+  color: var(--color-bg-main);
+}
+
+.players {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.player {
+  font-size: var(--font-size-s);
+  color: var(--color-text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.emptySeat {
+  font-size: var(--font-size-s);
+  color: var(--color-text-secondary);
+  font-style: italic;
+}

--- a/src/components/features/TableCard.tsx
+++ b/src/components/features/TableCard.tsx
@@ -1,0 +1,58 @@
+import type { CompetitionParticipant, CompetitionTable } from '../../types';
+import styles from './TableCard.module.css';
+
+const WIND_LABELS: Record<string, string> = {
+  East: '東',
+  South: '南',
+  West: '西',
+  North: '北',
+};
+
+const STATUS_LABELS: Record<string, string> = {
+  open: '空席あり',
+  ready: '準備完了',
+  playing: '対局中',
+  finished: '終了',
+};
+
+interface TableCardProps {
+  table: CompetitionTable;
+  participants: CompetitionParticipant[];
+  onClick: () => void;
+}
+
+export const TableCard = ({ table, participants, onClick }: TableCardProps) => {
+  const capacity = table.mode === '3ma' ? 3 : 4;
+  const playerMap = new Map(participants.map((p) => [p.id, p]));
+
+  return (
+    <button type="button" className={styles.card} onClick={onClick}>
+      <div className={styles.header}>
+        <span className={styles.name}>{table.name}</span>
+        <div className={styles.badges}>
+          <span className={styles.modeBadge}>{table.mode === '3ma' ? '3麻' : '4麻'}</span>
+          <span className={`${styles.statusBadge} ${styles[table.status]}`}>
+            {STATUS_LABELS[table.status]}
+          </span>
+        </div>
+      </div>
+      <div className={styles.players}>
+        {table.playerIds.map((pid) => {
+          const p = playerMap.get(pid);
+          const seat = table.seatAssignment?.[pid];
+          return (
+            <span key={pid} className={styles.player}>
+              {seat ? `${WIND_LABELS[seat] ?? seat} ` : ''}
+              {p?.name ?? pid}
+            </span>
+          );
+        })}
+        {Array.from({ length: capacity - table.playerIds.length }).map((_, i) => (
+          <span key={`empty-${i}`} className={styles.emptySeat}>
+            空席
+          </span>
+        ))}
+      </div>
+    </button>
+  );
+};

--- a/src/components/features/TableDetailModal.module.css
+++ b/src/components/features/TableDetailModal.module.css
@@ -1,0 +1,84 @@
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-m);
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-s);
+}
+
+.sectionTitle {
+  font-size: var(--font-size-s);
+  font-weight: var(--font-weight-bold);
+  margin: 0;
+}
+
+.emptyText {
+  font-size: var(--font-size-s);
+  color: var(--color-text-secondary);
+  margin: 0;
+}
+
+.seatList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.seatRow {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-s);
+  min-height: 36px;
+}
+
+.seatLabel {
+  font-size: var(--font-size-s);
+  font-weight: var(--font-weight-bold);
+  min-width: 2em;
+  text-align: center;
+}
+
+.seatSelect {
+  font-size: var(--font-size-s);
+  font-family: var(--font-main);
+  padding: var(--spacing-xs) var(--spacing-s);
+  border-radius: var(--border-radius-s);
+  border: 1px solid var(--color-text-secondary);
+  background: var(--color-bg-card);
+  color: var(--color-text-primary);
+  min-width: 3.5em;
+}
+
+.playerName {
+  font-size: var(--font-size-s);
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.assignRow {
+  display: flex;
+  gap: var(--spacing-s);
+  align-items: center;
+}
+
+.playerSelect {
+  flex: 1;
+  font-size: var(--font-size-s);
+  font-family: var(--font-main);
+  padding: var(--spacing-s);
+  border-radius: var(--border-radius-s);
+  border: 1px solid var(--color-text-secondary);
+  background: var(--color-bg-card);
+  color: var(--color-text-primary);
+}
+
+.modeRow {
+  display: flex;
+  gap: var(--spacing-s);
+}

--- a/src/components/features/TableDetailModal.tsx
+++ b/src/components/features/TableDetailModal.tsx
@@ -1,0 +1,316 @@
+import { useState } from 'react';
+import { useSnackbar } from '../../contexts/SnackbarContext';
+import {
+  assignPlayerToTable,
+  deleteTableWithCleanup,
+  unassignPlayerFromTable,
+  updateTable,
+} from '../../services/competitionService';
+import type {
+  CompetitionParticipant,
+  CompetitionStatus,
+  CompetitionTable,
+  SeatAssignment,
+} from '../../types';
+import { randomizeSeats } from '../../utils/tableLogic';
+import { Button } from '../ui/Button';
+import { ConfirmationDialog } from '../ui/ConfirmationDialog';
+import { Modal } from '../ui/Modal';
+import styles from './TableDetailModal.module.css';
+
+const WIND_LABELS: Record<string, string> = {
+  East: '東',
+  South: '南',
+  West: '西',
+  North: '北',
+};
+
+const ALL_SEATS_4MA = ['East', 'South', 'West', 'North'] as const;
+const ALL_SEATS_3MA = ['East', 'South', 'West'] as const;
+
+interface TableDetailModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  table: CompetitionTable;
+  participants: CompetitionParticipant[];
+  competitionId: string;
+  canManage: boolean;
+  competitionStatus: CompetitionStatus;
+}
+
+export const TableDetailModal = ({
+  isOpen,
+  onClose,
+  table,
+  participants,
+  competitionId,
+  canManage,
+  competitionStatus,
+}: TableDetailModalProps) => {
+  const { showSnackbar } = useSnackbar();
+  const [loading, setLoading] = useState(false);
+  const [selectedPlayerId, setSelectedPlayerId] = useState('');
+  const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
+
+  const capacity = table.mode === '3ma' ? 3 : 4;
+  const allSeats = table.mode === '3ma' ? ALL_SEATS_3MA : ALL_SEATS_4MA;
+  const isOpen_ = table.status === 'open';
+  const isPlaying = table.status === 'playing';
+  const playerMap = new Map(participants.map((p) => [p.id, p]));
+  const idlePlayers = participants.filter((p) => p.status === 'idle');
+  const canAssignMore = table.playerIds.length < capacity;
+
+  const handleAssign = async () => {
+    if (!selectedPlayerId || loading) return;
+    setLoading(true);
+    try {
+      await assignPlayerToTable(competitionId, table.id, table, selectedPlayerId);
+      setSelectedPlayerId('');
+      showSnackbar('プレイヤーを卓に追加しました');
+    } catch (error) {
+      console.error('Failed to assign player:', error);
+      showSnackbar('プレイヤーの追加に失敗しました');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleUnassign = async (participantId: string) => {
+    if (loading) return;
+    setLoading(true);
+    try {
+      await unassignPlayerFromTable(competitionId, table.id, table, participantId);
+      showSnackbar('プレイヤーを卓から外しました');
+    } catch (error) {
+      console.error('Failed to unassign player:', error);
+      showSnackbar('プレイヤーの解除に失敗しました');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleRandomizeSeats = async () => {
+    if (loading || table.playerIds.length === 0) return;
+    setLoading(true);
+    try {
+      const newSeats = randomizeSeats(table.playerIds, table.mode);
+      await updateTable(competitionId, table.id, { seatAssignment: newSeats });
+      showSnackbar('席順をランダムに変更しました');
+    } catch (error) {
+      console.error('Failed to randomize seats:', error);
+      showSnackbar('席順の変更に失敗しました');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSeatChange = async (playerId: string, newSeat: string) => {
+    if (loading) return;
+    const currentAssignment = table.seatAssignment ?? {};
+    // Swap: find who currently has the target seat
+    const swapPlayerId = Object.entries(currentAssignment).find(
+      ([, seat]) => seat === newSeat,
+    )?.[0];
+    const oldSeat = currentAssignment[playerId];
+
+    const updatedAssignment: SeatAssignment = { ...currentAssignment };
+    updatedAssignment[playerId] = newSeat as SeatAssignment[string];
+    if (swapPlayerId && oldSeat) {
+      updatedAssignment[swapPlayerId] = oldSeat;
+    }
+
+    setLoading(true);
+    try {
+      await updateTable(competitionId, table.id, { seatAssignment: updatedAssignment });
+    } catch (error) {
+      console.error('Failed to change seat:', error);
+      showSnackbar('席の変更に失敗しました');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleModeChange = async (newMode: '3ma' | '4ma') => {
+    if (loading || newMode === table.mode) return;
+    setLoading(true);
+    try {
+      await updateTable(competitionId, table.id, { mode: newMode });
+      showSnackbar(`モードを${newMode === '3ma' ? '3麻' : '4麻'}に変更しました`);
+    } catch (error) {
+      console.error('Failed to change mode:', error);
+      showSnackbar('モードの変更に失敗しました');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    setLoading(true);
+    try {
+      await deleteTableWithCleanup(competitionId, table.id, table.playerIds);
+      setIsDeleteConfirmOpen(false);
+      onClose();
+      showSnackbar('卓を削除しました');
+    } catch (error) {
+      console.error('Failed to delete table:', error);
+      showSnackbar('卓の削除に失敗しました');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const showManageControls =
+    canManage && competitionStatus !== 'closed' && competitionStatus !== 'archived';
+
+  return (
+    <>
+      <Modal isOpen={isOpen} onClose={onClose} title={table.name}>
+        <div className={styles.content}>
+          {/* 席順表示 */}
+          <div className={styles.section}>
+            <h4 className={styles.sectionTitle}>席順</h4>
+            {table.playerIds.length === 0 ? (
+              <p className={styles.emptyText}>プレイヤーが割り当てられていません</p>
+            ) : (
+              <div className={styles.seatList}>
+                {table.playerIds.map((pid) => {
+                  const p = playerMap.get(pid);
+                  const seat = table.seatAssignment?.[pid];
+                  return (
+                    <div key={pid} className={styles.seatRow}>
+                      {showManageControls && !isPlaying ? (
+                        <select
+                          className={styles.seatSelect}
+                          value={seat ?? ''}
+                          onChange={(e) => handleSeatChange(pid, e.target.value)}
+                          disabled={loading}
+                        >
+                          {allSeats.map((s) => (
+                            <option key={s} value={s}>
+                              {WIND_LABELS[s]}
+                            </option>
+                          ))}
+                        </select>
+                      ) : (
+                        <span className={styles.seatLabel}>{seat ? WIND_LABELS[seat] : '—'}</span>
+                      )}
+                      <span className={styles.playerName}>{p?.name ?? pid}</span>
+                      {showManageControls && !isPlaying && (
+                        <Button
+                          size="small"
+                          variant="ghost"
+                          onClick={() => handleUnassign(pid)}
+                          disabled={loading}
+                        >
+                          外す
+                        </Button>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+
+          {/* 席順操作 */}
+          {showManageControls && !isPlaying && table.playerIds.length > 0 && (
+            <div className={styles.section}>
+              <Button
+                size="small"
+                variant="secondary"
+                onClick={handleRandomizeSeats}
+                disabled={loading}
+              >
+                ランダム配席
+              </Button>
+            </div>
+          )}
+
+          {/* プレイヤー追加 */}
+          {showManageControls && canAssignMore && !isPlaying && (
+            <div className={styles.section}>
+              <h4 className={styles.sectionTitle}>プレイヤーを追加</h4>
+              <div className={styles.assignRow}>
+                <select
+                  className={styles.playerSelect}
+                  value={selectedPlayerId}
+                  onChange={(e) => setSelectedPlayerId(e.target.value)}
+                  disabled={loading}
+                >
+                  <option value="">選択してください</option>
+                  {idlePlayers.map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.name}
+                    </option>
+                  ))}
+                </select>
+                <Button
+                  size="small"
+                  variant="primary"
+                  onClick={handleAssign}
+                  disabled={!selectedPlayerId || loading}
+                >
+                  追加
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {/* モード変更 */}
+          {showManageControls && isOpen_ && table.playerIds.length === 0 && (
+            <div className={styles.section}>
+              <h4 className={styles.sectionTitle}>モード変更</h4>
+              <div className={styles.modeRow}>
+                <Button
+                  size="small"
+                  variant={table.mode === '4ma' ? 'primary' : 'secondary'}
+                  onClick={() => handleModeChange('4ma')}
+                  disabled={loading}
+                >
+                  4麻
+                </Button>
+                <Button
+                  size="small"
+                  variant={table.mode === '3ma' ? 'primary' : 'secondary'}
+                  onClick={() => handleModeChange('3ma')}
+                  disabled={loading}
+                >
+                  3麻
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {/* 削除 */}
+          {showManageControls && isOpen_ && (
+            <div className={styles.section}>
+              <Button
+                size="small"
+                variant="danger"
+                onClick={() => setIsDeleteConfirmOpen(true)}
+                disabled={loading}
+              >
+                卓を削除
+              </Button>
+            </div>
+          )}
+        </div>
+      </Modal>
+
+      <ConfirmationDialog
+        isOpen={isDeleteConfirmOpen}
+        onConfirm={handleDelete}
+        onCancel={() => setIsDeleteConfirmOpen(false)}
+        title="卓の削除"
+        message={
+          table.playerIds.length > 0
+            ? 'プレイヤーをデアサインして卓を削除しますか？'
+            : '卓を削除しますか？'
+        }
+        confirmText="削除"
+        cancelText="キャンセル"
+        type="danger"
+      />
+    </>
+  );
+};

--- a/src/components/features/TableList.module.css
+++ b/src/components/features/TableList.module.css
@@ -1,0 +1,12 @@
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-s);
+}
+
+.empty {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-s);
+  text-align: center;
+  padding: var(--spacing-l) 0;
+}

--- a/src/components/features/TableList.tsx
+++ b/src/components/features/TableList.tsx
@@ -1,0 +1,28 @@
+import type { CompetitionParticipant, CompetitionTable } from '../../types';
+import { TableCard } from './TableCard';
+import styles from './TableList.module.css';
+
+interface TableListProps {
+  tables: CompetitionTable[];
+  participants: CompetitionParticipant[];
+  onTableClick: (table: CompetitionTable) => void;
+}
+
+export const TableList = ({ tables, participants, onTableClick }: TableListProps) => {
+  if (tables.length === 0) {
+    return <p className={styles.empty}>卓がまだ作成されていません</p>;
+  }
+
+  return (
+    <div className={styles.list}>
+      {tables.map((table) => (
+        <TableCard
+          key={table.id}
+          table={table}
+          participants={participants}
+          onClick={() => onTableClick(table)}
+        />
+      ))}
+    </div>
+  );
+};

--- a/src/pages/CompetitionDashboardPage.tsx
+++ b/src/pages/CompetitionDashboardPage.tsx
@@ -3,8 +3,11 @@ import { Link, useParams } from 'react-router-dom';
 import { AddGuestModal } from '../components/features/AddGuestModal';
 import { CompetitionRuleSettings } from '../components/features/CompetitionRuleSettings';
 import { CompetitionStatusBadge } from '../components/features/CompetitionStatusBadge';
+import { CreateTableModal } from '../components/features/CreateTableModal';
 import { ParticipantList } from '../components/features/ParticipantList';
 import { ShareCompetitionModal } from '../components/features/ShareCompetitionModal';
+import { TableDetailModal } from '../components/features/TableDetailModal';
+import { TableList } from '../components/features/TableList';
 import { Button } from '../components/ui/Button';
 import { ConfirmationDialog } from '../components/ui/ConfirmationDialog';
 import { useSnackbar } from '../contexts/SnackbarContext';
@@ -12,12 +15,14 @@ import { useCompetition } from '../hooks/useCompetition';
 import {
   addGuestParticipant,
   appointCoOrganizer,
+  createTable,
   removeCoOrganizer,
   removeParticipant,
   updateCompetition,
 } from '../services/competitionService';
 import { auth } from '../services/firebase';
 import type { CompetitionParticipant, CompetitionSettings, CompetitionStatus } from '../types';
+import { generateId } from '../utils/id';
 import styles from './CompetitionDashboardPage.module.css';
 
 const NEXT_STATUS: Partial<Record<CompetitionStatus, CompetitionStatus>> = {
@@ -37,7 +42,7 @@ const STATUS_CONFIRM_MESSAGES: Partial<Record<CompetitionStatus, string>> = {
 
 export const CompetitionDashboardPage = () => {
   const { id } = useParams<{ id: string }>();
-  const { competition, participants, loading } = useCompetition(id || '');
+  const { competition, participants, tables, loading } = useCompetition(id || '');
   const { showSnackbar } = useSnackbar();
   const [isShareOpen, setIsShareOpen] = useState(false);
   const [isConfirmOpen, setIsConfirmOpen] = useState(false);
@@ -46,11 +51,17 @@ export const CompetitionDashboardPage = () => {
   const [editSettings, setEditSettings] = useState<CompetitionSettings | null>(null);
   const [isGuestModalOpen, setIsGuestModalOpen] = useState(false);
   const [removeTarget, setRemoveTarget] = useState<CompetitionParticipant | null>(null);
+  const [isCreateTableOpen, setIsCreateTableOpen] = useState(false);
+  const [selectedTableId, setSelectedTableId] = useState<string | null>(null);
 
   const currentUserId = auth.currentUser?.uid;
   const isOrganizer = competition?.organizerId === currentUserId;
   const isCoOrganizer = competition?.coOrganizerIds.includes(currentUserId ?? '') ?? false;
   const canManage = isOrganizer || isCoOrganizer;
+
+  const selectedTable = selectedTableId
+    ? (tables.find((t) => t.id === selectedTableId) ?? null)
+    : null;
 
   const handleStatusChange = async () => {
     if (!id || !competition) return;
@@ -154,6 +165,24 @@ export const CompetitionDashboardPage = () => {
     }
   };
 
+  const handleCreateTable = async (name: string, mode: '3ma' | '4ma') => {
+    if (!id) return;
+    try {
+      await createTable(id, {
+        id: generateId(),
+        name,
+        mode,
+        status: 'open',
+        playerIds: [],
+      });
+      showSnackbar(`卓「${name}」を作成しました`);
+    } catch (error) {
+      console.error('Failed to create table:', error);
+      showSnackbar('卓の作成に失敗しました');
+      throw error;
+    }
+  };
+
   if (loading) {
     return (
       <div className={styles.container}>
@@ -224,6 +253,23 @@ export const CompetitionDashboardPage = () => {
           onAppointCoOrganizer={handleAppointCoOrganizer}
           onRemoveCoOrganizer={handleRemoveCoOrganizer}
           onRemoveParticipant={(p) => setRemoveTarget(p)}
+        />
+      </div>
+
+      {/* 卓一覧 */}
+      <div className={styles.section}>
+        <div className={styles.sectionHeader}>
+          <h2 className={styles.sectionTitle}>卓一覧 ({tables.length}卓)</h2>
+          {canManage && (
+            <Button size="small" variant="secondary" onClick={() => setIsCreateTableOpen(true)}>
+              卓を作成
+            </Button>
+          )}
+        </div>
+        <TableList
+          tables={tables}
+          participants={participants}
+          onTableClick={(t) => setSelectedTableId(t.id)}
         />
       </div>
 
@@ -348,6 +394,26 @@ export const CompetitionDashboardPage = () => {
         onClose={() => setIsGuestModalOpen(false)}
         onAdd={handleAddGuest}
       />
+
+      {/* 卓作成モーダル */}
+      <CreateTableModal
+        isOpen={isCreateTableOpen}
+        onClose={() => setIsCreateTableOpen(false)}
+        onCreateTable={handleCreateTable}
+      />
+
+      {/* 卓詳細モーダル */}
+      {selectedTable && id && (
+        <TableDetailModal
+          isOpen={!!selectedTable}
+          onClose={() => setSelectedTableId(null)}
+          table={selectedTable}
+          participants={participants}
+          competitionId={id}
+          canManage={canManage}
+          competitionStatus={competition.status}
+        />
+      )}
     </div>
   );
 };

--- a/src/services/competitionService.test.ts
+++ b/src/services/competitionService.test.ts
@@ -5,10 +5,12 @@ import {
   addGuestParticipant,
   addParticipant,
   appointCoOrganizer,
+  assignPlayerToTable,
   COMPETITION_COLLECTION,
   createCompetition,
   createTable,
   deleteTable,
+  deleteTableWithCleanup,
   getParticipant,
   getUserCompetitions,
   removeCoOrganizer,
@@ -17,6 +19,7 @@ import {
   subscribeToGameResults,
   subscribeToParticipants,
   subscribeToTables,
+  unassignPlayerFromTable,
   updateCompetition,
   updateParticipant,
   updateTable,
@@ -47,6 +50,7 @@ const mocks = vi.hoisted(() => ({
   mockGenerateId: vi.fn(() => 'generated-id'),
   mockWriteBatch: vi.fn(),
   mockBatchUpdate: vi.fn(),
+  mockBatchDelete: vi.fn(),
   mockBatchCommit: vi.fn(),
 }));
 
@@ -67,7 +71,11 @@ vi.mock('firebase/firestore', () => ({
   arrayRemove: mocks.mockArrayRemove,
   writeBatch: (...args: any[]) => {
     mocks.mockWriteBatch(...args);
-    return { update: mocks.mockBatchUpdate, commit: mocks.mockBatchCommit };
+    return {
+      update: mocks.mockBatchUpdate,
+      delete: mocks.mockBatchDelete,
+      commit: mocks.mockBatchCommit,
+    };
   },
 }));
 
@@ -576,6 +584,134 @@ describe('competitionService', () => {
           joinedAt: 'SERVER_TIMESTAMP',
         }),
       );
+    });
+  });
+
+  describe('assignPlayerToTable', () => {
+    it('should batch-update table and participant when assigning', async () => {
+      const table = {
+        id: 'table-1',
+        name: 'Table 1',
+        mode: '4ma' as const,
+        status: 'open' as const,
+        playerIds: ['p1', 'p2'],
+        gameCount: 0,
+        createdAt: 0,
+      };
+
+      await assignPlayerToTable('comp-1', 'table-1', table, 'p3');
+
+      expect(mocks.mockWriteBatch).toHaveBeenCalled();
+      // table update with new playerIds, status, seatAssignment
+      expect(mocks.mockBatchUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'table-1' }),
+        expect.objectContaining({
+          playerIds: ['p1', 'p2', 'p3'],
+          status: 'open',
+          seatAssignment: { p1: 'East', p2: 'South', p3: 'West' },
+        }),
+      );
+      // participant update
+      expect(mocks.mockBatchUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'p3' }),
+        expect.objectContaining({ status: 'assigned', currentTableId: 'table-1' }),
+      );
+      expect(mocks.mockBatchCommit).toHaveBeenCalled();
+    });
+
+    it('should set status to ready when table reaches capacity', async () => {
+      const table = {
+        id: 'table-1',
+        name: 'Table 1',
+        mode: '4ma' as const,
+        status: 'open' as const,
+        playerIds: ['p1', 'p2', 'p3'],
+        gameCount: 0,
+        createdAt: 0,
+      };
+
+      await assignPlayerToTable('comp-1', 'table-1', table, 'p4');
+
+      expect(mocks.mockBatchUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'table-1' }),
+        expect.objectContaining({
+          playerIds: ['p1', 'p2', 'p3', 'p4'],
+          status: 'ready',
+        }),
+      );
+    });
+  });
+
+  describe('unassignPlayerFromTable', () => {
+    it('should batch-update table and participant when unassigning', async () => {
+      const table = {
+        id: 'table-1',
+        name: 'Table 1',
+        mode: '4ma' as const,
+        status: 'ready' as const,
+        playerIds: ['p1', 'p2', 'p3', 'p4'],
+        seatAssignment: {
+          p1: 'East' as const,
+          p2: 'South' as const,
+          p3: 'West' as const,
+          p4: 'North' as const,
+        },
+        gameCount: 0,
+        createdAt: 0,
+      };
+
+      await unassignPlayerFromTable('comp-1', 'table-1', table, 'p3');
+
+      expect(mocks.mockWriteBatch).toHaveBeenCalled();
+      expect(mocks.mockBatchUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'table-1' }),
+        expect.objectContaining({
+          playerIds: ['p1', 'p2', 'p4'],
+          status: 'open',
+          seatAssignment: { p1: 'East', p2: 'South', p4: 'North' },
+        }),
+      );
+      expect(mocks.mockBatchUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'p3' }),
+        expect.objectContaining({ status: 'idle', currentTableId: '' }),
+      );
+      expect(mocks.mockBatchCommit).toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteTableWithCleanup', () => {
+    it('should delete table and reset all assigned players', async () => {
+      await deleteTableWithCleanup('comp-1', 'table-1', ['p1', 'p2', 'p3']);
+
+      expect(mocks.mockWriteBatch).toHaveBeenCalled();
+      // Each player should be reset
+      expect(mocks.mockBatchUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'p1' }),
+        expect.objectContaining({ status: 'idle', currentTableId: '' }),
+      );
+      expect(mocks.mockBatchUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'p2' }),
+        expect.objectContaining({ status: 'idle', currentTableId: '' }),
+      );
+      expect(mocks.mockBatchUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'p3' }),
+        expect.objectContaining({ status: 'idle', currentTableId: '' }),
+      );
+      // Table should be deleted
+      expect(mocks.mockBatchDelete).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'table-1' }),
+      );
+      expect(mocks.mockBatchCommit).toHaveBeenCalled();
+    });
+
+    it('should delete table even with no players', async () => {
+      await deleteTableWithCleanup('comp-1', 'table-1', []);
+
+      expect(mocks.mockBatchDelete).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'table-1' }),
+      );
+      expect(mocks.mockBatchUpdate).not.toHaveBeenCalled();
+      expect(mocks.mockBatchCommit).toHaveBeenCalled();
     });
   });
 });

--- a/src/services/competitionService.ts
+++ b/src/services/competitionService.ts
@@ -21,6 +21,7 @@ import type {
   CompetitionTable,
 } from '../types';
 import { generateId } from '../utils/id';
+import { assignDefaultSeats, computeTableStatus, getTableCapacity } from '../utils/tableLogic';
 import { db } from './firebase';
 
 export const COMPETITION_COLLECTION = 'competitions';
@@ -301,4 +302,78 @@ export const addGuestParticipant = async (competitionId: string, name: string): 
     role: 'player',
     status: 'idle',
   });
+};
+
+// --- Table assignment operations ---
+
+export const assignPlayerToTable = async (
+  competitionId: string,
+  tableId: string,
+  table: CompetitionTable,
+  participantId: string,
+): Promise<void> => {
+  const capacity = getTableCapacity(table.mode);
+  const newPlayerIds = [...table.playerIds, participantId];
+  const newStatus = computeTableStatus(newPlayerIds.length, capacity);
+  const newSeats = assignDefaultSeats(newPlayerIds, table.mode);
+
+  const batch = writeBatch(db);
+  const tableRef = doc(db, COMPETITION_COLLECTION, competitionId, 'tables', tableId);
+  const participantRef = doc(
+    db,
+    COMPETITION_COLLECTION,
+    competitionId,
+    'participants',
+    participantId,
+  );
+  batch.update(tableRef, { playerIds: newPlayerIds, status: newStatus, seatAssignment: newSeats });
+  batch.update(participantRef, { status: 'assigned', currentTableId: tableId });
+  await batch.commit();
+};
+
+export const unassignPlayerFromTable = async (
+  competitionId: string,
+  tableId: string,
+  table: CompetitionTable,
+  participantId: string,
+): Promise<void> => {
+  const capacity = getTableCapacity(table.mode);
+  const newPlayerIds = table.playerIds.filter((id) => id !== participantId);
+  const newStatus = computeTableStatus(newPlayerIds.length, capacity);
+  const currentSeats = table.seatAssignment ?? {};
+  const remainingSeats = Object.fromEntries(
+    Object.entries(currentSeats).filter(([id]) => id !== participantId),
+  );
+
+  const batch = writeBatch(db);
+  const tableRef = doc(db, COMPETITION_COLLECTION, competitionId, 'tables', tableId);
+  const participantRef = doc(
+    db,
+    COMPETITION_COLLECTION,
+    competitionId,
+    'participants',
+    participantId,
+  );
+  batch.update(tableRef, {
+    playerIds: newPlayerIds,
+    status: newStatus,
+    seatAssignment: remainingSeats,
+  });
+  batch.update(participantRef, { status: 'idle', currentTableId: '' });
+  await batch.commit();
+};
+
+export const deleteTableWithCleanup = async (
+  competitionId: string,
+  tableId: string,
+  playerIds: string[],
+): Promise<void> => {
+  const batch = writeBatch(db);
+  const tableRef = doc(db, COMPETITION_COLLECTION, competitionId, 'tables', tableId);
+  for (const pid of playerIds) {
+    const participantRef = doc(db, COMPETITION_COLLECTION, competitionId, 'participants', pid);
+    batch.update(participantRef, { status: 'idle', currentTableId: '' });
+  }
+  batch.delete(tableRef);
+  await batch.commit();
 };

--- a/src/utils/tableLogic.test.ts
+++ b/src/utils/tableLogic.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import type { SeatAssignment } from '../types';
+import {
+  assignDefaultSeats,
+  computeTableStatus,
+  getAvailableSeats,
+  getTableCapacity,
+  randomizeSeats,
+} from './tableLogic';
+
+describe('tableLogic', () => {
+  describe('getTableCapacity', () => {
+    it('should return 3 for 3ma', () => {
+      expect(getTableCapacity('3ma')).toBe(3);
+    });
+
+    it('should return 4 for 4ma', () => {
+      expect(getTableCapacity('4ma')).toBe(4);
+    });
+  });
+
+  describe('computeTableStatus', () => {
+    it('should return "open" when playerCount < capacity', () => {
+      expect(computeTableStatus(0, 4)).toBe('open');
+      expect(computeTableStatus(2, 4)).toBe('open');
+      expect(computeTableStatus(3, 4)).toBe('open');
+    });
+
+    it('should return "ready" when playerCount >= capacity (4ma)', () => {
+      expect(computeTableStatus(4, 4)).toBe('ready');
+    });
+
+    it('should return "ready" when playerCount >= capacity (3ma)', () => {
+      expect(computeTableStatus(3, 3)).toBe('ready');
+    });
+  });
+
+  describe('assignDefaultSeats', () => {
+    it('should assign East, South, West, North in order for 4ma with 4 players', () => {
+      const result = assignDefaultSeats(['p1', 'p2', 'p3', 'p4'], '4ma');
+      expect(result).toEqual({
+        p1: 'East',
+        p2: 'South',
+        p3: 'West',
+        p4: 'North',
+      });
+    });
+
+    it('should assign East, South, West in order for 3ma with 3 players', () => {
+      const result = assignDefaultSeats(['p1', 'p2', 'p3'], '3ma');
+      expect(result).toEqual({
+        p1: 'East',
+        p2: 'South',
+        p3: 'West',
+      });
+    });
+
+    it('should assign only available seats for fewer players (2 in 4ma)', () => {
+      const result = assignDefaultSeats(['p1', 'p2'], '4ma');
+      expect(result).toEqual({
+        p1: 'East',
+        p2: 'South',
+      });
+    });
+
+    it('should return empty assignment for empty players', () => {
+      const result = assignDefaultSeats([], '4ma');
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('randomizeSeats', () => {
+    it('should assign all players to seats for 4ma', () => {
+      const result = randomizeSeats(['p1', 'p2', 'p3', 'p4'], '4ma');
+      const playerIds = Object.keys(result);
+      const seats = Object.values(result);
+
+      expect(playerIds).toHaveLength(4);
+      expect(new Set(seats).size).toBe(4);
+      expect(seats.every((s) => ['East', 'South', 'West', 'North'].includes(s))).toBe(true);
+    });
+
+    it('should assign all players to seats for 3ma', () => {
+      const result = randomizeSeats(['p1', 'p2', 'p3'], '3ma');
+      const playerIds = Object.keys(result);
+      const seats = Object.values(result);
+
+      expect(playerIds).toHaveLength(3);
+      expect(new Set(seats).size).toBe(3);
+      expect(seats.every((s) => ['East', 'South', 'West'].includes(s))).toBe(true);
+    });
+
+    it('should assign only available seats for fewer players', () => {
+      const result = randomizeSeats(['p1', 'p2'], '4ma');
+      const playerIds = Object.keys(result);
+      const seats = Object.values(result);
+
+      expect(playerIds).toHaveLength(2);
+      expect(new Set(seats).size).toBe(2);
+      expect(seats.every((s) => ['East', 'South', 'West', 'North'].includes(s))).toBe(true);
+    });
+
+    it('should return empty assignment for empty players', () => {
+      const result = randomizeSeats([], '4ma');
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('getAvailableSeats', () => {
+    it('should return remaining seats for partially filled 4ma table', () => {
+      const assignment: SeatAssignment = { p1: 'East', p2: 'South' };
+      const result = getAvailableSeats(assignment, '4ma');
+      expect(result).toEqual(['West', 'North']);
+    });
+
+    it('should return all seats when no one is assigned', () => {
+      const result = getAvailableSeats(undefined, '4ma');
+      expect(result).toEqual(['East', 'South', 'West', 'North']);
+    });
+
+    it('should return all seats for empty assignment object', () => {
+      const result = getAvailableSeats({}, '3ma');
+      expect(result).toEqual(['East', 'South', 'West']);
+    });
+
+    it('should return empty array when table is full', () => {
+      const assignment: SeatAssignment = { p1: 'East', p2: 'South', p3: 'West', p4: 'North' };
+      const result = getAvailableSeats(assignment, '4ma');
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/src/utils/tableLogic.ts
+++ b/src/utils/tableLogic.ts
@@ -1,0 +1,41 @@
+import type { SeatAssignment } from '../types';
+
+const SEATS_4MA = ['East', 'South', 'West', 'North'] as const;
+const SEATS_3MA = ['East', 'South', 'West'] as const;
+
+export const getTableCapacity = (mode: '3ma' | '4ma'): number => (mode === '3ma' ? 3 : 4);
+
+export const computeTableStatus = (playerCount: number, capacity: number): 'open' | 'ready' =>
+  playerCount >= capacity ? 'ready' : 'open';
+
+export const assignDefaultSeats = (playerIds: string[], mode: '3ma' | '4ma'): SeatAssignment => {
+  const seats = mode === '3ma' ? SEATS_3MA : SEATS_4MA;
+  const assignment: SeatAssignment = {};
+  playerIds.forEach((id, i) => {
+    if (i < seats.length) assignment[id] = seats[i];
+  });
+  return assignment;
+};
+
+export const randomizeSeats = (playerIds: string[], mode: '3ma' | '4ma'): SeatAssignment => {
+  const seats = mode === '3ma' ? [...SEATS_3MA] : [...SEATS_4MA];
+  // Fisher-Yates shuffle
+  for (let i = seats.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [seats[i], seats[j]] = [seats[j], seats[i]];
+  }
+  const assignment: SeatAssignment = {};
+  playerIds.forEach((id, i) => {
+    if (i < seats.length) assignment[id] = seats[i];
+  });
+  return assignment;
+};
+
+export const getAvailableSeats = (
+  seatAssignment: SeatAssignment | undefined,
+  mode: '3ma' | '4ma',
+): string[] => {
+  const allSeats = mode === '3ma' ? [...SEATS_3MA] : [...SEATS_4MA];
+  const usedSeats = new Set(Object.values(seatAssignment ?? {}));
+  return allSeats.filter((s) => !usedSeats.has(s));
+};


### PR DESCRIPTION
## 概要

Issue #66 の卓管理機能を実装。卓の作成・削除、参加者のアサイン/デアサイン、席順設定をサポートする。

Epic: #71

## 変更内容 (13 files, +1193 / -2)

### 新規作成

| ファイル | 説明 |
|---------|------|
| src/utils/tableLogic.ts + test | 卓ロジック（容量チェック、ステータス判定、席配置関数）17テスト |
| src/components/features/CreateTableModal.tsx + CSS | 卓作成モーダル |
| src/components/features/TableCard.tsx + CSS | 卓カード表示 |
| src/components/features/TableList.tsx + CSS | 卓一覧レイアウト |
| src/components/features/TableDetailModal.tsx + CSS | 卓詳細（アサイン/席順/削除） |

### 修正

| ファイル | 説明 |
|---------|------|
| competitionService.ts | assignPlayerToTable / unassignPlayerFromTable / deleteTableWithCleanup (writeBatch) |
| competitionService.test.ts | batch 操作テスト追加 |
| CompetitionDashboardPage.tsx | 卓セクション統合、リアルタイムテーブル同期 |

## レビュー対応

- C-2: selectedTable を ID ベースに変更しリアルタイム同期
- H-2: デアサイン時の席順保持（対象者のみ除去）

## テスト計画

- [x] 180 テスト全パス
- [x] lint パス
- [x] build パス
- [x] tableLogic 17 テスト（容量、ステータス、席配置）
- [x] competitionService batch 操作テスト

Closes #66
