### PR TITLE
feat: 対局の途中終了機能を追加

### DIFF
--- a/docs/issue-105-reflection.md
+++ b/docs/issue-105-reflection.md
@@ -1,0 +1,89 @@
+# Issue #105 振り返り
+
+## 1. 概要
+
+- 対象Issue: #105
+- 要約: 対局の途中終了機能を追加し、半荘/東風の途中でも精算を可能にした。途中終了時に成績（大会成績）への反映可否を選択可能とし、供託は1位総取りとした。
+- 結果: PRブロッカー 0（2件対応済み） / 主要検証 pass（lint, build, test 264件全パス、受け入れテスト 17項目 Pass）
+
+## 2. 背景と目的
+
+- 背景: 従来は半荘/東風が最終局まで完了しないと精算できなかった。実際の利用場面では時間切れや参加者の都合で途中終了が必要になるケースがある。
+- 影響: 途中終了が発生した場合に精算が行えず、手動計算やスコアの未記録が生じていた（推定）。
+- 目的:
+  - 対局を任意のタイミングで途中終了し、その時点のスコアで精算できるようにする
+  - 途中終了時に大会成績へ反映するかどうかを選択可能にする
+  - 供託（リーチ棒）の処理を1位総取りルールで統一する
+
+## 3. 実装内容とポイント
+
+- 変更ファイル/モジュール:
+  - `src/types/index.ts`
+  - `src/utils/gameLogic.ts`
+  - `src/utils/resultCalculator.ts`
+  - `src/utils/__tests__/resultCalculator.test.ts`
+  - `src/hooks/useMatchGame.ts`
+  - `src/pages/MatchPage.tsx`
+  - `src/pages/CompetitionTablePage.tsx`
+- 主な実装:
+  1. **型定義の拡張**: `GameEndReason` 型に `'Aborted'` を追加し、`GameResult` に `gameEndReason` フィールドを追加した。途中終了を型レベルで区別できるようにした。
+  2. **供託1位総取りロジック**: `resultCalculator.ts` に `distributeRemainingRiichiSticks` 関数を新設し、供託の分配ロジックをユーティリティとして分離した。`calculateFinalScores` にオプション引数 `CalculateFinalScoresOptions` を追加し、途中終了時の振る舞いを制御可能にした。
+  3. **フック層**: `useMatchGame.ts` に `handleAbortGame({ saveResult: boolean })` を追加した。`saveResult` フラグにより成績反映の有無を制御する。
+  4. **UI**: `MatchPage.tsx` および `CompetitionTablePage.tsx` に「途中終了」ボタンと確認モーダルを追加した。`CompetitionTablePage` では管理者向けに `Modal` コンポーネントを新たにインポートして使用している。
+  5. **テスト**: `resultCalculator.test.ts` に5件のテストケースを追加し、供託分配ロジックの正確性を検証した。
+- 設計判断:
+  - 供託分配ロジックを `distributeRemainingRiichiSticks` として独立関数に分離した。テスタビリティと再利用性を優先した判断である。
+  - `MatchPage` は `useMatchGame` フックを使わず独自にロジックを実装している既存構造であるため、今回は `MatchPage` 内に途中終了ロジックを追加しつつフックとのロジック一致を確保する方針とした。`MatchPage` 全体の `useMatchGame` 移行は大規模リファクタリングとなるためスコープ外とした。
+  - `isRiichi` フラグのリセットは通常終了フローでは自動で行われるが、途中終了では明示的なリセットが必要であることを確認し、対応を追加した。
+
+## 4. レビュー指摘と対応
+
+| 区分     | ID  | 内容                                                           | 判定     | 対応                                                                                                  |
+| -------- | --- | -------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------- |
+| 必須対応 | C-1 | MatchPage と useMatchGame の handleAbortGame ロジック重複      | 対応済み | ロジック一致を確保した。MatchPage全体のuseMatchGame移行は大規模リファクタリングのためスコープ外とした |
+| 必須対応 | H-1 | isRiichi フラグが途中終了時にリセットされない                  | 対応済み | `isRiichi: false` リセットを途中終了フローに追加した                                                  |
+| 任意課題 | H-2 | 通常終了時の gameEndReason 伝播が未実装                        | 未対応   | 既存コードの問題であり本Issueのスコープ外                                                             |
+| 任意課題 | H-3 | handleAbortGame のエラーハンドリングが不十分                   | 未対応   | 既存パターンと一貫した実装としており、変更による影響を限定した                                        |
+| 任意課題 | M-1 | インラインスタイルを CSS Module に移行すべき                   | 未対応   | 動作影響なし。将来的に対応予定                                                                        |
+| 任意課題 | M-2 | 空の条件分岐が存在する                                         | 未対応   | 意図コメントを追記済み                                                                                |
+| 任意課題 | M-4 | MatchPage の権限チェックが未実装                               | 未対応   | 通常対局の権限モデルがスコープ外                                                                      |
+| 任意課題 | L-1 | Abort Modal の JSX が MatchPage と CompetitionTablePage で重複 | 未対応   | 将来リファクタリングとして対応予定                                                                    |
+| 任意課題 | L-3 | gameEndReason の UI 表示が未実装                               | 未対応   | 今回のスコープ外                                                                                      |
+
+- 最終判定: PRブロッカー なし（2件の必須対応はすべて対応済み）
+
+## 5. 検証結果
+
+- lint: pass
+- build: pass
+- test (unit): pass（264テスト全パス、新規5件含む）
+- acceptance test: pass（全17項目。コードベース静的検査による確認）
+- e2e（ブラウザ操作）: 未実施（ブラウザ操作ツールが未有効のため）
+- 補足: E2E 実操作テストは未実施である。途中終了フロー（モーダル表示 → 成績反映選択 → 精算完了）の手動またはE2Eでの検証を別途推奨する。
+
+## 6. 学びと改善アクション
+
+- 学び:
+  - MatchPage は useMatchGame フックを使わず独自にロジックを実装しているため、新機能追加時はフックとのロジック一致に注意が必要である。ロジックの二重管理はバグの温床となる。
+  - 途中終了フローでは通常終了フローと異なり `isRiichi` のリセットが自動で行われないため、明示的なリセットが必要である。異常系・中断系フローではステート管理の漏れに注意が必要である。
+  - 供託（riichiSticks）の1位総取りロジックをユーティリティ関数として分離したことで、テストが書きやすくなり、ロジックの正確性を独立して検証できるようになった。
+- 改善アクション:
+  1. MatchPage の useMatchGame 移行リファクタリングを別 Issue として起票し、ロジック重複を解消する
+  2. 途中終了フローのE2Eテスト（モーダル操作 → 精算完了 → 成績反映有無の確認）を追加する
+  3. Abort Modal の共通コンポーネント化を検討し、JSX 重複を解消する
+
+## 7. 残課題
+
+- MatchPage の useMatchGame 移行（C-1 根本対応）
+- 通常終了時の `gameEndReason` 伝播（H-2）
+- インラインスタイルの CSS Module 移行（M-1）
+- `gameEndReason` の UI 表示対応（L-3）
+- Abort Modal の共通コンポーネント化（L-1）
+- 途中終了フローの E2E テスト追加
+
+## 8. 参照
+
+- Issue: #105
+- 関連ドキュメント: `docs/specification.md`, `docs/game_rules.md`
+- 型定義: `src/types/index.ts`
+- テスト: `src/utils/__tests__/resultCalculator.test.ts`

