### PR TITLE
fix: モーダルのドラッグアウト時に閉じないよう判定を改善

### DIFF
--- a/docs/issue-109-reflection.md
+++ b/docs/issue-109-reflection.md
@@ -1,0 +1,60 @@
+# Issue #109 振り返り
+
+## 1. 概要
+
+- 対象Issue: #109
+- タイトル: モーダルのドラッグアウト操作で意図せず閉じる挙動の修正
+- 要約: モーダルの閉じる判定を pointer の開始位置/終了位置で厳密化し、モーダル内で押して外で離した場合に閉じないよう修正した。
+- 結果: review/triage の最終判定は PR ブロッカーなし。
+
+## 2. 背景と目的
+
+- 背景: 既存実装では外側クリック判定が単純で、モーダル内で押下開始して外側で離す操作でも閉じることがあった。
+- 目的: 「外側で開始し外側で終了した操作」のみ閉じるようにし、意図しない close を防止する。
+
+## 3. 実装内容
+
+- 変更ファイル:
+  - src/components/ui/Modal.tsx
+  - src/components/ui/Modal.test.tsx
+- 実装ポイント:
+  1. overlay の `onClick` 閉鎖を廃止し、`onPointerDown`/`onPointerUp`/`onPointerCancel` で判定する方式に変更。
+  2. pointer down の開始位置が overlay かを ref で保持し、pointer up も overlay で終わった場合のみ `onClose` を呼ぶ。
+  3. `event.isPrimary && event.button === 0` を満たす入力のみ閉鎖対象にし、副ボタン操作で閉じないようにした。
+  4. `pointercancel` で状態をリセットして誤閉鎖を防止した。
+
+## 4. テスト
+
+- 追加ファイル:
+  - src/components/ui/Modal.test.tsx
+- 追加した主要ケース:
+  1. overlay で開始/終了したとき閉じる
+  2. モーダル内開始→overlay 終了では閉じない
+  3. overlay 開始→モーダル内終了では閉じない
+  4. pointer cancel 後は閉じない
+  5. 非主ボタン入力では閉じない
+  6. Escape キーで閉じる（回帰防止）
+
+## 5. 検証結果
+
+- lint: Pass
+- build: Pass
+- test: Pass（274 tests）
+- acceptance_test:
+  - Pass: 要件1〜4（外側クリックで閉じる、ドラッグアウトと逆方向ドラッグで閉じない、Escape で閉じる）
+  - Fail/未達: モバイル幅の実画面検証（実行環境のブラウザ操作制約により未実施）
+
+## 6. レビューとトリアージ
+
+- 初回レビューで指摘された必須対応:
+  1. 非主ボタン入力で閉じるリスク
+  2. pointercancel 分岐のテスト不足
+- 対応後の再レビュー結果: Blocker なし
+- triage 最終判定: 必須対応 0件、任意対応のみ
+
+## 7. 学びと今後の改善
+
+- 学び: モーダルの outside 判定は click 単体より pointer 開始/終了の組み合わせで管理するほうが誤操作耐性が高い。
+- 任意改善:
+  1. touch/pen (`pointerType`) を明示したテストの追加
+  2. multi-pointer シナリオを考慮した厳密化

