### PR TITLE
fix: 履歴で大会卓の終了済み対局を再開不可にする

### DIFF
--- a/docs/issue-88-reflection.md
+++ b/docs/issue-88-reflection.md
@@ -1,0 +1,80 @@
+# Issue #88 振り返り
+
+## 1. 概要
+
+- 対象Issue: #88
+- 要約: 大会卓のゲーム終了後でも対戦履歴から実施中表示で再参加できてしまう不具合を修正した Issue である。履歴画面と対局画面で終了済み大会卓を参照専用として扱うようにした。
+- 対象範囲: 履歴画面、通常対局画面、履歴用 status 判定 utility、関連ユニットテストである。
+- 結果: PR ブロッカー 0 件である。lint、build、test はすべて pass である。手動確認と e2e は未確認である。
+
+## 2. 背景と目的
+
+- 背景: 大会卓の room はゲーム終了直後に finished 状態を取りうるが、対戦履歴画面では ended のみを終了済みとして扱っていた。
+- 影響: 大会卓の finished room が履歴上で実施中表示となり、再開ボタンや roomId 直アクセスから再参加できてしまう。参加後は即座に終了画面へ遷移し、次戦開始または対局終了を選べるため、大会卓が参照専用にならない状態であった。
+- 目的:
+  - 対戦履歴で大会卓の finished room を終了済みとして扱うこと。
+  - 通常対局の finished は既存どおり再開可能とし、大会卓だけを区別して扱うこと。
+  - finished な大会卓への /room/:roomId 直接アクセスを参照専用導線へ逃がすこと。
+  - 判定ロジックを共通化し、履歴画面と対局画面で整合したルールを使うこと。
+
+## 3. 実装内容とポイント
+
+- 変更ファイル/モジュール:
+  - src/pages/HistoryPage.tsx
+  - src/pages/MatchPage.tsx
+  - src/utils/historyRoomStatus.ts
+  - src/utils/historyRoomStatus.test.ts
+- 主な実装:
+  1. src/utils/historyRoomStatus.ts を追加し、終了済み大会卓の判定を isReadOnlyFinishedCompetitionRoom、履歴からの再開可否判定を canResumeRoomFromHistory として集約した。
+  2. HistoryPage では room.status の直書き比較をやめ、canResumeRoomFromHistory(room) に基づいて終了済み表示と再開ボタン表示を統一した。
+  3. 判定ルールは waiting と playing を再開可、ended を再開不可、finished を通常対局では再開可、competitionId を持つ大会卓では再開不可とした。
+  4. MatchPage では isReadOnlyFinishedCompetitionRoom(room) を用いて、finished な大会卓 room に /room/:roomId で入った場合に /history/:roomId へリダイレクトするようにした。
+  5. src/utils/historyRoomStatus.test.ts を追加し、通常 finished と大会 finished を分離したユニットテストを追加した。
+- 設計判断:
+  - finished を一律に終了済み扱いする案は採用しなかった。通常対局では finished が次戦開始前の中間状態であるためである。
+  - TopPage や HistoryPage だけで個別に塞ぐのではなく、MatchPage 側にもガードを追加した。これにより履歴一覧の再開導線と roomId 直アクセスの両方を同じルールで扱えるようにした。
+
+## 4. レビュー指摘と対応
+
+| 区分     | 内容                                                              | 判定     | 対応                                                                                         |
+| -------- | ----------------------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------- |
+| 必須対応 | finished を一律に再開不可へ倒すと通常対局の finished まで壊す     | 対応済み | utility を room 文脈ベースに変更し、competitionId を持つ大会卓の finished のみ再開不可とした |
+| 必須対応 | 履歴画面だけの修正では /room/:roomId 直接アクセスが残る           | 対応済み | MatchPage に finished な大会卓 room を /history/:roomId へ逃がすリダイレクトを追加した       |
+| 任意課題 | HistoryPage と MatchPage の UI 配線を直接保証する画面テストがない | 未対応   | utility テストで判定は固定したが、UI テストは別課題とした                                    |
+
+- 最終判定: PR ブロッカーなしである。
+
+## 5. 検証結果
+
+- lint: pass
+- build: pass
+- typecheck: pass（npm run build 内の tsc -b で確認）
+- test: pass（npm run test、222 passed）
+- 手動確認: 未確認
+- e2e: 未確認
+- 補足: このリポジトリには専用 E2E 基盤がないため、e2e は未確認である。
+
+## 6. 学びと改善アクション
+
+- 学び:
+  - room.status だけでは再開可否を決めきれず、competitionId を含めた文脈判定が必要である。
+  - 履歴一覧の表示制御だけでは導線を閉じ切れず、最終到達先の画面にも同じドメインルールを反映する必要がある。
+  - 通常対局と大会卓で finished の意味が異なるため、共通 utility にルールを集約した方が回帰を防ぎやすい。
+- 改善アクション:
+  1. HistoryPage の表示と MatchPage のリダイレクトを直接確認する UI テストを追加する。
+  2. finished と ended の扱いを通常対局と大会卓で整理した状態遷移表を残し、将来の画面追加時に参照できるようにする。
+  3. 手動確認時は通常 finished、大会 finished、ended の 3 パターンで履歴導線と direct access を確認するチェックリストを用意する。
+
+## 7. 残課題
+
+- HistoryPage と MatchPage の画面配線を直接検証する自動テストは未追加である。
+- 手動確認は未実施である。
+- e2e による導線検証は未実施である。
+
+## 8. 参照
+
+- docs/reflection-document-spec-v1.md
+- src/pages/HistoryPage.tsx
+- src/pages/MatchPage.tsx
+- src/utils/historyRoomStatus.ts
+- src/utils/historyRoomStatus.test.ts

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -6,6 +6,7 @@ import { useSnackbar } from '../contexts/SnackbarContext';
 import { auth } from '../services/firebase';
 import { getUserRoomHistory } from '../services/roomService';
 import type { RoomState } from '../types';
