### PR TITLE
fix: align competition table numeric columns

### DIFF
--- a/src/pages/CompetitionLivePage.module.css
+++ b/src/pages/CompetitionLivePage.module.css
@@ -152,8 +152,14 @@
   white-space: nowrap;
 }
 
+.numericHeader {
+  text-align: right !important;
+}
+
 .numericCell {
+  text-align: right !important;
   font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
 

--- a/src/pages/CompetitionLivePage.tsx
+++ b/src/pages/CompetitionLivePage.tsx
@@ -182,10 +182,10 @@ const LiveViewContent = ({ competitionId }: { competitionId: string }) => {
                   <tr>
                     <th>順位</th>
                     <th>参加者名</th>
-                    <th>対局数</th>
-                    <th>合計ポイント</th>
-                    <th>平均順位</th>
-                    {useChip && <th>チップ収支</th>}
+                    <th className={styles.numericHeader}>対局数</th>
+                    <th className={styles.numericHeader}>合計ポイント</th>
+                    <th className={styles.numericHeader}>平均順位</th>
+                    {useChip && <th className={styles.numericHeader}>チップ収支</th>}
                   </tr>
                 </thead>
                 <tbody>

--- a/src/pages/CompetitionLivePage.tsx
+++ b/src/pages/CompetitionLivePage.tsx
@@ -9,7 +9,7 @@ import { useLiveRooms } from '../hooks/useLiveRooms';
 import { subscribeToCompetition, verifyPasscode } from '../services/competitionService';
 import type { Competition } from '../types';
 import { aggregateOverallStandings } from '../utils/competitionReport';
-import { formatPoint } from '../utils/formatUtils';
+import { formatAverageRank, formatPoint } from '../utils/formatUtils';
 import styles from './CompetitionLivePage.module.css';
 
 const AUTO_SCROLL_SPEED = 1;
@@ -197,7 +197,7 @@ const LiveViewContent = ({ competitionId }: { competitionId: string }) => {
                       <td className={`${styles.numericCell} ${pointClass(s.totalPoint)}`}>
                         {formatPoint(s.totalPoint)}
                       </td>
-                      <td className={styles.numericCell}>{s.averageRank}</td>
+                      <td className={styles.numericCell}>{formatAverageRank(s.averageRank)}</td>
                       {useChip && (
                         <td className={`${styles.numericCell} ${pointClass(s.totalChip)}`}>
                           {s.totalChip > 0 ? '+' : ''}

--- a/src/pages/CompetitionReportPage.module.css
+++ b/src/pages/CompetitionReportPage.module.css
@@ -99,8 +99,14 @@
   white-space: nowrap;
 }
 
+.numericHeader {
+  text-align: right !important;
+}
+
 .numericCell {
+  text-align: right !important;
   font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
 

--- a/src/pages/CompetitionReportPage.tsx
+++ b/src/pages/CompetitionReportPage.tsx
@@ -13,7 +13,7 @@ import {
   generatePdfReport,
   generateReportFilename,
 } from '../utils/exportReport';
-import { formatPoint } from '../utils/formatUtils';
+import { formatAverageRank, formatPoint } from '../utils/formatUtils';
 import styles from './CompetitionReportPage.module.css';
 
 const pointClass = (pt: number): string => {
@@ -119,7 +119,7 @@ export const CompetitionReportPage = () => {
                     <td className={`${styles.numericCell} ${pointClass(s.totalPoint)}`}>
                       {formatPoint(s.totalPoint)}
                     </td>
-                    <td className={styles.numericCell}>{s.averageRank}</td>
+                    <td className={styles.numericCell}>{formatAverageRank(s.averageRank)}</td>
                     {useChip && (
                       <td className={`${styles.numericCell} ${pointClass(s.totalChip)}`}>
                         {s.totalChip > 0 ? '+' : ''}

--- a/src/pages/CompetitionReportPage.tsx
+++ b/src/pages/CompetitionReportPage.tsx
@@ -102,10 +102,10 @@ export const CompetitionReportPage = () => {
                 <tr>
                   <th>順位</th>
                   <th>参加者名</th>
-                  <th>対局数</th>
-                  <th>合計ポイント</th>
-                  <th>平均順位</th>
-                  {useChip && <th>チップ収支</th>}
+                  <th className={styles.numericHeader}>対局数</th>
+                  <th className={styles.numericHeader}>合計ポイント</th>
+                  <th className={styles.numericHeader}>平均順位</th>
+                  {useChip && <th className={styles.numericHeader}>チップ収支</th>}
                 </tr>
               </thead>
               <tbody>
@@ -145,12 +145,12 @@ export const CompetitionReportPage = () => {
               <thead>
                 <tr>
                   <th>卓名</th>
-                  <th>対局番号</th>
+                  <th className={styles.numericHeader}>対局番号</th>
                   <th>参加者名</th>
                   <th>順位</th>
-                  <th>素点</th>
-                  <th>ポイント</th>
-                  {useChip && <th>チップ収支</th>}
+                  <th className={styles.numericHeader}>素点</th>
+                  <th className={styles.numericHeader}>ポイント</th>
+                  {useChip && <th className={styles.numericHeader}>チップ収支</th>}
                 </tr>
               </thead>
               <tbody>
@@ -195,7 +195,7 @@ export const CompetitionReportPage = () => {
                 <tr>
                   <th>卓名</th>
                   <th>モード</th>
-                  <th>対局回数</th>
+                  <th className={styles.numericHeader}>対局回数</th>
                   <th>参加者</th>
                 </tr>
               </thead>

--- a/src/utils/exportReport.test.ts
+++ b/src/utils/exportReport.test.ts
@@ -90,4 +90,14 @@ describe('generateCsvBlob', () => {
     expect(detailLines[0]).toContain(',1,');
     expect(detailLines[1]).toContain(',2,');
   });
+
+  it('formats average rank with one decimal place in CSV', async () => {
+    const standings = [makeStanding({ averageRank: 2 })];
+    const details = [makeDetail()];
+
+    const blob = generateCsvBlob(standings, details, false);
+    const text = await blob.text();
+
+    expect(text).toContain(',2.0');
+  });
 });

--- a/src/utils/exportReport.ts
+++ b/src/utils/exportReport.ts
@@ -1,4 +1,5 @@
 import type { MatchDetail, OverallStanding } from './competitionReport';
+import { formatAverageRank } from './formatUtils';
 
 const BOM = '\uFEFF';
 
@@ -32,7 +33,13 @@ export const generateCsvBlob = (
   lines.push(toCsvRow(standingHeader));
 
   for (const s of standings) {
-    const row: (string | number)[] = [s.rank, s.name, s.gameCount, s.totalPoint, s.averageRank];
+    const row: (string | number)[] = [
+      s.rank,
+      s.name,
+      s.gameCount,
+      s.totalPoint,
+      formatAverageRank(s.averageRank),
+    ];
     if (useChip) row.push(s.totalChip);
     lines.push(toCsvRow(row));
   }

--- a/src/utils/formatUtils.test.ts
+++ b/src/utils/formatUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { formatPoint } from './formatUtils';
+import { formatAverageRank, formatPoint } from './formatUtils';
 
 describe('formatPoint', () => {
   it('formats positive values with + prefix', () => {
@@ -23,5 +23,19 @@ describe('formatPoint', () => {
     const result = formatPoint(1234.5);
     // Locale-dependent grouping; just verify prefix and decimal
     expect(result).toMatch(/^\+.*1.*234\.5$/);
+  });
+});
+
+describe('formatAverageRank', () => {
+  it('formats integer ranks with a trailing decimal', () => {
+    expect(formatAverageRank(1)).toBe('1.0');
+  });
+
+  it('keeps one decimal place for fractional ranks', () => {
+    expect(formatAverageRank(2.4)).toBe('2.4');
+  });
+
+  it('rounds to one decimal place when needed', () => {
+    expect(formatAverageRank(1.25)).toBe('1.3');
   });
 });

--- a/src/utils/formatUtils.ts
+++ b/src/utils/formatUtils.ts
@@ -6,3 +6,8 @@ export const formatPoint = (pt: number): string => {
   const prefix = pt > 0 ? '+' : '';
   return `${prefix}${pt.toLocaleString(undefined, { minimumFractionDigits: 1, maximumFractionDigits: 1 })}`;
 };
+
+/**
+ * Format an average rank value with exactly 1 decimal place.
+ */
+export const formatAverageRank = (rank: number): string => rank.toFixed(1);


### PR DESCRIPTION
## 概要
- CompetitionLivePage の総合成績表で、数値列ヘッダーを右揃え対象に変更しました
- CompetitionReportPage の総合成績表、対局別詳細、卓別サマリで、数値列ヘッダーを右揃え対象に変更しました
- CompetitionLivePage.module.css と CompetitionReportPage.module.css の numericCell を右揃えに統一し、tabular-nums を適用しました

## 小さく直したこと
- 対局数、合計ポイント、平均順位、チップ収支などの数値列ヘッダーに numericHeader を適用しました
- 数値セルの右揃えを明示し、等幅数字で桁を比較しやすくしました

## 影響画面 / 対象コンポーネント
- CompetitionLivePage の総合成績表
- CompetitionReportPage の総合成績表
- CompetitionReportPage の対局別詳細
- CompetitionReportPage の卓別サマリ

## 検証
- [x] npm run lint
- [x] npm run build
- [x] npm run test -- --run
- [x] 26 files, 255 tests passed

## 未確認事項
- 対象の大会データを使った画面上での手動確認は未実施です
- 実データ表示時の見た目確認は GitHub 上のプレビューではなくローカル画面での確認が必要です

closes #101
