### PR TITLE
feat: 集計・レポート機能 — 総合成績・対局別詳細・CSV/PDFエクスポート

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -352,31 +352,6 @@
         "react": ">=16.8.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -352,6 +352,31 @@
         "react": ">=16.8.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -2294,9 +2319,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.14",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.14.tgz",
-      "integrity": "sha512-fOVLPAsFTsQfuCkvahZkzq6nf8KvGWanlYoTh0SVA0A/PIUxQGU2AOZAoD95n2gFLVDW/jP6sbGLny95nmEuHA==",
+      "version": "2.10.15",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.15.tgz",
+      "integrity": "sha512-1nfKCq9wuAZFTkA2ey/3OXXx7GzFjLdkTiFVNwlJ9WqdI706CZRIhEqjuwanjMIja+84jDLa9rcyZDPDiVkASQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2363,9 +2388,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001785",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001785.tgz",
-      "integrity": "sha512-blhOL/WNR+Km1RI/LCVAvA73xplXA7ZbjzI4YkMK9pa6T/P3F2GxjNpEkyw5repTw9IvkyrjyHpwjnhZ5FOvYQ==",
+      "version": "1.0.30001786",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001786.tgz",
+      "integrity": "sha512-4oxTZEvqmLLrERwxO76yfKM7acZo310U+v4kqexI2TL1DkkUEMT8UijrxxcnVdxR3qkVf5awGRX+4Z6aPHVKrA==",
       "dev": true,
       "funding": [
         {
@@ -4749,9 +4774,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.3.tgz",
-      "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.5.tgz",
+      "integrity": "sha512-nmu43Qvq9UopTRfMx2jOYW5l16pb3iDC1JH6yMuPkpVbzK0k+L7dfsEDH4jRgYFmsg0sTAqkojoZgzLMlwHsCQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -4777,7 +4802,7 @@
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
         "@vitejs/devtools": "^0.1.0",
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
         "sass": "^1.70.0",

--- a/src/pages/CompetitionDashboardPage.tsx
+++ b/src/pages/CompetitionDashboardPage.tsx
@@ -222,6 +222,15 @@ export const CompetitionDashboardPage = () => {
             <Button size="small" variant="secondary" onClick={() => setIsShareOpen(true)}>
               共有
             </Button>
+            {(competition.status === 'in_progress' ||
+              competition.status === 'closed' ||
+              competition.status === 'archived') && (
+              <Link to={`/competitions/${id}/report`}>
+                <Button size="small" variant="secondary">
+                  レポート
+                </Button>
+              </Link>
+            )}
             {isOrganizer && STATUS_ACTION_LABELS[competition.status] && (
               <Button
                 size="small"

--- a/src/pages/CompetitionReportPage.module.css
+++ b/src/pages/CompetitionReportPage.module.css
@@ -1,0 +1,240 @@
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: var(--spacing-m) var(--spacing-l);
+  font-family: var(--font-main);
+  color: var(--color-text-primary);
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--spacing-m);
+  margin-bottom: var(--spacing-l);
+}
+
+.titleArea {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  min-width: 0;
+}
+
+.title {
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-bold);
+}
+
+.subtitle {
+  font-size: var(--font-size-s);
+  color: var(--color-text-secondary);
+}
+
+.actions {
+  display: flex;
+  gap: var(--spacing-s);
+  flex-shrink: 0;
+}
+
+.section {
+  margin-bottom: var(--spacing-xl);
+}
+
+.sectionTitle {
+  font-size: var(--font-size-l);
+  font-weight: var(--font-weight-bold);
+  margin-bottom: var(--spacing-m);
+  padding-bottom: var(--spacing-xs);
+  border-bottom: 1px solid var(--color-bg-card);
+}
+
+.tableWrapper {
+  overflow-x: auto;
+  border-radius: var(--border-radius-m);
+  background: var(--color-bg-card);
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 500px;
+  font-size: var(--font-size-s);
+}
+
+.table th {
+  padding: var(--spacing-s) var(--spacing-m);
+  text-align: center;
+  font-weight: var(--font-weight-bold);
+  white-space: nowrap;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+  position: sticky;
+  top: 0;
+  background: var(--color-bg-card);
+}
+
+.table td {
+  padding: var(--spacing-s) var(--spacing-m);
+  text-align: center;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.table tbody tr:hover {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.rankCell {
+  font-weight: var(--font-weight-bold);
+  font-family: var(--font-mono);
+}
+
+.nameCell {
+  text-align: left !important;
+  max-width: 150px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.numericCell {
+  font-family: var(--font-mono);
+  white-space: nowrap;
+}
+
+.positive {
+  color: var(--color-success);
+  font-weight: var(--font-weight-bold);
+}
+
+.negative {
+  color: var(--color-danger);
+  font-weight: var(--font-weight-bold);
+}
+
+.zero {
+  color: var(--color-text-secondary);
+}
+
+.tagList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-xs);
+}
+
+.tag {
+  font-size: var(--font-size-xs);
+  padding: 2px var(--spacing-s);
+  border-radius: var(--border-radius-s);
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.center {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 200px;
+  font-size: var(--font-size-m);
+  color: var(--color-text-secondary);
+}
+
+.backLink {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  color: var(--color-text-accent);
+  text-decoration: none;
+  font-size: var(--font-size-s);
+  margin-bottom: var(--spacing-m);
+}
+
+.backLink:hover {
+  text-decoration: underline;
+}
+
+.statusBadge {
+  display: inline-block;
+  font-size: var(--font-size-xs);
+  padding: 2px var(--spacing-s);
+  border-radius: var(--border-radius-s);
+  background: #ff9800;
+  color: #000;
+  font-weight: var(--font-weight-bold);
+  margin-left: var(--spacing-s);
+}
+
+@media (max-width: 600px) {
+  .container {
+    padding: var(--spacing-s) var(--spacing-m);
+  }
+
+  .header {
+    flex-direction: column;
+  }
+
+  .actions {
+    width: 100%;
+  }
+
+  .title {
+    font-size: var(--font-size-l);
+  }
+}
+
+@media print {
+  .container {
+    background: #fff;
+    color: #000;
+    padding: 0;
+  }
+
+  .actions,
+  .backLink {
+    display: none;
+  }
+
+  .tableWrapper {
+    background: #fff;
+  }
+
+  .table th {
+    background: #eee;
+    color: #000;
+    border-bottom: 2px solid #333;
+  }
+
+  .table td {
+    border-bottom: 1px solid #ccc;
+    color: #000;
+  }
+
+  .positive {
+    color: #006400;
+  }
+
+  .negative {
+    color: #8b0000;
+  }
+
+  .zero {
+    color: #666;
+  }
+
+  .sectionTitle {
+    border-bottom-color: #333;
+    color: #000;
+  }
+
+  .statusBadge {
+    border: 1px solid #333;
+  }
+
+  .subtitle {
+    color: #555;
+  }
+
+  .tag {
+    background: #eee;
+    color: #000;
+    border: 1px solid #ccc;
+  }
+}

--- a/src/pages/CompetitionReportPage.tsx
+++ b/src/pages/CompetitionReportPage.tsx
@@ -1,3 +1,225 @@
+import { useMemo } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { Button } from '../components/ui/Button';
+import { useCompetition } from '../hooks/useCompetition';
+import {
+  aggregateMatchDetails,
+  aggregateOverallStandings,
+  aggregateTableSummary,
+} from '../utils/competitionReport';
+import {
+  downloadBlob,
+  generateCsvBlob,
+  generatePdfReport,
+  generateReportFilename,
+} from '../utils/exportReport';
+import styles from './CompetitionReportPage.module.css';
+
+const formatPoint = (pt: number): string => {
+  const prefix = pt > 0 ? '+' : '';
+  return `${prefix}${pt.toLocaleString(undefined, { minimumFractionDigits: 1, maximumFractionDigits: 1 })}`;
+};
+
+const pointClass = (pt: number): string => {
+  if (pt > 0) return styles.positive;
+  if (pt < 0) return styles.negative;
+  return styles.zero;
+};
+
 export const CompetitionReportPage = () => {
-  return <div>大会レポート</div>;
+  const { id } = useParams<{ id: string }>();
+  const { competition, participants, tables, gameResults, loading } = useCompetition(id ?? '');
+
+  const standings = useMemo(
+    () => aggregateOverallStandings(gameResults, participants),
+    [gameResults, participants],
+  );
+
+  const matchDetails = useMemo(
+    () => aggregateMatchDetails(gameResults, participants),
+    [gameResults, participants],
+  );
+
+  const tableSummary = useMemo(
+    () => aggregateTableSummary(tables, participants, gameResults),
+    [tables, participants, gameResults],
+  );
+
+  const useChip = competition?.settings.useChip ?? false;
+  const isInProgress = competition?.status === 'in_progress';
+
+  const handleCsvExport = () => {
+    if (!competition) return;
+    const blob = generateCsvBlob(standings, matchDetails, useChip);
+    downloadBlob(blob, generateReportFilename(competition.name, 'csv'));
+  };
+
+  const handlePdfExport = () => {
+    generatePdfReport();
+  };
+
+  if (!id) {
+    return <div className={styles.center}>大会が見つかりません</div>;
+  }
+
+  if (loading) {
+    return <div className={styles.center}>読み込み中...</div>;
+  }
+
+  if (!competition) {
+    return <div className={styles.center}>大会が見つかりません</div>;
+  }
+
+  return (
+    <div className={styles.container}>
+      <Link to={`/competitions/${id}`} className={styles.backLink}>
+        ← ダッシュボードに戻る
+      </Link>
+
+      <div className={styles.header}>
+        <div className={styles.titleArea}>
+          <span className={styles.title}>
+            {competition.name} レポート
+            {isInProgress && <span className={styles.statusBadge}>途中結果</span>}
+          </span>
+          <span className={styles.subtitle}>
+            {participants.length}名参加 / {tables.length}卓 / {gameResults.length}対局
+          </span>
+        </div>
+        <div className={styles.actions}>
+          <Button onClick={handleCsvExport} disabled={gameResults.length === 0}>
+            CSV
+          </Button>
+          <Button onClick={handlePdfExport} disabled={gameResults.length === 0}>
+            PDF（印刷）
+          </Button>
+        </div>
+      </div>
+
+      {/* Overall Standings */}
+      <div className={styles.section}>
+        <h2 className={styles.sectionTitle}>総合成績</h2>
+        {standings.length > 0 ? (
+          <div className={styles.tableWrapper}>
+            <table className={styles.table}>
+              <thead>
+                <tr>
+                  <th>順位</th>
+                  <th>参加者名</th>
+                  <th>対局数</th>
+                  <th>合計ポイント</th>
+                  <th>平均順位</th>
+                  {useChip && <th>チップ収支</th>}
+                </tr>
+              </thead>
+              <tbody>
+                {standings.map((s) => (
+                  <tr key={s.participantId}>
+                    <td className={styles.rankCell}>{s.rank}</td>
+                    <td className={styles.nameCell}>{s.name}</td>
+                    <td className={styles.numericCell}>{s.gameCount}</td>
+                    <td className={`${styles.numericCell} ${pointClass(s.totalPoint)}`}>
+                      {formatPoint(s.totalPoint)}
+                    </td>
+                    <td className={styles.numericCell}>{s.averageRank}</td>
+                    {useChip && (
+                      <td className={`${styles.numericCell} ${pointClass(s.totalChip)}`}>
+                        {s.totalChip > 0 ? '+' : ''}
+                        {s.totalChip}
+                      </td>
+                    )}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <div className={styles.center}>対局結果がまだありません</div>
+        )}
+      </div>
+
+      {/* Match Details */}
+      <div className={styles.section}>
+        <h2 className={styles.sectionTitle}>対局別詳細</h2>
+        {matchDetails.length > 0 ? (
+          <div className={styles.tableWrapper}>
+            <table className={styles.table}>
+              <thead>
+                <tr>
+                  <th>卓名</th>
+                  <th>対局番号</th>
+                  <th>参加者名</th>
+                  <th>順位</th>
+                  <th>素点</th>
+                  <th>ポイント</th>
+                  {useChip && <th>チップ収支</th>}
+                </tr>
+              </thead>
+              <tbody>
+                {matchDetails.map((d, i) => (
+                  <tr key={`${d.participantId}-${d.tableName}-${d.gameIndex}-${i}`}>
+                    <td>{d.tableName}</td>
+                    <td className={styles.numericCell}>{d.gameIndex}</td>
+                    <td className={styles.nameCell}>{d.name}</td>
+                    <td className={styles.rankCell}>{d.rank}</td>
+                    <td className={styles.numericCell}>{d.rawScore.toLocaleString()}</td>
+                    <td className={`${styles.numericCell} ${pointClass(d.point)}`}>
+                      {formatPoint(d.point)}
+                    </td>
+                    {useChip && (
+                      <td className={`${styles.numericCell} ${pointClass(d.chipDiff)}`}>
+                        {d.chipDiff > 0 ? '+' : ''}
+                        {d.chipDiff}
+                      </td>
+                    )}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <div className={styles.center}>対局結果がまだありません</div>
+        )}
+      </div>
+
+      {/* Table Summary */}
+      <div className={styles.section}>
+        <h2 className={styles.sectionTitle}>卓別サマリ</h2>
+        {tableSummary.length > 0 ? (
+          <div className={styles.tableWrapper}>
+            <table className={styles.table}>
+              <thead>
+                <tr>
+                  <th>卓名</th>
+                  <th>モード</th>
+                  <th>対局回数</th>
+                  <th>参加者</th>
+                </tr>
+              </thead>
+              <tbody>
+                {tableSummary.map((t) => (
+                  <tr key={t.tableId}>
+                    <td>{t.tableName}</td>
+                    <td>{t.mode === '3ma' ? '3麻' : '4麻'}</td>
+                    <td className={styles.numericCell}>{t.gameCount}</td>
+                    <td style={{ textAlign: 'left' }}>
+                      <div className={styles.tagList}>
+                        {t.participantNames.map((name) => (
+                          <span key={name} className={styles.tag}>
+                            {name}
+                          </span>
+                        ))}
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <div className={styles.center}>卓がまだ作成されていません</div>
+        )}
+      </div>
+    </div>
+  );
 };

--- a/src/utils/competitionReport.test.ts
+++ b/src/utils/competitionReport.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from 'vitest';
+import {
+  aggregateOverallStandings,
+  aggregateMatchDetails,
+  aggregateTableSummary,
+} from './competitionReport';
+import type {
+  CompetitionGameResult,
+  CompetitionParticipant,
+  CompetitionTable,
+  GameResult,
+  PlayerGameResult,
+} from '../types';
+
+const makeScore = (overrides: Partial<PlayerGameResult> = {}): PlayerGameResult => ({
+  playerId: 'p1',
+  name: 'Player 1',
+  rank: 1,
+  rawScore: 30000,
+  point: 20,
+  chipDiff: 0,
+  ...overrides,
+});
+
+const makeGameResult = (overrides: Partial<GameResult> = {}): GameResult => ({
+  id: 'game-1',
+  timestamp: Date.now(),
+  ruleSnapshot: {} as GameResult['ruleSnapshot'],
+  scores: [],
+  ...overrides,
+});
+
+const makeCompGameResult = (
+  overrides: Partial<CompetitionGameResult> = {},
+): CompetitionGameResult => ({
+  id: 'cgr-1',
+  tableId: 'table-1',
+  tableName: 'A卓',
+  gameIndex: 1,
+  result: makeGameResult(),
+  participantIds: ['p1'],
+  timestamp: Date.now(),
+  ...overrides,
+});
+
+const makeParticipant = (
+  overrides: Partial<CompetitionParticipant> = {},
+): CompetitionParticipant => ({
+  id: 'p1',
+  name: 'Player 1',
+  isGuest: false,
+  status: 'idle',
+  role: 'player',
+  joinedAt: Date.now(),
+  ...overrides,
+});
+
+const makeTable = (overrides: Partial<CompetitionTable> = {}): CompetitionTable => ({
+  id: 'table-1',
+  name: 'A卓',
+  mode: '4ma',
+  status: 'finished',
+  playerIds: ['p1', 'p2', 'p3', 'p4'],
+  gameCount: 2,
+  createdAt: Date.now(),
+  ...overrides,
+});
+
+describe('aggregateOverallStandings', () => {
+  it('returns empty array when no game results', () => {
+    const result = aggregateOverallStandings([], []);
+    expect(result).toEqual([]);
+  });
+
+  it('aggregates single player across multiple games', () => {
+    const gameResults: CompetitionGameResult[] = [
+      makeCompGameResult({
+        result: makeGameResult({
+          scores: [makeScore({ playerId: 'p1', point: 20, rank: 1, chipDiff: 3 })],
+        }),
+        participantIds: ['p1'],
+      }),
+      makeCompGameResult({
+        id: 'cgr-2',
+        result: makeGameResult({
+          scores: [makeScore({ playerId: 'p1', point: -10, rank: 3, chipDiff: -1 })],
+        }),
+        participantIds: ['p1'],
+      }),
+    ];
+    const participants = [makeParticipant({ id: 'p1', name: 'Player 1' })];
+
+    const result = aggregateOverallStandings(gameResults, participants);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].participantId).toBe('p1');
+    expect(result[0].totalPoint).toBe(10);
+    expect(result[0].gameCount).toBe(2);
+    expect(result[0].averageRank).toBe(2);
+    expect(result[0].totalChip).toBe(2);
+    expect(result[0].rank).toBe(1);
+  });
+
+  it('ranks players by total point descending', () => {
+    const gameResults: CompetitionGameResult[] = [
+      makeCompGameResult({
+        result: makeGameResult({
+          scores: [
+            makeScore({ playerId: 'p1', point: 10, rank: 2 }),
+            makeScore({ playerId: 'p2', point: 30, rank: 1 }),
+            makeScore({ playerId: 'p3', point: -40, rank: 3 }),
+          ],
+        }),
+        participantIds: ['p1', 'p2', 'p3'],
+      }),
+    ];
+    const participants = [
+      makeParticipant({ id: 'p1', name: 'P1' }),
+      makeParticipant({ id: 'p2', name: 'P2' }),
+      makeParticipant({ id: 'p3', name: 'P3' }),
+    ];
+
+    const result = aggregateOverallStandings(gameResults, participants);
+
+    expect(result[0].participantId).toBe('p2');
+    expect(result[0].rank).toBe(1);
+    expect(result[1].participantId).toBe('p1');
+    expect(result[1].rank).toBe(2);
+    expect(result[2].participantId).toBe('p3');
+    expect(result[2].rank).toBe(3);
+  });
+
+  it('resolves player name from participants when available', () => {
+    const gameResults: CompetitionGameResult[] = [
+      makeCompGameResult({
+        result: makeGameResult({
+          scores: [makeScore({ playerId: 'uid-1', name: 'Display Name', point: 10, rank: 1 })],
+        }),
+        participantIds: ['p1'],
+      }),
+    ];
+    const participants = [makeParticipant({ id: 'p1', userId: 'uid-1', name: 'Participant Name' })];
+
+    const result = aggregateOverallStandings(gameResults, participants);
+
+    expect(result[0].name).toBe('Participant Name');
+    expect(result[0].participantId).toBe('p1');
+  });
+});
+
+describe('aggregateMatchDetails', () => {
+  it('returns empty array when no game results', () => {
+    expect(aggregateMatchDetails([], [])).toEqual([]);
+  });
+
+  it('flattens game results into per-player rows', () => {
+    const gameResults: CompetitionGameResult[] = [
+      makeCompGameResult({
+        tableName: 'A卓',
+        gameIndex: 1,
+        result: makeGameResult({
+          scores: [
+            makeScore({
+              playerId: 'p1',
+              name: 'P1',
+              rank: 1,
+              rawScore: 35000,
+              point: 30,
+              chipDiff: 2,
+            }),
+            makeScore({
+              playerId: 'p2',
+              name: 'P2',
+              rank: 2,
+              rawScore: 25000,
+              point: -30,
+              chipDiff: -2,
+            }),
+          ],
+        }),
+        participantIds: ['p1', 'p2'],
+      }),
+    ];
+    const participants = [
+      makeParticipant({ id: 'p1', name: 'P1' }),
+      makeParticipant({ id: 'p2', name: 'P2' }),
+    ];
+
+    const result = aggregateMatchDetails(gameResults, participants);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].tableName).toBe('A卓');
+    expect(result[0].gameIndex).toBe(1);
+    expect(result[0].rank).toBe(1);
+    expect(result[0].rawScore).toBe(35000);
+    expect(result[0].point).toBe(30);
+    expect(result[0].chipDiff).toBe(2);
+  });
+});
+
+describe('aggregateTableSummary', () => {
+  it('returns empty array when no tables', () => {
+    expect(aggregateTableSummary([], [], [])).toEqual([]);
+  });
+
+  it('builds summary from tables, participants, and game results', () => {
+    const tables = [makeTable({ id: 't1', name: 'A卓', mode: '4ma', gameCount: 3 })];
+    const participants = [
+      makeParticipant({ id: 'p1', name: 'P1' }),
+      makeParticipant({ id: 'p2', name: 'P2' }),
+    ];
+    const gameResults: CompetitionGameResult[] = [
+      makeCompGameResult({ tableId: 't1', participantIds: ['p1', 'p2'] }),
+    ];
+
+    const result = aggregateTableSummary(tables, participants, gameResults);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].tableName).toBe('A卓');
+    expect(result[0].mode).toBe('4ma');
+    expect(result[0].gameCount).toBe(3);
+    expect(result[0].participantNames).toContain('P1');
+    expect(result[0].participantNames).toContain('P2');
+  });
+});

--- a/src/utils/competitionReport.ts
+++ b/src/utils/competitionReport.ts
@@ -1,0 +1,194 @@
+import type { CompetitionGameResult, CompetitionParticipant, CompetitionTable } from '../types';
+
+export interface OverallStanding {
+  rank: number;
+  participantId: string;
+  name: string;
+  gameCount: number;
+  totalPoint: number;
+  averageRank: number;
+  totalChip: number;
+}
+
+export interface MatchDetail {
+  tableName: string;
+  gameIndex: number;
+  participantId: string;
+  name: string;
+  rank: number;
+  rawScore: number;
+  point: number;
+  chipDiff: number;
+  timestamp: number;
+}
+
+export interface TableSummary {
+  tableId: string;
+  tableName: string;
+  mode: '3ma' | '4ma';
+  gameCount: number;
+  participantNames: string[];
+}
+
+/**
+ * Build a mapping from playerId (which may be Firebase UID) back to participant.
+ * For guest players, playerId === participant.id.
+ * For account users, playerId === participant.userId.
+ */
+const buildPlayerToParticipantMap = (
+  participants: CompetitionParticipant[],
+): Map<string, CompetitionParticipant> => {
+  const map = new Map<string, CompetitionParticipant>();
+  for (const p of participants) {
+    map.set(p.id, p);
+    if (p.userId) {
+      map.set(p.userId, p);
+    }
+  }
+  return map;
+};
+
+const resolveParticipant = (
+  playerId: string,
+  participantIds: string[],
+  playerMap: Map<string, CompetitionParticipant>,
+): CompetitionParticipant | undefined => {
+  // Direct match by playerId
+  const direct = playerMap.get(playerId);
+  if (direct) return direct;
+  // Fallback: check participantIds
+  for (const pid of participantIds) {
+    const p = playerMap.get(pid);
+    if (p && (p.userId === playerId || p.id === playerId)) return p;
+  }
+  return undefined;
+};
+
+export const aggregateOverallStandings = (
+  gameResults: CompetitionGameResult[],
+  participants: CompetitionParticipant[],
+): OverallStanding[] => {
+  if (gameResults.length === 0) return [];
+
+  const playerMap = buildPlayerToParticipantMap(participants);
+
+  // Accumulate per-participant stats
+  const statsMap = new Map<
+    string,
+    { name: string; totalPoint: number; rankSum: number; gameCount: number; totalChip: number }
+  >();
+
+  for (const gr of gameResults) {
+    for (const score of gr.result.scores) {
+      const participant = resolveParticipant(score.playerId, gr.participantIds, playerMap);
+      const participantId = participant?.id ?? score.playerId;
+      const name = participant?.name ?? score.name;
+
+      const existing = statsMap.get(participantId);
+      if (existing) {
+        statsMap.set(participantId, {
+          name: existing.name,
+          totalPoint: existing.totalPoint + score.point,
+          rankSum: existing.rankSum + score.rank,
+          gameCount: existing.gameCount + 1,
+          totalChip: existing.totalChip + score.chipDiff,
+        });
+      } else {
+        statsMap.set(participantId, {
+          name,
+          totalPoint: score.point,
+          rankSum: score.rank,
+          gameCount: 1,
+          totalChip: score.chipDiff,
+        });
+      }
+    }
+  }
+
+  // Sort by totalPoint descending
+  const entries = [...statsMap.entries()]
+    .map(([participantId, stats]) => ({
+      participantId,
+      name: stats.name,
+      gameCount: stats.gameCount,
+      totalPoint: stats.totalPoint,
+      averageRank: Math.round((stats.rankSum / stats.gameCount) * 10) / 10,
+      totalChip: stats.totalChip,
+    }))
+    .sort((a, b) => b.totalPoint - a.totalPoint);
+
+  return entries.map((entry, index) => ({
+    ...entry,
+    rank: index + 1,
+  }));
+};
+
+export const aggregateMatchDetails = (
+  gameResults: CompetitionGameResult[],
+  participants: CompetitionParticipant[],
+): MatchDetail[] => {
+  if (gameResults.length === 0) return [];
+
+  const playerMap = buildPlayerToParticipantMap(participants);
+  const details: MatchDetail[] = [];
+
+  const sorted = [...gameResults].sort((a, b) => a.timestamp - b.timestamp);
+
+  for (const gr of sorted) {
+    for (const score of gr.result.scores) {
+      const participant = resolveParticipant(score.playerId, gr.participantIds, playerMap);
+      details.push({
+        tableName: gr.tableName,
+        gameIndex: gr.gameIndex,
+        participantId: participant?.id ?? score.playerId,
+        name: participant?.name ?? score.name,
+        rank: score.rank,
+        rawScore: score.rawScore,
+        point: score.point,
+        chipDiff: score.chipDiff,
+        timestamp: gr.timestamp,
+      });
+    }
+  }
+
+  return details;
+};
+
+export const aggregateTableSummary = (
+  tables: CompetitionTable[],
+  participants: CompetitionParticipant[],
+  gameResults: CompetitionGameResult[],
+): TableSummary[] => {
+  if (tables.length === 0) return [];
+
+  const participantMap = new Map(participants.map((p) => [p.id, p]));
+
+  // Collect unique participant IDs per table from game results
+  const tableParticipantIds = new Map<string, Set<string>>();
+  for (const gr of gameResults) {
+    const existing = tableParticipantIds.get(gr.tableId) ?? new Set<string>();
+    for (const pid of gr.participantIds) {
+      existing.add(pid);
+    }
+    tableParticipantIds.set(gr.tableId, existing);
+  }
+
+  return tables
+    .map((table) => {
+      const pids = tableParticipantIds.get(table.id) ?? new Set<string>();
+      // Also include currently assigned players
+      for (const pid of table.playerIds) {
+        pids.add(pid);
+      }
+      const participantNames = [...pids].map((pid) => participantMap.get(pid)?.name ?? pid).sort();
+
+      return {
+        tableId: table.id,
+        tableName: table.name,
+        mode: table.mode,
+        gameCount: table.gameCount,
+        participantNames,
+      };
+    })
+    .sort((a, b) => a.tableName.localeCompare(b.tableName, 'ja'));
+};

--- a/src/utils/exportReport.test.ts
+++ b/src/utils/exportReport.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { generateCsvBlob } from './exportReport';
+import type { OverallStanding, MatchDetail } from './competitionReport';
+
+const makeStanding = (overrides: Partial<OverallStanding> = {}): OverallStanding => ({
+  rank: 1,
+  participantId: 'p1',
+  name: 'Player 1',
+  gameCount: 3,
+  totalPoint: 30,
+  averageRank: 1.7,
+  totalChip: 5,
+  ...overrides,
+});
+
+const makeDetail = (overrides: Partial<MatchDetail> = {}): MatchDetail => ({
+  tableName: 'A卓',
+  gameIndex: 1,
+  participantId: 'p1',
+  name: 'Player 1',
+  rank: 1,
+  rawScore: 35000,
+  point: 30,
+  chipDiff: 2,
+  timestamp: Date.now(),
+  ...overrides,
+});
+
+describe('generateCsvBlob', () => {
+  it('generates CSV with overall standings and match details', () => {
+    const standings = [makeStanding()];
+    const details = [makeDetail()];
+
+    const blob = generateCsvBlob(standings, details, false);
+
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.type).toBe('text/csv;charset=utf-8');
+  });
+
+  it('includes chip columns when useChip is true', async () => {
+    const standings = [makeStanding({ totalChip: 5 })];
+    const details = [makeDetail({ chipDiff: 2 })];
+
+    const blob = generateCsvBlob(standings, details, true);
+    const text = await blob.text();
+
+    expect(text).toContain('チップ収支');
+  });
+
+  it('excludes chip columns when useChip is false', async () => {
+    const standings = [makeStanding()];
+    const details = [makeDetail()];
+
+    const blob = generateCsvBlob(standings, details, false);
+    const text = await blob.text();
+
+    expect(text).not.toContain('チップ収支');
+  });
+
+  it('handles empty data', () => {
+    const blob = generateCsvBlob([], [], false);
+    expect(blob).toBeInstanceOf(Blob);
+  });
+
+  it('escapes formula injection characters in names', async () => {
+    const standings = [makeStanding({ name: '=HYPERLINK("http://evil.com","Click")' })];
+    const details = [makeDetail({ name: '+cmd|calc' })];
+
+    const blob = generateCsvBlob(standings, details, false);
+    const text = await blob.text();
+
+    // Formula-prefixed values should have single-quote prefix
+    expect(text).toContain("'=HYPERLINK");
+    expect(text).toContain("'+cmd|calc");
+  });
+});

--- a/src/utils/exportReport.ts
+++ b/src/utils/exportReport.ts
@@ -1,0 +1,83 @@
+import type { MatchDetail, OverallStanding } from './competitionReport';
+
+const BOM = '\uFEFF';
+
+const FORMULA_PREFIX = /^[=+\-@\t\r]/;
+
+const escapeCsvField = (value: string | number): string => {
+  const str = String(value);
+  // Guard against CSV formula injection (OWASP)
+  if (FORMULA_PREFIX.test(str)) {
+    return `"'${str.replace(/"/g, '""')}"`;
+  }
+  if (str.includes(',') || str.includes('"') || str.includes('\n')) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+};
+
+const toCsvRow = (fields: (string | number)[]): string => fields.map(escapeCsvField).join(',');
+
+export const generateCsvBlob = (
+  standings: OverallStanding[],
+  details: MatchDetail[],
+  useChip: boolean,
+): Blob => {
+  const lines: string[] = [];
+
+  // Overall standings section
+  lines.push('--- 総合成績 ---');
+  const standingHeader = ['順位', '参加者名', '対局数', '合計ポイント', '平均順位'];
+  if (useChip) standingHeader.push('チップ収支');
+  lines.push(toCsvRow(standingHeader));
+
+  for (const s of standings) {
+    const row: (string | number)[] = [s.rank, s.name, s.gameCount, s.totalPoint, s.averageRank];
+    if (useChip) row.push(s.totalChip);
+    lines.push(toCsvRow(row));
+  }
+
+  lines.push('');
+
+  // Match details section
+  lines.push('--- 対局別詳細 ---');
+  const detailHeader = ['卓名', '対局番号', '参加者名', '順位', '素点', 'ポイント'];
+  if (useChip) detailHeader.push('チップ収支');
+  lines.push(toCsvRow(detailHeader));
+
+  for (const d of details) {
+    const row: (string | number)[] = [
+      d.tableName,
+      d.gameIndex,
+      d.name,
+      d.rank,
+      d.rawScore,
+      d.point,
+    ];
+    if (useChip) row.push(d.chipDiff);
+    lines.push(toCsvRow(row));
+  }
+
+  return new Blob([BOM + lines.join('\n')], { type: 'text/csv;charset=utf-8' });
+};
+
+export const downloadBlob = (blob: Blob, filename: string): void => {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+};
+
+export const generateReportFilename = (competitionName: string, ext: string): string => {
+  const date = new Date().toISOString().slice(0, 10);
+  const safeName = competitionName.replace(/[/\\?%*:|"<>]/g, '_');
+  return `${safeName}_report_${date}.${ext}`;
+};
+
+export const generatePdfReport = (): void => {
+  window.print();
+};


### PR DESCRIPTION
## 概要

大会の集計・レポート機能を実装しました。総合成績テーブル、対局別詳細テーブル、卓別サマリテーブルの3つのビューと、CSV/PDFエクスポート機能を提供します。

Epic: #71

## 主な変更点

### 新規ファイル
- `src/utils/competitionReport.ts` — 集計ロジック（aggregateOverallStandings, aggregateMatchDetails, aggregateTableSummary）
- `src/utils/competitionReport.test.ts` — 集計テスト（8テスト）
- `src/utils/exportReport.ts` — CSV/PDFエクスポート（CSV formula injection対策、ブラウザ印刷ベースPDF）
- `src/utils/exportReport.test.ts` — エクスポートテスト（5テスト）
- `src/pages/CompetitionReportPage.module.css` — レポートページスタイル（印刷用CSSメディアクエリ付き）

### 修正ファイル
- `src/pages/CompetitionReportPage.tsx` — プレースホルダーから完全実装へ
- `src/pages/CompetitionDashboardPage.tsx` — in_progress/closed/archived時にレポートリンク追加

## 機能詳細

- 総合成績テーブル（順位・参加者名・対局数・合計ポイント・平均順位・チップ収支）
- 対局別詳細テーブル（卓名・対局番号・参加者名・順位・素点・ポイント・チップ収支）
- 卓別サマリテーブル（卓名・モード・対局回数・参加者）
- チップ使用時のみチップ列を条件表示
- CSVエクスポート（BOM付きUTF-8、formula injection対策済み）
- PDFエクスポート（window.print()で日本語ネイティブ対応）
- in_progress中は「途中結果」バッジ付きリアルタイム表示

## セキュリティ対応

- CSV formula injection対策: =, +, -, @ で始まるセルにシングルクォートプレフィックス
- jsPDFからwindow.print()に変更し外部ライブラリ依存を排除

## テスト計画

- [x] 211テスト全パス（新規13テスト含む）
- [x] lint クリーン
- [x] build クリーン

Closes #69