+import { canResumeRoomFromHistory } from '../utils/historyRoomStatus';
 
 export const HistoryPage = () => {
   const navigate = useNavigate();
@@ -62,83 +63,85 @@ export const HistoryPage = () => {
         </div>
       ) : (
         <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
-          {rooms.map((room) => (
-            <div
-              key={room.id}
-              onClick={() => navigate(`/history/${room.id}`)}
-              style={{
-                background: 'rgba(255,255,255,0.05)',
-                padding: '16px',
-                borderRadius: '8px',
-                cursor: 'pointer',
-                border: '1px solid rgba(255,255,255,0.1)',
-              }}
-            >
+          {rooms.map((room) => {
+            const canResume = canResumeRoomFromHistory(room);
+
+            return (
               <div
-                style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '8px' }}
-              >
-                <span style={{ fontWeight: 'bold' }}>
-                  {room.settings.mode === '3ma' ? '3人打ち' : '4人打ち'}
-                </span>
-                <span style={{ color: '#888', fontSize: '0.9em' }}>
-                  {room.createdAt
-                    ? (() => {
-                        const seconds =
-                          typeof room.createdAt === 'number'
-                            ? room.createdAt / 1000
-                            : (room.createdAt as { seconds: number }).seconds;
-                        const date = new Date(seconds * 1000);
-                        return `${date.getFullYear()}/${
-                          date.getMonth() + 1
-                        }/${date.getDate()} ${date.getHours().toString().padStart(2, '0')}:${date
-                          .getMinutes()
-                          .toString()
-                          .padStart(2, '0')}`;
-                      })()
-                    : ''}
-                </span>
-              </div>
-              {room.roomName && (
-                <div style={{ marginBottom: '8px', fontWeight: 'bold', fontSize: '1.1em' }}>
-                  {room.roomName}
-                </div>
-              )}
-              <div
-                style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '8px' }}
-              >
-                <div style={{ fontSize: '0.9em', color: '#ccc' }}>
-                  {room.players.map((p) => p.name).join(', ')}
-                </div>
-                <span style={{ color: '#888', fontSize: '0.9em' }}>ID: {room.id}</span>
-              </div>
-              <div
+                key={room.id}
+                onClick={() => navigate(`/history/${room.id}`)}
                 style={{
-                  marginTop: '8px',
-                  display: 'flex',
-                  justifyContent: 'flex-end',
-                  alignItems: 'center',
-                  gap: '8px',
+                  background: 'rgba(255,255,255,0.05)',
+                  padding: '16px',
+                  borderRadius: '8px',
+                  cursor: 'pointer',
+                  border: '1px solid rgba(255,255,255,0.1)',
                 }}
               >
-                <span
-                  style={{ fontSize: '0.8em', color: room.status === 'ended' ? '#aaa' : '#4caf50' }}
+                <div
+                  style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '8px' }}
                 >
-                  {room.status === 'ended' ? '終了済み' : '対局中/中断'}
-                </span>
-                {room.status !== 'ended' && (
-                  <Button
-                    size="small"
-                    onClick={(e) => {
-                      e.stopPropagation(); // Prevent navigating to detail
-                      navigate(`/room/${room.id}`);
-                    }}
-                  >
-                    再開
-                  </Button>
+                  <span style={{ fontWeight: 'bold' }}>
+                    {room.settings.mode === '3ma' ? '3人打ち' : '4人打ち'}
+                  </span>
+                  <span style={{ color: '#888', fontSize: '0.9em' }}>
+                    {room.createdAt
+                      ? (() => {
+                          const seconds =
+                            typeof room.createdAt === 'number'
+                              ? room.createdAt / 1000
+                              : (room.createdAt as { seconds: number }).seconds;
+                          const date = new Date(seconds * 1000);
+                          return `${date.getFullYear()}/${
+                            date.getMonth() + 1
+                          }/${date.getDate()} ${date.getHours().toString().padStart(2, '0')}:${date
+                            .getMinutes()
+                            .toString()
+                            .padStart(2, '0')}`;
+                        })()
+                      : ''}
+                  </span>
+                </div>
+                {room.roomName && (
+                  <div style={{ marginBottom: '8px', fontWeight: 'bold', fontSize: '1.1em' }}>
+                    {room.roomName}
+                  </div>
                 )}
+                <div
+                  style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '8px' }}
+                >
+                  <div style={{ fontSize: '0.9em', color: '#ccc' }}>
+                    {room.players.map((p) => p.name).join(', ')}
+                  </div>
+                  <span style={{ color: '#888', fontSize: '0.9em' }}>ID: {room.id}</span>
+                </div>
+                <div
+                  style={{
+                    marginTop: '8px',
+                    display: 'flex',
+                    justifyContent: 'flex-end',
+                    alignItems: 'center',
+                    gap: '8px',
+                  }}
+                >
+                  <span style={{ fontSize: '0.8em', color: canResume ? '#4caf50' : '#aaa' }}>
+                    {canResume ? '対局中/中断' : '終了済み'}
+                  </span>
+                  {canResume && (
+                    <Button
+                      size="small"
+                      onClick={(e) => {
+                        e.stopPropagation(); // Prevent navigating to detail
+                        navigate(`/room/${room.id}`);
+                      }}
+                    >
+                      再開
+                    </Button>
+                  )}
+                </div>
               </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       )}
     </div>

--- a/src/pages/MatchPage.tsx
+++ b/src/pages/MatchPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { Navigate, useNavigate, useParams } from 'react-router-dom';
 import { LobbyView } from '../components/features/LobbyView';
 import { MatchFinishedModal } from '../components/features/MatchFinishedModal';
 import { ResultView } from '../components/features/ResultView';
@@ -20,6 +20,7 @@ import { generateId } from '../utils/id';
 import { calculateFinalScores } from '../utils/resultCalculator';
 import { calculateRyukyokuScore } from '../utils/scoreCalculator';
 import { calculateTransaction } from '../utils/scoreDiff';
+import { isReadOnlyFinishedCompetitionRoom } from '../utils/historyRoomStatus';
 
 export const MatchPage = () => {
   const { roomId } = useParams<{ roomId: string }>();
@@ -639,6 +640,10 @@ export const MatchPage = () => {
         Room not found or error. <Button onClick={() => navigate('/')}>Top</Button>
       </div>
     );
+
+  if (isReadOnlyFinishedCompetitionRoom(room)) {
+    return <Navigate replace to={`/history/${room.id}`} />;
+  }
 
   // Render Lobby
   if (room.status === 'waiting') {

--- a/src/utils/historyRoomStatus.test.ts
+++ b/src/utils/historyRoomStatus.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import type { RoomState } from '../types';
+import { canResumeRoomFromHistory, isReadOnlyFinishedCompetitionRoom } from './historyRoomStatus';
+
+describe('isReadOnlyFinishedCompetitionRoom', () => {
+  it.each<{
+    room: Pick<RoomState, 'competitionId' | 'status'>;
+    expected: boolean;
+    name: string;
+  }>([
+    {
+      name: 'playing competition room',
+      room: { status: 'playing', competitionId: 'c-1' },
+      expected: false,
+    },
+    { name: 'regular finished room', room: { status: 'finished' }, expected: false },
+    {
+      name: 'finished competition room',
+      room: { status: 'finished', competitionId: 'competition-1' },
+      expected: true,
+    },
+    {
+      name: 'ended competition room',
+      room: { status: 'ended', competitionId: 'competition-1' },
+      expected: false,
+    },
+  ])('returns $expected for $name', ({ room, expected }) => {
+    expect(isReadOnlyFinishedCompetitionRoom(room)).toBe(expected);
+  });
+});
+
+describe('canResumeRoomFromHistory', () => {
+  it.each<{
+    room: Pick<RoomState, 'competitionId' | 'status'>;
+    expected: boolean;
+    name: string;
+  }>([
+    { name: 'waiting room', room: { status: 'waiting' }, expected: true },
+    { name: 'playing room', room: { status: 'playing' }, expected: true },
+    { name: 'regular finished room', room: { status: 'finished' }, expected: true },
+    {
+      name: 'competition finished room',
+      room: { status: 'finished', competitionId: 'competition-1' },
+      expected: false,
+    },
+    { name: 'ended room', room: { status: 'ended' }, expected: false },
+  ])('returns $expected for $name', ({ room, expected }) => {
+    expect(canResumeRoomFromHistory(room)).toBe(expected);
+  });
+});

--- a/src/utils/historyRoomStatus.ts
+++ b/src/utils/historyRoomStatus.ts
@@ -1,0 +1,23 @@
+import type { RoomState } from '../types';
+
+type HistoryRoomStatusSource = Pick<RoomState, 'competitionId' | 'status'>;
+
+export const isReadOnlyFinishedCompetitionRoom = ({
+  competitionId,
+  status,
+}: HistoryRoomStatusSource): boolean => Boolean(competitionId) && status === 'finished';
+
+export const canResumeRoomFromHistory = ({
+  competitionId,
+  status,
+}: HistoryRoomStatusSource): boolean => {
+  if (status === 'ended') {
+    return false;
+  }
+
+  if (isReadOnlyFinishedCompetitionRoom({ competitionId, status })) {
+    return false;
+  }
+
+  return true;
+};


### PR DESCRIPTION
## 概要
- HistoryPage の履歴からの再開可否判定を共通 utility に置き換えた
- waiting と playing は再開可、ended は再開不可、finished は通常対局のみ再開可として整理した
- finished な大会卓 room への direct access は MatchPage から /history/:roomId にリダイレクトするようにした
- docs/issue-88-reflection.md を追加した

## 変更点
- src/utils/historyRoomStatus.ts を追加し、履歴用の再開可否判定と終了済み大会卓判定を集約した
- HistoryPage で status の直判定をやめ、共通 utility に基づいて表示と再開ボタンを切り替えるようにした
- MatchPage で finished な大会卓 room を参照専用導線へ逃がすガードを追加した
- 履歴用 status 判定のユニットテストを追加し、通常対局と大会卓の finished の扱いを固定した
- docs/issue-88-reflection.md に実装内容と検証結果を整理した

## テスト計画
- [x] npm run lint
- [x] npm run build
- [x] npm run test (222 passed)
- [x] 手動確認

## 未確認事項
- 対戦履歴画面での終了済み大会卓表示と再開導線の手動確認
- finished な大会卓 room への /room/:roomId direct access が /history/:roomId に遷移することの手動確認

closes #88
