### PR TITLE
feat: 各卓実況機能 - リアルタイムライブビュー (#68)

### DIFF
--- a/src/components/features/LiveTableTile.module.css
+++ b/src/components/features/LiveTableTile.module.css
@@ -1,0 +1,146 @@
+.tile {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-s);
+  background: var(--color-bg-card);
+  border-radius: var(--border-radius-m);
+  padding: var(--spacing-m);
+  border: 2px solid transparent;
+  transition: border-color 0.3s;
+}
+
+.playing {
+  border-color: #ff9800;
+}
+
+.finished {
+  border-color: var(--color-text-secondary);
+  opacity: 0.75;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--spacing-s);
+}
+
+.name {
+  font-size: var(--font-size-l);
+  font-weight: var(--font-weight-bold);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.badges {
+  display: flex;
+  gap: var(--spacing-xs);
+  flex-shrink: 0;
+}
+
+.badge {
+  font-size: var(--font-size-xs);
+  padding: 2px var(--spacing-s);
+  border-radius: var(--border-radius-s);
+  font-weight: var(--font-weight-bold);
+}
+
+.modeBadge {
+  composes: badge;
+  background: var(--color-info);
+  color: var(--color-text-primary);
+}
+
+.statusOpen {
+  composes: badge;
+  background: var(--color-primary);
+  color: var(--color-text-primary);
+}
+
+.statusReady {
+  composes: badge;
+  background: var(--color-info);
+  color: var(--color-text-primary);
+}
+
+.statusPlaying {
+  composes: badge;
+  background: #ff9800;
+  color: #000;
+}
+
+.statusFinished {
+  composes: badge;
+  background: var(--color-text-secondary);
+  color: var(--color-bg-main);
+}
+
+.roundInfo {
+  font-size: var(--font-size-m);
+  color: var(--color-text-accent);
+  font-weight: var(--font-weight-bold);
+}
+
+.gameCount {
+  font-size: var(--font-size-s);
+  color: var(--color-text-secondary);
+  margin-left: var(--spacing-s);
+}
+
+.players {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.playerRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--spacing-s);
+  padding: var(--spacing-xs) 0;
+}
+
+.wind {
+  font-size: var(--font-size-s);
+  color: var(--color-text-secondary);
+  min-width: 1.5em;
+  text-align: center;
+}
+
+.playerName {
+  font-size: var(--font-size-m);
+  color: var(--color-text-primary);
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.score {
+  font-size: var(--font-size-m);
+  font-family: var(--font-mono);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text-primary);
+  min-width: 5em;
+  text-align: right;
+}
+
+.emptySeat {
+  font-size: var(--font-size-s);
+  color: var(--color-text-secondary);
+  font-style: italic;
+  padding: var(--spacing-xs) 0;
+}
+
+.idle {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 80px;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-m);
+}