--- a/src/hooks/useMatchGame.ts
+++ b/src/hooks/useMatchGame.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import type { GameResult, HandLog, Player, RoomState, ScorePayment } from '../types';
 import { processHandEnd } from '../utils/gameLogic';
 import { generateId } from '../utils/id';
-import { calculateFinalScores } from '../utils/resultCalculator';
+import { calculateFinalScores, distributeRemainingRiichiSticks } from '../utils/resultCalculator';
 import { calculateRyukyokuScore } from '../utils/scoreCalculator';
 import { calculateTransaction } from '../utils/scoreDiff';
 import {
@@ -30,6 +30,7 @@ export interface UseMatchGameReturn {
   handleRiichi: (playerId: string) => Promise<void>;
   handleStartGame: () => Promise<void>;
   handleReorder: (newPlayers: Player[]) => Promise<void>;
+  handleAbortGame: (options: { saveResult: boolean }) => Promise<GameResult | null>;
   isTransitioning: boolean;
   showFinishedModal: boolean;
   extensionOverlay: string | null;
@@ -412,6 +413,42 @@ export const useMatchGame = ({ room, updateState }: UseMatchGameOptions): UseMat
     [updateState],
   );
 
+  const handleAbortGame = useCallback(
+    async (options: { saveResult: boolean }): Promise<GameResult | null> => {
+      if (!room) return null;
+
+      const riichiSticks = room.round.riichiSticks || 0;
+      // Distribute remaining riichi sticks to 1st place and reset isRiichi
+      const playersWithSticks = distributeRemainingRiichiSticks(room.players, riichiSticks).map(
+        (p) => ({ ...p, isRiichi: false }),
+      );
+
+      let nextGameResults = room.gameResults || [];
+      let result: GameResult | null = null;
+
+      if (options.saveResult) {
+        result = calculateFinalScores(playersWithSticks, room.settings, generateId(12), {
+          gameEndReason: 'Aborted',
+        });
+        result.logs = room.currentLogs || [];
+        nextGameResults = [...nextGameResults, result];
+      }
+
+      triggerGameEndTransition();
+
+      await updateState({
+        players: playersWithSticks,
+        round: { ...room.round, riichiSticks: 0 },
+        status: 'finished',
+        gameResults: nextGameResults,
+        currentLogs: [],
+      });
+
+      return result;
+    },
+    [room, updateState, triggerGameEndTransition],
+  );
+
   const dismissFinishedModal = useCallback(() => {
     setShowFinishedModal(false);
     setIsTransitioning(false);
@@ -424,6 +461,7 @@ export const useMatchGame = ({ room, updateState }: UseMatchGameOptions): UseMat
     handleRiichi,
     handleStartGame,
     handleReorder,
+    handleAbortGame,
     isTransitioning,
     showFinishedModal,
     extensionOverlay,

--- a/src/pages/CompetitionTablePage.tsx
+++ b/src/pages/CompetitionTablePage.tsx
@@ -24,6 +24,7 @@ import { ScoringModal } from '../components/features/ScoringModal';
 import { SoundEffectToggle } from '../components/features/SoundEffectToggle';
 import { Button } from '../components/ui/Button';
 import { ConfirmationDialog } from '../components/ui/ConfirmationDialog';
+import { Modal } from '../components/ui/Modal';
 import { useSnackbar } from '../contexts/SnackbarContext';
 import { useCompetitionMatch } from '../hooks/useCompetitionMatch';
 import { useMatchGame } from '../hooks/useMatchGame';
@@ -124,6 +125,9 @@ export const CompetitionTablePage = () => {
   // Dissolve confirmation
   const [isDissolveConfirmOpen, setIsDissolveConfirmOpen] = useState(false);
 
+  // Abort game
+  const [isAbortConfirmOpen, setIsAbortConfirmOpen] = useState(false);
+
   // Seat arrangement for next match
   const [seatArrangementMode, setSeatArrangementMode] = useState(false);
   const [arrangedPlayerIds, setArrangedPlayerIds] = useState<string[]>([]);
@@ -147,6 +151,17 @@ export const CompetitionTablePage = () => {
       });
     }
   }, [room?.status, matchGame.gameResult, saveResult, showSnackbar]);