--- a/src/components/ui/Modal.test.tsx
+++ b/src/components/ui/Modal.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Modal } from './Modal';
+
+afterEach(() => {
+  cleanup();
+});
+
+const renderModal = (onClose = vi.fn()) => {
+  render(
+    <Modal isOpen onClose={onClose} title="テストモーダル">
+      <div>モーダル内容</div>
+    </Modal>,
+  );
+
+  const contentText = screen.getByText('モーダル内容');
+  const contentContainer = contentText.parentElement as HTMLElement;
+  const modalContainer = contentContainer.parentElement as HTMLElement;
+  const overlay = modalContainer.parentElement as HTMLElement;
+
+  return { onClose, modalContainer, overlay };
+};
+
+describe('Modal', () => {
+  it('closes when pointer starts and ends on overlay', () => {
+    const { onClose, overlay } = renderModal();
+
+    fireEvent.pointerDown(overlay, { button: 0, isPrimary: true });
+    fireEvent.pointerUp(overlay, { button: 0, isPrimary: true });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not close when pointer starts inside modal and ends on overlay', () => {
+    const { onClose, modalContainer, overlay } = renderModal();
+
+    fireEvent.pointerDown(modalContainer, { button: 0, isPrimary: true });
+    fireEvent.pointerUp(overlay, { button: 0, isPrimary: true });
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('does not close when pointer starts on overlay and ends inside modal', () => {
+    const { onClose, modalContainer, overlay } = renderModal();
+
+    fireEvent.pointerDown(overlay, { button: 0, isPrimary: true });
+    fireEvent.pointerUp(modalContainer, { button: 0, isPrimary: true });
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('does not close after pointer is canceled before pointer up on overlay', () => {
+    const { onClose, overlay } = renderModal();
+
+    fireEvent.pointerDown(overlay, { button: 0, isPrimary: true });
+    fireEvent.pointerCancel(overlay, { button: 0, isPrimary: true });
+    fireEvent.pointerUp(overlay, { button: 0, isPrimary: true });
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('does not close when using non-primary mouse button on overlay', () => {
+    const { onClose, overlay } = renderModal();
+
+    fireEvent.pointerDown(overlay, { button: 2, isPrimary: true });
+    fireEvent.pointerUp(overlay, { button: 2, isPrimary: true });
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('closes on Escape key while open', () => {
+    const { onClose } = renderModal();
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import styles from './Modal.module.css';
 
@@ -12,6 +12,7 @@ interface ModalProps {
 
 export const Modal = ({ isOpen, onClose, title, children, width }: ModalProps) => {
   const [isVisible, setIsVisible] = useState(isOpen);
+  const pointerStartedOnOverlayRef = useRef(false);
 
   if (isOpen && !isVisible) {
     setIsVisible(true);
@@ -36,8 +37,39 @@ export const Modal = ({ isOpen, onClose, title, children, width }: ModalProps) =
 
   if (!isVisible && !isOpen) return null;
 
+  const isPrimaryPointer = (event: React.PointerEvent<HTMLDivElement>) => {
+    return event.isPrimary && event.button === 0;
+  };
+
+  const handleOverlayPointerDown: React.PointerEventHandler<HTMLDivElement> = (event) => {
+    pointerStartedOnOverlayRef.current =
+      isPrimaryPointer(event) && event.target === event.currentTarget;
+  };
+
+  const handleOverlayPointerUp: React.PointerEventHandler<HTMLDivElement> = (event) => {
+    if (!isPrimaryPointer(event)) {
+      pointerStartedOnOverlayRef.current = false;
+      return;
+    }
+
+    const endedOnOverlay = event.target === event.currentTarget;
+    if (pointerStartedOnOverlayRef.current && endedOnOverlay) {
+      onClose();
+    }
+    pointerStartedOnOverlayRef.current = false;
+  };
+
+  const handleOverlayPointerCancel: React.PointerEventHandler<HTMLDivElement> = () => {
+    pointerStartedOnOverlayRef.current = false;
+  };
+
   return createPortal(
-    <div className={`${styles.overlay} ${!isOpen ? styles.overlayClosing : ''}`} onClick={onClose}>
+    <div
+      className={`${styles.overlay} ${!isOpen ? styles.overlayClosing : ''}`}
+      onPointerCancel={handleOverlayPointerCancel}
+      onPointerDown={handleOverlayPointerDown}
+      onPointerUp={handleOverlayPointerUp}
+    >
       <div
         className={`${styles.modal} ${!isOpen ? styles.modalClosing : ''}`}
         onClick={(e) => e.stopPropagation()}


### PR DESCRIPTION
## 概要
モーダルの閉鎖判定を pointerdown と pointerup の開始終了位置ベースに見直し、ドラッグアウト操作で意図せず閉じる不具合を修正しました。

Closes #109

## 変更内容
### component
- src/components/ui/Modal.tsx
- pointerdown 時に開始位置（モーダル内外）を記録し、pointerup 時に終了位置と組み合わせて閉鎖可否を判定
- primary pointer かつ left button のみを閉鎖判定対象に制限
- pointercancel で保持状態をリセット

### test
- src/components/ui/Modal.test.tsx
- 回帰テストを 6 ケース追加し、以下を検証
- 外側で down/up した場合のみ閉じる
- 内側開始やドラッグアウト時は閉じない
- non-primary pointer では閉じない
- left button 以外では閉じない
- pointercancel 後に閉じない

### docs
- docs/issue-109-reflection.md
- 実装方針、検証内容、残課題（モバイル幅の実画面確認）を追記

## テスト計画
- [x] npm run lint
- [x] npm run build
- [x] npm run test（274 passed）
- [x] 受入テスト（要件1-4 pass）
- [ ] モバイル幅の実画面確認（環境制約により未実施）