--- a/src/components/features/LiveTableTile.tsx
+++ b/src/components/features/LiveTableTile.tsx
@@ -1,0 +1,106 @@
+import type { CompetitionParticipant, CompetitionTable, RoomState } from '../../types';
+import styles from './LiveTableTile.module.css';
+
+const WIND_LABELS: Record<string, string> = {
+  East: '東',
+  South: '南',
+  West: '西',
+  North: '北',
+};
+
+const STATUS_LABELS: Record<string, string> = {
+  open: '空席あり',
+  ready: '準備完了',
+  playing: '対局中',
+  finished: '終了',
+};
+
+const STATUS_STYLE: Record<string, string> = {
+  open: styles.statusOpen,
+  ready: styles.statusReady,
+  playing: styles.statusPlaying,
+  finished: styles.statusFinished,
+};
+
+const formatRound = (room: RoomState): string => {
+  const wind = WIND_LABELS[room.round.wind] ?? room.round.wind;
+  const num = room.round.number;
+  const honba = room.round.honba;
+  const base = `${wind}${num}局`;
+  return honba > 0 ? `${base} ${honba}本場` : base;
+};
+
+const formatScore = (score: number): string => score.toLocaleString('ja-JP');
+
+interface LiveTableTileProps {
+  table: CompetitionTable;
+  room: RoomState | null;
+  participants: CompetitionParticipant[];
+}
+
+export const LiveTableTile = ({ table, room, participants }: LiveTableTileProps) => {
+  const participantMap = new Map(participants.map((p) => [p.id, p]));
+  const isPlaying = room?.status === 'playing';
+  const isFinished =
+    table.status === 'finished' || room?.status === 'finished' || room?.status === 'ended';
+  const showRoomInfo = room && (isPlaying || isFinished);
+
+  const tileClass = [
+    styles.tile,
+    isPlaying ? styles.playing : '',
+    isFinished ? styles.finished : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const effectiveStatus = isPlaying ? 'playing' : isFinished ? 'finished' : table.status;
+
+  return (
+    <div className={tileClass}>
+      <div className={styles.header}>
+        <span className={styles.name}>{table.name}</span>
+        <div className={styles.badges}>
+          <span className={styles.modeBadge}>{table.mode === '3ma' ? '3麻' : '4麻'}</span>
+          <span className={STATUS_STYLE[effectiveStatus] ?? styles.statusOpen}>
+            {STATUS_LABELS[effectiveStatus]}
+          </span>
+        </div>
+      </div>
+
+      {showRoomInfo && (
+        <div>
+          <span className={styles.roundInfo}>{formatRound(room)}</span>
+          {table.gameCount > 0 && <span className={styles.gameCount}>第{table.gameCount}戦</span>}
+        </div>
+      )}
+
+      {showRoomInfo ? (
+        <div className={styles.players}>
+          {room.players.map((player) => (
+            <div key={player.id} className={styles.playerRow}>
+              <span className={styles.wind}>{WIND_LABELS[player.wind] ?? ''}</span>
+              <span className={styles.playerName}>{player.name}</span>
+              <span className={styles.score}>{formatScore(player.score)}</span>
+            </div>
+          ))}
+        </div>
+      ) : table.playerIds.length > 0 ? (
+        <div className={styles.players}>
+          {table.playerIds.map((pid) => {
+            const p = participantMap.get(pid);
+            const seat = table.seatAssignment?.[pid];
+            return (
+              <div key={pid} className={styles.playerRow}>
+                <span className={styles.wind}>{seat ? (WIND_LABELS[seat] ?? '') : ''}</span>
+                <span className={styles.playerName}>{p?.name ?? pid}</span>
+                <span className={styles.score}>-</span>
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <div className={styles.idle}>プレイヤー未配置</div>
+      )}
+    </div>
+  );
+};

--- a/src/hooks/useLiveRooms.ts
+++ b/src/hooks/useLiveRooms.ts
@@ -1,0 +1,76 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { subscribeToRoom } from '../services/roomService';
+import type { CompetitionTable, RoomState } from '../types';
+import { diffRoomIds, extractRoomIds } from '../utils/liveRoomUtils';
+
+export const useLiveRooms = (tables: CompetitionTable[]) => {
+  const [rooms, setRooms] = useState<Map<string, RoomState>>(new Map());
+  const [loading, setLoading] = useState(true);
+  const listenersRef = useRef<Map<string, () => void>>(new Map());
+  const pendingRef = useRef<Set<string>>(new Set());
+
+  const roomIds = useMemo(() => extractRoomIds(tables), [tables]);
+
+  const roomIdsKey = roomIds.join(',');
+
+  // Unmount-only cleanup: release all listeners when the component unmounts
+  useEffect(() => {
+    const listeners = listenersRef.current;
+    return () => {
+      for (const unsub of listeners.values()) {
+        unsub();
+      }
+      listeners.clear();
+    };
+  }, []);
+
+  // Incremental sync: add/remove listeners based on diff
+  useEffect(() => {
+    const currentListeners = listenersRef.current;
+    const currentIds = new Set(roomIds);
+    const previousIds = new Set(currentListeners.keys());
+    const { added, removed } = diffRoomIds(previousIds, currentIds);
+
+    // Remove listeners for roomIds that are no longer present
+    for (const id of removed) {
+      currentListeners.get(id)?.();
+      currentListeners.delete(id);
+      pendingRef.current.delete(id);
+      setRooms((prev) => {
+        const next = new Map(prev);
+        next.delete(id);
+        return next;
+      });
+    }
+
+    // Add listeners for new roomIds
+    for (const id of added) {
+      pendingRef.current.add(id);
+      const unsub = subscribeToRoom(id, (data) => {
+        pendingRef.current.delete(id);
+        if (pendingRef.current.size === 0) {
+          setLoading(false);
+        }
+        setRooms((prev) => {
+          if (data) {
+            const next = new Map(prev);
+            next.set(id, data);
+            return next;
+          }
+          const next = new Map(prev);
+          next.delete(id);
+          return next;
+        });
+      });
+      currentListeners.set(id, unsub);
+    }
+
+    // If no roomIds to subscribe to, immediately mark as loaded
+    if (currentIds.size === 0) {
+      setLoading(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [roomIdsKey]);
+
+  return { rooms, loading };
+};

--- a/src/pages/CompetitionLivePage.module.css
+++ b/src/pages/CompetitionLivePage.module.css
@@ -1,0 +1,140 @@
+.container {
+  min-height: 100dvh;
+  background: #000;
+  color: var(--color-text-primary);
+  font-family: var(--font-main);
+  display: flex;
+  flex-direction: column;
+}
+
+.pageHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--spacing-m) var(--spacing-l);
+  background: var(--color-bg-main);
+  border-bottom: 1px solid var(--color-bg-card);
+  flex-shrink: 0;
+}
+
+.titleArea {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-m);
+  min-width: 0;
+}
+
+.title {
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-bold);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.summary {
+  font-size: var(--font-size-s);
+  color: var(--color-text-secondary);
+  flex-shrink: 0;
+}
+
+.controls {
+  display: flex;
+  gap: var(--spacing-s);
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.autoScrollBtn {
+  background: var(--color-bg-card);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-text-secondary);
+  border-radius: var(--border-radius-s);
+  padding: var(--spacing-xs) var(--spacing-s);
+  font-size: var(--font-size-xs);
+  font-family: var(--font-main);
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.autoScrollBtn:hover {
+  background: var(--color-primary);
+}
+
+.autoScrollActive {
+  composes: autoScrollBtn;
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: var(--spacing-m);
+  padding: var(--spacing-m) var(--spacing-l);
+  flex: 1;
+  overflow-y: auto;
+  align-content: start;
+}
+
+/* Passcode gate */
+.gate {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100dvh;
+  padding: var(--spacing-xl);
+  background: #000;
+  gap: var(--spacing-l);
+}
+
+.gateName {
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text-primary);
+}
+
+.gateForm {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-m);
+  width: 100%;
+  max-width: 320px;
+}
+
+/* Loading / Error states */
+.center {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100dvh;
+  font-size: var(--font-size-l);
+  color: var(--color-text-secondary);
+  background: #000;
+}
+
+/* Large screen: wider tiles */
+@media (min-width: 1600px) {
+  .grid {
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  }
+}
+
+/* Small screen: single column */
+@media (max-width: 600px) {
+  .grid {
+    grid-template-columns: 1fr;
+    padding: var(--spacing-s);
+  }
+
+  .pageHeader {
+    padding: var(--spacing-s) var(--spacing-m);
+    flex-wrap: wrap;
+    gap: var(--spacing-s);
+  }
+
+  .title {
+    font-size: var(--font-size-l);
+  }
+}

--- a/src/pages/CompetitionLivePage.tsx
+++ b/src/pages/CompetitionLivePage.tsx
@@ -1,3 +1,159 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { LiveTableTile } from '../components/features/LiveTableTile';
+import { Button } from '../components/ui/Button';
+import { Input } from '../components/ui/Input';
+import { useSnackbar } from '../contexts/SnackbarContext';
+import { useCompetition } from '../hooks/useCompetition';
+import { useLiveRooms } from '../hooks/useLiveRooms';
+import { subscribeToCompetition, verifyPasscode } from '../services/competitionService';
+import type { Competition } from '../types';
+import styles from './CompetitionLivePage.module.css';
+
+const AUTO_SCROLL_SPEED = 1;
+const AUTO_SCROLL_INTERVAL = 50;
+
 export const CompetitionLivePage = () => {
-  return <div>大会実況</div>;
+  const { id } = useParams<{ id: string }>();
+  const { showSnackbar } = useSnackbar();
+
+  // Passcode gate state
+  const [gateLoading, setGateLoading] = useState(true);
+  const [gateComp, setGateComp] = useState<Competition | null>(null);
+  const [authenticated, setAuthenticated] = useState(false);
+  const [passcodeInput, setPasscodeInput] = useState('');
+  const [verifying, setVerifying] = useState(false);
+
+  // Load competition for passcode check
+  useEffect(() => {
+    if (!id) return;
+    const unsub = subscribeToCompetition(id, (data) => {
+      setGateComp(data);
+      setGateLoading(false);
+      if (data && !data.hasPasscode) {
+        setAuthenticated(true);
+      }
+    });
+    return () => unsub();
+  }, [id]);
+
+  const handlePasscodeSubmit = useCallback(async () => {
+    if (!id) return;
+    setVerifying(true);
+    try {
+      const valid = await verifyPasscode(id, passcodeInput);
+      if (valid) {
+        setAuthenticated(true);
+      } else {
+        showSnackbar('パスコードが正しくありません', { position: 'top' });
+      }
+    } finally {
+      setVerifying(false);
+    }
+  }, [id, passcodeInput, showSnackbar]);
+
+  if (!id) {
+    return <div className={styles.center}>大会が見つかりません</div>;
+  }
+
+  if (gateLoading) {
+    return <div className={styles.center}>読み込み中...</div>;
+  }
+
+  if (!gateComp) {
+    return <div className={styles.center}>大会が見つかりません</div>;
+  }
+
+  if (!authenticated) {
+    return (
+      <div className={styles.gate}>
+        <span className={styles.gateName}>{gateComp.name}</span>
+        <div className={styles.gateForm}>
+          <Input
+            type="password"
+            placeholder="パスコード"
+            value={passcodeInput}
+            onChange={(e) => setPasscodeInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') handlePasscodeSubmit();
+            }}
+          />
+          <Button onClick={handlePasscodeSubmit} disabled={verifying}>
+            {verifying ? '確認中...' : 'ライブビューを表示'}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return <LiveViewContent competitionId={id} />;
+};
+
+const LiveViewContent = ({ competitionId }: { competitionId: string }) => {
+  const { competition, participants, tables, loading } = useCompetition(competitionId);
+  const { rooms } = useLiveRooms(tables);
+  const [autoScroll, setAutoScroll] = useState(false);
+  const gridRef = useRef<HTMLDivElement>(null);
+
+  // Auto-scroll effect
+  useEffect(() => {
+    if (!autoScroll || !gridRef.current) return;
+    let direction = 1;
+    const interval = setInterval(() => {
+      const el = gridRef.current;
+      if (!el) return;
+      el.scrollTop += AUTO_SCROLL_SPEED * direction;
+      if (el.scrollTop + el.clientHeight >= el.scrollHeight) {
+        direction = -1;
+      } else if (el.scrollTop <= 0) {
+        direction = 1;
+      }
+    }, AUTO_SCROLL_INTERVAL);
+    return () => clearInterval(interval);
+  }, [autoScroll]);
+
+  if (loading) {
+    return <div className={styles.center}>読み込み中...</div>;
+  }
+
+  if (!competition) {
+    return <div className={styles.center}>大会が見つかりません</div>;
+  }
+
+  const sortedTables = [...tables].sort((a, b) => a.name.localeCompare(b.name, 'ja'));
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.pageHeader}>
+        <div className={styles.titleArea}>
+          <span className={styles.title}>{competition.name}</span>
+          <span className={styles.summary}>
+            {tables.length}卓 / {participants.length}名
+          </span>
+        </div>
+        <div className={styles.controls}>
+          <button
+            type="button"
+            className={autoScroll ? styles.autoScrollActive : styles.autoScrollBtn}
+            onClick={() => setAutoScroll((v) => !v)}
+          >
+            {autoScroll ? '自動スクロール ON' : '自動スクロール OFF'}
+          </button>
+        </div>
+      </div>
+      <div ref={gridRef} className={styles.grid}>
+        {sortedTables.map((table) => (
+          <LiveTableTile
+            key={table.id}
+            table={table}
+            room={table.currentRoomId ? (rooms.get(table.currentRoomId) ?? null) : null}
+            participants={participants}
+          />
+        ))}
+        {sortedTables.length === 0 && (
+          <div className={styles.center}>卓がまだ作成されていません</div>
+        )}
+      </div>
+    </div>
+  );
 };

--- a/src/utils/liveRoomUtils.test.ts
+++ b/src/utils/liveRoomUtils.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { diffRoomIds, extractRoomIds } from './liveRoomUtils';
+import type { CompetitionTable } from '../types';
+
+const makeTable = (overrides: Partial<CompetitionTable> = {}): CompetitionTable => ({
+  id: 'table-1',
+  name: 'A卓',
+  mode: '4ma',
+  status: 'playing',
+  playerIds: [],
+  gameCount: 1,
+  createdAt: Date.now(),
+  ...overrides,
+});
+
+describe('extractRoomIds', () => {
+  it('returns empty array when no tables have currentRoomId', () => {
+    const tables = [makeTable(), makeTable({ id: 't2' })];
+    expect(extractRoomIds(tables)).toEqual([]);
+  });
+
+  it('extracts unique roomIds from tables', () => {
+    const tables = [
+      makeTable({ id: 't1', currentRoomId: 'room-b' }),
+      makeTable({ id: 't2', currentRoomId: 'room-a' }),
+    ];
+    expect(extractRoomIds(tables)).toEqual(['room-a', 'room-b']);
+  });
+
+  it('deduplicates same roomId', () => {
+    const tables = [
+      makeTable({ id: 't1', currentRoomId: 'room-1' }),
+      makeTable({ id: 't2', currentRoomId: 'room-1' }),
+    ];
+    expect(extractRoomIds(tables)).toEqual(['room-1']);
+  });
+
+  it('filters out tables without currentRoomId', () => {
+    const tables = [
+      makeTable({ id: 't1', currentRoomId: 'room-1' }),
+      makeTable({ id: 't2', currentRoomId: undefined }),
+      makeTable({ id: 't3', currentRoomId: 'room-2' }),
+    ];
+    expect(extractRoomIds(tables)).toEqual(['room-1', 'room-2']);
+  });
+});
+
+describe('diffRoomIds', () => {
+  it('returns all as added when prev is empty', () => {
+    const result = diffRoomIds(new Set(), new Set(['a', 'b']));
+    expect(result.added).toEqual(['a', 'b']);
+    expect(result.removed).toEqual([]);
+  });
+
+  it('returns all as removed when next is empty', () => {
+    const result = diffRoomIds(new Set(['a', 'b']), new Set());
+    expect(result.added).toEqual([]);
+    expect(result.removed).toEqual(['a', 'b']);
+  });
+
+  it('detects added and removed', () => {
+    const result = diffRoomIds(new Set(['a', 'b']), new Set(['b', 'c']));
+    expect(result.added).toEqual(['c']);
+    expect(result.removed).toEqual(['a']);
+  });
+
+  it('returns empty when sets are identical', () => {
+    const result = diffRoomIds(new Set(['a', 'b']), new Set(['a', 'b']));
+    expect(result.added).toEqual([]);
+    expect(result.removed).toEqual([]);
+  });
+});

--- a/src/utils/liveRoomUtils.ts
+++ b/src/utils/liveRoomUtils.ts
@@ -1,0 +1,17 @@
+import type { CompetitionTable } from '../types';
+
+/** Extract unique, sorted roomIds from tables that have a currentRoomId. */
+export const extractRoomIds = (tables: CompetitionTable[]): string[] => {
+  const ids = tables.filter((t) => t.currentRoomId).map((t) => t.currentRoomId as string);
+  return [...new Set(ids)].sort();
+};
+
+/** Compute which roomIds were added and which were removed. */
+export const diffRoomIds = (
+  prev: ReadonlySet<string>,
+  next: ReadonlySet<string>,
+): { added: string[]; removed: string[] } => {
+  const added = [...next].filter((id) => !prev.has(id));
+  const removed = [...prev].filter((id) => !next.has(id));
+  return { added, removed };
+};


### PR DESCRIPTION
## 概要

各卓実況機能のリアルタイムライブビューを実装。
`/competitions/{id}/live` で全卓のスコア・局情報をタイル形式でリアルタイム一覧表示できる。

## 主な機能

- パスコード大会はパスコード入力後にアクセス可能
- 全卓のスコア・局情報をタイル形式でリアルタイム一覧表示
- Firestoreリアルタイムリスナーによる差分更新（incremental add/remove）
- プロジェクター投影想定の高コントラスト黒背景レイアウト
- 自動スクロールのトグル機能
- レスポンシブ対応（大画面5列、タブレット3列、モバイル1列）

## 変更ファイル（7ファイル、+714行）

### 新規作成
- `src/hooks/useLiveRooms.ts` — 複数テーブルのRoomStateを動的にサブスクライブするフック（incremental diff管理）
- `src/utils/liveRoomUtils.ts` — roomId抽出・差分計算ユーティリティ
- `src/utils/liveRoomUtils.test.ts` — ユーティリティテスト（8テスト通過）
- `src/components/features/LiveTableTile.tsx` + CSS Module — 卓タイルコンポーネント
- `src/pages/CompetitionLivePage.module.css` — ライブビューページスタイル

### 修正
- `src/pages/CompetitionLivePage.tsx` — プレースホルダーから完全実装に置き換え

## レビュー対応

- C-1: useEffect cleanupをunmount-onlyに分離し、diffロジックが正しく機能するよう修正
- H-1: loading状態をFirestore snapshot到着まで保持するよう修正（pendingRef）

## テスト計画

- [x] 198テスト全パス（新規8テスト含む）
- [x] lint クリーン
- [x] build クリーン

Closes #68