+
+  const handleAbortGame = useCallback(
+    async (saveToResult: boolean) => {
+      setIsAbortConfirmOpen(false);
+      const result = await matchGame.handleAbortGame({ saveResult: saveToResult });
+      if (saveToResult && result) {
+        // Auto-save will pick up the result via useEffect above
+      }
+    },
+    [matchGame],
+  );
 
   const handlePlayerClick = useCallback(
     (id: string) => {
@@ -310,6 +325,14 @@ export const CompetitionTablePage = () => {
           </div>
         )}
 
+        {canManage && room.status === 'playing' && (
+          <div className={styles.undoRow}>
+            <Button variant="danger" onClick={() => setIsAbortConfirmOpen(true)}>
+              途中終了
+            </Button>
+          </div>
+        )}
+
         <ScoringModal
           isOpen={isModalOpen}
           onClose={() => setIsModalOpen(false)}
@@ -333,6 +356,38 @@ export const CompetitionTablePage = () => {
           isOpen={matchGame.showFinishedModal}
           onConfirm={matchGame.dismissFinishedModal}
         />
+
+        {/* Abort Game Modal */}
+        <Modal
+          isOpen={isAbortConfirmOpen}
+          onClose={() => setIsAbortConfirmOpen(false)}
+          title="途中終了の確認"
+        >
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+            <p style={{ margin: 0, lineHeight: 1.5 }}>対局を途中終了しますか？</p>
+            <p
+              style={{
+                margin: 0,
+                lineHeight: 1.5,
+                fontSize: '14px',
+                color: 'var(--color-text-secondary, #666)',
+              }}
+            >
+              供託は1位総取りとなります。
+            </p>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+              <Button variant="primary" onClick={() => handleAbortGame(true)}>
+                大会成績に反映して終了
+              </Button>
+              <Button variant="danger" onClick={() => handleAbortGame(false)}>
+                大会成績に反映せず終了
+              </Button>
+              <Button variant="secondary" onClick={() => setIsAbortConfirmOpen(false)}>
+                キャンセル
+              </Button>
+            </div>
+          </div>
+        </Modal>
 
         {matchGame.extensionOverlay && (
           <div className={styles.extensionOverlay}>

--- a/src/pages/MatchPage.tsx
+++ b/src/pages/MatchPage.tsx
@@ -19,7 +19,7 @@ import { auth } from '../services/firebase';
 import type { HandLog, Player, RoomState, ScorePayment } from '../types';
 import { processHandEnd } from '../utils/gameLogic';
 import { generateId } from '../utils/id';
-import { calculateFinalScores } from '../utils/resultCalculator';
+import { calculateFinalScores, distributeRemainingRiichiSticks } from '../utils/resultCalculator';
 import { calculateRyukyokuScore } from '../utils/scoreCalculator';
 import { calculateTransaction } from '../utils/scoreDiff';
 import { isReadOnlyFinishedCompetitionRoom } from '../utils/historyRoomStatus';
@@ -57,6 +57,7 @@ export const MatchPage = () => {
 
   const [isEndMatchConfirmOpen, setIsEndMatchConfirmOpen] = useState(false);
   const [isSettlementOpen, setIsSettlementOpen] = useState(false);
+  const [isAbortConfirmOpen, setIsAbortConfirmOpen] = useState(false);
   const { isSoundEnabled, setIsSoundEnabled } = useRoomSoundEffects(room?.lastEvent);
 
   useEffect(() => {
@@ -687,6 +688,37 @@ export const MatchPage = () => {
     setIsSettlementOpen(true);
   };
 
+  const handleAbortGame = async (saveResult: boolean) => {
+    if (!room) return;
+    setIsAbortConfirmOpen(false);
+
+    const riichiSticks = room.round.riichiSticks || 0;
+    // Distribute remaining riichi sticks to 1st place and reset isRiichi
+    const playersWithSticks = distributeRemainingRiichiSticks(room.players, riichiSticks).map(
+      (p) => ({ ...p, isRiichi: false }),
+    );
+
+    let nextGameResults = room.gameResults || [];
+    if (saveResult) {
+      const result = calculateFinalScores(playersWithSticks, room.settings, generateId(12), {
+        gameEndReason: 'Aborted',
+      });
+      result.logs = room.currentLogs || [];
+      nextGameResults = [...nextGameResults, result];
+    }
+
+    setIsTransitioning(true);
+    setTimeout(() => setShowFinishedModal(true), 3000);
+
+    await updateState({
+      players: playersWithSticks,
+      round: { ...room.round, riichiSticks: 0 },
+      status: 'finished',
+      gameResults: nextGameResults,
+      currentLogs: [],
+    });
+  };
+
   const handleSettlementClose = async () => {
     if (!room) return;
     await updateState({
@@ -859,6 +891,17 @@ export const MatchPage = () => {
           >
             戦績 (History)
           </Button>
+          {room.status === 'playing' && (
+            <Button
+              variant="danger"
+              onClick={() => {
+                setIsMenuOpen(false);
+                setIsAbortConfirmOpen(true);
+              }}
+            >
+              途中終了
+            </Button>
+          )}
           <Button variant="secondary" onClick={() => navigate('/')}>
             トップへ戻る
           </Button>
@@ -902,6 +945,38 @@ export const MatchPage = () => {
         gameResults={room.gameResults || []}
         rate={room.settings.rate || 0}
       />
+
+      {/* Abort Game Modal */}
+      <Modal
+        isOpen={isAbortConfirmOpen}
+        onClose={() => setIsAbortConfirmOpen(false)}
+        title="途中終了の確認"
+      >
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+          <p style={{ margin: 0, lineHeight: 1.5 }}>対局を途中終了しますか？</p>
+          <p
+            style={{
+              margin: 0,
+              lineHeight: 1.5,
+              fontSize: '14px',
+              color: 'var(--color-text-secondary, #666)',
+            }}
+          >
+            供託は1位総取りとなります。
+          </p>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+            <Button variant="primary" onClick={() => handleAbortGame(true)}>
+              成績に反映して終了
+            </Button>
+            <Button variant="danger" onClick={() => handleAbortGame(false)}>
+              成績に反映せず終了
+            </Button>
+            <Button variant="secondary" onClick={() => setIsAbortConfirmOpen(false)}>
+              キャンセル
+            </Button>
+          </div>
+        </div>
+      </Modal>
 
       {/* Extension Overlay */}
       {extensionOverlay && (

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,5 @@
+export type GameEndReason = 'Bankruptcy' | 'ScoreReached' | 'MaxRoundReached' | 'Aborted';
+
 export interface Player {
   id: string;
   name: string;
@@ -22,6 +24,7 @@ export interface GameResult {
   ruleSnapshot: GameSettings;
   scores: PlayerGameResult[];
   logs?: HandLog[]; // Detailed hand logs for this game
+  gameEndReason?: GameEndReason;
 }
 
 export interface ScorePointDetail {

--- a/src/utils/__tests__/resultCalculator.test.ts
+++ b/src/utils/__tests__/resultCalculator.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { GameSettings, Player } from '../../types';
 import {
   calculateFinalScores,
+  distributeRemainingRiichiSticks,
   getCurrentPlayerRanks,
   sortPlayersByRank,
 } from '../resultCalculator';
@@ -319,5 +320,103 @@ describe('current rank helpers', () => {
     const sorted = sortPlayersByRank(players);
 
     expect(sorted.map((player) => player.id)).toEqual(['seat1', 'seat2', 'seat3', 'seat4']);
+  });
+});
+
+describe('distributeRemainingRiichiSticks', () => {
+  const createPlayer = (id: string, score: number, wind: Player['wind']): Player => ({
+    id,
+    name: id,
+    score,
+    wind,
+    isRiichi: false,
+    chip: 0,
+  });
+
+  it('adds remaining riichi sticks (as points) to the top-ranked player', () => {
+    const players = [
+      createPlayer('A', 40000, 'East'),
+      createPlayer('B', 30000, 'South'),
+      createPlayer('C', 20000, 'West'),
+      createPlayer('D', 10000, 'North'),
+    ];
+    const result = distributeRemainingRiichiSticks(players, 2);
+    const topPlayer = result.find((p) => p.id === 'A')!;
+    expect(topPlayer.score).toBe(42000); // 40000 + 2 * 1000
+    // Others unchanged
+    expect(result.find((p) => p.id === 'B')!.score).toBe(30000);
+    expect(result.find((p) => p.id === 'C')!.score).toBe(20000);
+    expect(result.find((p) => p.id === 'D')!.score).toBe(10000);
+  });
+
+  it('returns players unchanged when riichiSticks is 0', () => {
+    const players = [createPlayer('A', 25000, 'East'), createPlayer('B', 25000, 'South')];
+    const result = distributeRemainingRiichiSticks(players, 0);
+    expect(result).toEqual(players);
+  });
+
+  it('gives sticks to the first player by seating order when scores are tied', () => {
+    const players = [
+      createPlayer('A', 25000, 'South'),
+      createPlayer('B', 25000, 'East'),
+      createPlayer('C', 25000, 'West'),
+      createPlayer('D', 25000, 'North'),
+    ];
+    const result = distributeRemainingRiichiSticks(players, 3);
+    // A is first in seating order among tied players → gets sticks
+    expect(result.find((p) => p.id === 'A')!.score).toBe(28000);
+    expect(result.find((p) => p.id === 'B')!.score).toBe(25000);
+  });
+});
+
+describe('calculateFinalScores with gameEndReason', () => {
+  const baseSettings: GameSettings = {
+    mode: '4ma',
+    length: 'Hanchan',
+    startPoint: 25000,
+    returnPoint: 30000,
+    uma: [10, 30],
+    hasHonba: true,
+    honbaPoints: 300,
+    tenpaiRenchan: true,
+    useTobi: true,
+    useChip: false,
+    useOka: true,
+    useFuCalculation: true,
+    westExtension: false,
+    rate: 50,
+  };
+
+  const createPlayer = (id: string, score: number, wind: Player['wind']): Player => ({
+    id,
+    name: id,
+    score,
+    wind,
+    isRiichi: false,
+    chip: 0,
+  });
+
+  it('sets gameEndReason on result when provided', () => {
+    const players = [
+      createPlayer('A', 40000, 'East'),
+      createPlayer('B', 25000, 'South'),
+      createPlayer('C', 20000, 'West'),
+      createPlayer('D', 15000, 'North'),
+    ];
+    const result = calculateFinalScores(players, baseSettings, 'test-abort', {
+      gameEndReason: 'Aborted',
+    });
+    expect(result.gameEndReason).toBe('Aborted');
+  });
+
+  it('does not set gameEndReason when not provided', () => {
+    const players = [
+      createPlayer('A', 40000, 'East'),
+      createPlayer('B', 25000, 'South'),
+      createPlayer('C', 20000, 'West'),
+      createPlayer('D', 15000, 'North'),
+    ];
+    const result = calculateFinalScores(players, baseSettings, 'test-normal');
+    expect(result.gameEndReason).toBeUndefined();
   });
 });

--- a/src/utils/gameLogic.ts
+++ b/src/utils/gameLogic.ts
@@ -1,6 +1,4 @@
-import type { Player, RoomState, ScorePayment } from '../types';
-
-export type GameEndReason = 'Bankruptcy' | 'ScoreReached' | 'MaxRoundReached';
+import type { GameEndReason, Player, RoomState, ScorePayment } from '../types';
 
 export interface HandResult {
   type: 'Win' | 'Draw';

--- a/src/utils/resultCalculator.ts
+++ b/src/utils/resultCalculator.ts
@@ -1,6 +1,10 @@
-import type { GameResult, GameSettings, Player, PlayerGameResult } from '../types';
+import type { GameEndReason, GameResult, GameSettings, Player, PlayerGameResult } from '../types';
 import { normalizeGameSettings } from './gameSettings';
 import { getUmaPointsByRank } from './uma';
+
+export interface CalculateFinalScoresOptions {
+  gameEndReason?: GameEndReason;
+}
 
 export const sortPlayersByRank = (players: Player[]): Player[] => {
   return players
@@ -38,10 +42,27 @@ export const getCurrentPlayerRanks = (players: Player[]): Record<string, number>
  *    - -1 * sum(2nd..4th points)
  * 4. Add Uma
  */
+/**
+ * Distributes remaining riichi sticks to the top-ranked player (1st place gets all).
+ * Returns a new array of players with updated scores.
+ */
+export const distributeRemainingRiichiSticks = (
+  players: Player[],
+  riichiSticks: number,
+): Player[] => {
+  if (riichiSticks <= 0) return players;
+  const sorted = sortPlayersByRank(players);
+  const topPlayerId = sorted[0].id;
+  return players.map((p) =>
+    p.id === topPlayerId ? { ...p, score: p.score + riichiSticks * 1000 } : p,
+  );
+};
+
 export const calculateFinalScores = (
   players: Player[],
   settings: GameSettings,
   gameId: string,
+  options?: CalculateFinalScoresOptions,
 ): GameResult => {
   const sortedPlayers = sortPlayersByRank(players);
 
@@ -123,5 +144,6 @@ export const calculateFinalScores = (
     timestamp: Date.now(),
     ruleSnapshot: normalizeGameSettings(settings),
     scores,
+    ...(options?.gameEndReason ? { gameEndReason: options.gameEndReason } : {}),
   };
 };


### PR DESCRIPTION
## 概要

半荘/東風の途中でも対局を終了して精算できる機能を追加しました。
供託リーチ棒は1位総取りとし、大会成績に反映するかどうかを選択可能にしています。

## 主な変更内容

- `GameEndReason` 型に `'Aborted'` を追加
- `GameResult.gameEndReason` フィールドを追加
- `distributeRemainingRiichiSticks` ヘルパー関数を追加（供託1位総取り）
- `calculateFinalScores` にオプション引数 `CalculateFinalScoresOptions` を追加（途中終了対応）
- `useMatchGame` に `handleAbortGame` ハンドラーを追加
- `MatchPage` メニューに途中終了ボタンと確認モーダルを追加
- `CompetitionTablePage` に管理者向け途中終了ボタンと確認モーダルを追加
- 途中終了時に `isRiichi` フラグをリセット

## 変更ファイル

- `src/types/index.ts`
- `src/utils/gameLogic.ts`
- `src/utils/resultCalculator.ts`
- `src/utils/__tests__/resultCalculator.test.ts`
- `src/hooks/useMatchGame.ts`
- `src/pages/MatchPage.tsx`
- `src/pages/CompetitionTablePage.tsx`
- `docs/issue-105-reflection.md`

## テスト計画

- [x] `npm run lint` パス
- [x] `npm run build` パス
- [x] `npm run test` 264テスト全パス（新規5件含む）
- [x] 受入テスト 全17項目 Pass（静的検査）

Closes #105
