### PR TITLE
feat: 大会↔ライブビューの相互リンク追加 (#80)

### DIFF
--- a/src/pages/CompetitionDashboardPage.tsx
+++ b/src/pages/CompetitionDashboardPage.tsx
@@ -219,6 +219,11 @@ export const CompetitionDashboardPage = () => {
       {canManage && (
         <div className={styles.section}>
           <div className={styles.actionRow}>
+            <Link to={`/competitions/${id}/live`}>
+              <Button size="small" variant="secondary">
+                ライブビュー
+              </Button>
+            </Link>
             <Button size="small" variant="secondary" onClick={() => setIsShareOpen(true)}>
               共有
             </Button>

--- a/src/pages/CompetitionLivePage.module.css
+++ b/src/pages/CompetitionLivePage.module.css
@@ -45,6 +45,20 @@
   flex-shrink: 0;
 }
 
+.dashboardLink {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-xs);
+  text-decoration: none;
+  padding: var(--spacing-xs) var(--spacing-s);
+  border: 1px solid var(--color-text-secondary);
+  border-radius: var(--border-radius-s);
+  transition: background 0.15s;
+}
+
+.dashboardLink:hover {
+  background: var(--color-bg-card);
+}
+
 .autoScrollBtn {
   background: var(--color-bg-card);
   color: var(--color-text-primary);

--- a/src/pages/CompetitionLivePage.tsx
+++ b/src/pages/CompetitionLivePage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 import { LiveTableTile } from '../components/features/LiveTableTile';
 import { Button } from '../components/ui/Button';
 import { Input } from '../components/ui/Input';
@@ -132,6 +132,9 @@ const LiveViewContent = ({ competitionId }: { competitionId: string }) => {
           </span>
         </div>
         <div className={styles.controls}>
+          <Link to={`/competitions/${competitionId}`} className={styles.dashboardLink}>
+            大会ダッシュボード
+          </Link>
           <button
             type="button"
             className={autoScroll ? styles.autoScrollActive : styles.autoScrollBtn}


### PR DESCRIPTION
## 概要

Issue #80 — 大会ダッシュボードとライブビュー間の相互リンクを追加。

## 変更内容

### 大会ダッシュボード → ライブビュー
- `CompetitionDashboardPage` のアクション行（共有・レポートボタンの横）に「ライブビュー」ボタンを追加
- `/competitions/:id/live` へ遷移

### ライブビュー → 大会ダッシュボード
- `CompetitionLivePage` のヘッダー controls 内に「大会ダッシュボード」リンクを追加
- `/competitions/:id` へ遷移
- 既存の自動スクロールボタンと統一感のあるスタイル

## テスト
- ビルド通過
- ESLint 通過
- 213テスト全パス

closes #80
