### PR TITLE
fix: stabilize competition join IME input

### DIFF
--- a/src/pages/CompetitionJoinPage.tsx
+++ b/src/pages/CompetitionJoinPage.tsx
@@ -24,6 +24,9 @@ export const CompetitionJoinPage = () => {
   const [playerName, setPlayerName] = useState(
     () => localStorage.getItem('mahjong_player_name') || '',
   );
+  const [isPlayerNameComposing, setIsPlayerNameComposing] = useState(false);
+
+  const normalizedPlayerName = playerName.trim();
 
   useEffect(() => {
     if (!id) return;
@@ -42,8 +45,13 @@ export const CompetitionJoinPage = () => {
       return;
     }
 
-    if (!playerName.trim()) {
+    if (!normalizedPlayerName) {
       showSnackbar('名前を入力してください', { position: 'top' });
+      return;
+    }
+
+    if (isPlayerNameComposing) {
+      showSnackbar('名前の入力を確定してから参加してください', { position: 'top' });
       return;
     }
 
@@ -65,12 +73,12 @@ export const CompetitionJoinPage = () => {
         return;
       }
 
-      localStorage.setItem('mahjong_player_name', playerName.trim());
+      localStorage.setItem('mahjong_player_name', normalizedPlayerName);
 
       await addParticipant(id, {
         id: currentUser.uid,
         userId: currentUser.uid,
-        name: playerName.trim(),
+        name: normalizedPlayerName,
         isGuest: currentUser.isAnonymous,
         status: 'idle',
         role: 'player',
@@ -145,7 +153,15 @@ export const CompetitionJoinPage = () => {
           <Input
             value={playerName}
             onChange={(e) => setPlayerName(e.target.value)}
+            onCompositionStart={() => setIsPlayerNameComposing(true)}
+            onCompositionEnd={() => setIsPlayerNameComposing(false)}
             placeholder="表示名を入力"
+            name="displayName"
+            autoComplete="nickname"
+            autoCorrect="off"
+            spellCheck={false}
+            inputMode="text"
+            enterKeyHint="done"
             fullWidth
           />
         </div>
@@ -174,7 +190,7 @@ export const CompetitionJoinPage = () => {
         <Button
           variant="primary"
           onClick={handleJoin}
-          disabled={joining || !playerName.trim()}
+          disabled={joining || isPlayerNameComposing || !normalizedPlayerName}
           fullWidth
         >
           {joining ? '参加中...' : '大会に参加する'}

--- a/src/pages/CompetitionJoinPage.tsx
+++ b/src/pages/CompetitionJoinPage.tsx
@@ -156,8 +156,9 @@ export const CompetitionJoinPage = () => {
             onCompositionStart={() => setIsPlayerNameComposing(true)}
             onCompositionEnd={() => setIsPlayerNameComposing(false)}
             placeholder="表示名を入力"
-            name="displayName"
-            autoComplete="nickname"
+            name="participantName"
+            autoComplete="section-competition nickname"
+            autoCapitalize="none"
             autoCorrect="off"
             spellCheck={false}
             inputMode="text"
@@ -182,6 +183,11 @@ export const CompetitionJoinPage = () => {
               value={passcodeInput}
               onChange={(e) => setPasscodeInput(e.target.value)}
               placeholder="パスコードを入力"
+              name="competitionPasscode"
+              autoComplete="section-competition new-password"
+              autoCapitalize="none"
+              autoCorrect="off"
+              spellCheck={false}
               fullWidth
             />
           </div>

--- a/src/pages/CompetitionJoinPage.tsx
+++ b/src/pages/CompetitionJoinPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { CompetitionStatusBadge } from '../components/features/CompetitionStatusBadge';
 import { Button } from '../components/ui/Button';
@@ -25,8 +25,18 @@ export const CompetitionJoinPage = () => {
     () => localStorage.getItem('mahjong_player_name') || '',
   );
   const [isPlayerNameComposing, setIsPlayerNameComposing] = useState(false);
+  const [isPasscodeFieldActive, setIsPasscodeFieldActive] = useState(false);
+  const passcodeInputRef = useRef<HTMLInputElement>(null);
 
   const normalizedPlayerName = playerName.trim();
+
+  const activatePasscodeField = () => {
+    if (passcodeInputRef.current?.readOnly) {
+      passcodeInputRef.current.readOnly = false;
+    }
+
+    setIsPasscodeFieldActive(true);
+  };
 
   useEffect(() => {
     if (!id) return;
@@ -156,7 +166,7 @@ export const CompetitionJoinPage = () => {
             onCompositionStart={() => setIsPlayerNameComposing(true)}
             onCompositionEnd={() => setIsPlayerNameComposing(false)}
             placeholder="表示名を入力"
-            name="participantName"
+            name="joinAliasInput"
             autoComplete="section-competition nickname"
             autoCapitalize="none"
             autoCorrect="off"
@@ -179,15 +189,21 @@ export const CompetitionJoinPage = () => {
               パスコード
             </label>
             <Input
+              ref={passcodeInputRef}
               type="password"
               value={passcodeInput}
               onChange={(e) => setPasscodeInput(e.target.value)}
+              onFocus={activatePasscodeField}
+              onTouchStart={activatePasscodeField}
+              onMouseDown={activatePasscodeField}
               placeholder="パスコードを入力"
-              name="competitionPasscode"
+              name="competitionSecretInput"
               autoComplete="section-competition new-password"
               autoCapitalize="none"
               autoCorrect="off"
               spellCheck={false}
+              inputMode="text"
+              readOnly={!isPasscodeFieldActive}
               fullWidth
             />
           </div>


### PR DESCRIPTION
## 概要
- 大会参加ページの名前入力で、IME 合成中の参加操作を抑止しました。
- 大会参加ページの名前入力に、テキスト入力ヒントを追加しました。

## 影響範囲
- 大会参加ページの参加者名入力欄

## 実行した検証
- [x] npm run lint
- [x] npm run build
- [x] npm run test

## 手動確認
- 未実施

closes #86
