### PR TITLE
fix: 途中終了時に ResultView へ即時遷移するよう修正

### DIFF
--- a/src/hooks/useMatchGame.ts
+++ b/src/hooks/useMatchGame.ts
@@ -46,6 +46,7 @@ export const useMatchGame = ({ room, updateState }: UseMatchGameOptions): UseMat
 
   const prevStatusRef = useRef<RoomState['status'] | undefined>(undefined);
   const prevRoundWindRef = useRef<RoomState['round']['wind'] | undefined>(undefined);
+  const skipFinishedTransitionRef = useRef(false);
 
   // Track latest game result
   const gameResult: GameResult | null =
@@ -56,6 +57,14 @@ export const useMatchGame = ({ room, updateState }: UseMatchGameOptions): UseMat
   // Finish detection
   useEffect(() => {
     if (room && room.status === 'finished' && !hasHandledFinish) {
+      if (skipFinishedTransitionRef.current) {
+        skipFinishedTransitionRef.current = false;
+        setTimeout(() => {
+          setHasHandledFinish(true);
+        }, 0);
+        return;
+      }
+
       setTimeout(() => {
         setHasHandledFinish(true);
         if (!isTransitioning) {
@@ -74,6 +83,11 @@ export const useMatchGame = ({ room, updateState }: UseMatchGameOptions): UseMat
         prevStatusRef.current = current;
       }
       if (current === 'finished' && prev && prev !== 'finished') {
+        if (skipFinishedTransitionRef.current) {
+          skipFinishedTransitionRef.current = false;
+          prevStatusRef.current = current;
+          return;
+        }
         if (!isTransitioning) {
           setTimeout(() => {
             setIsTransitioning(true);
@@ -434,7 +448,11 @@ export const useMatchGame = ({ room, updateState }: UseMatchGameOptions): UseMat
         nextGameResults = [...nextGameResults, result];
       }
 
-      triggerGameEndTransition();
+      // Abort flow does not need score animation wait; skip finish transition once.
+      skipFinishedTransitionRef.current = true;
+      setHasHandledFinish(true);
+      setIsTransitioning(false);
+      setShowFinishedModal(false);
 
       await updateState({
         players: playersWithSticks,
@@ -446,7 +464,7 @@ export const useMatchGame = ({ room, updateState }: UseMatchGameOptions): UseMat
 
       return result;
     },
-    [room, updateState, triggerGameEndTransition],
+    [room, updateState],
   );
 
   const dismissFinishedModal = useCallback(() => {

--- a/src/pages/MatchPage.tsx
+++ b/src/pages/MatchPage.tsx
@@ -51,6 +51,7 @@ export const MatchPage = () => {
   const [isTransitioning, setIsTransitioning] = useState(false);
   const [showFinishedModal, setShowFinishedModal] = useState(false);
   const prevStatusRef = useRef<RoomState['status'] | undefined>(undefined);
+  const skipFinishedTransitionRef = useRef(false);
 
   // Track if we have handled the finish state
   const [hasHandledFinish, setHasHandledFinish] = useState(false);
@@ -62,6 +63,14 @@ export const MatchPage = () => {
 
   useEffect(() => {
     if (room && room.status === 'finished' && !hasHandledFinish) {
+      if (skipFinishedTransitionRef.current) {
+        skipFinishedTransitionRef.current = false;
+        setTimeout(() => {
+          setHasHandledFinish(true);
+        }, 0);
+        return;
+      }
+
       // Wrap in timeout to avoid synchronous setState in effect (lint warning)
       setTimeout(() => {
         setHasHandledFinish(true);
@@ -88,6 +97,12 @@ export const MatchPage = () => {
 
       // Detect change to finished
       if (current === 'finished' && prev && prev !== 'finished') {
+        if (skipFinishedTransitionRef.current) {
+          skipFinishedTransitionRef.current = false;
+          prevStatusRef.current = current;
+          return;
+        }
+
         // If not already transitioning (self-triggered), trigger it now
         if (!isTransitioning) {
           // Trigger logic inline to avoid dependency issues or use function ref
@@ -707,8 +722,11 @@ export const MatchPage = () => {
       nextGameResults = [...nextGameResults, result];
     }
 
-    setIsTransitioning(true);
-    setTimeout(() => setShowFinishedModal(true), 3000);
+    // Abort flow does not need score animation wait; skip finish transition once.
+    skipFinishedTransitionRef.current = true;
+    setHasHandledFinish(true);
+    setIsTransitioning(false);
+    setShowFinishedModal(false);
 
     await updateState({
       players: playersWithSticks,


### PR DESCRIPTION
## 概要

途中終了（中断終了）を選択した際、従来は 3 秒のアニメーション待機後に ResultView へ遷移していた問題を修正しました。

- **通常対局ページ** (): `handleAbortGame` 内でフラグを先行設定
- **大会対戦ページ** ( / `useMatchGame`): 同様のフラグ制御を `useMatchGame` フックに適用

どちらの場合も途中終了時は Firestore の `finished` 更新受信直後に ResultView の表示条件を満たし、即時遷移を実現しています。

## 変更内容

- `handleAbortGame` 内で `skipFinishedTransitionRef.current = true` と `hasHandledFinish = true` を事前に設定
- Firestore から `status: finished` を受信した時点で即座に ResultView へ遷移
- 通常終了フロー（3 秒遅延）には影響なし

## 変更ファイル

- `src/pages/MatchPage.tsx`
- `src/hooks/useMatchGame.ts`

## テスト結果

- [x] `npm run lint` — Pass
- [x] `npm run build` — Pass（エラーなし）
- [x] `npm run test` — 274 tests, 27 files, all Pass
- [x] 受入テスト（acceptance-test エージェント）— 3 観点すべて Pass
  - 途中終了 → 即時 ResultView 遷移
  - 結果画面が正常表示（スコア・集計）
  - 通常終了の 3 秒遅延は維持されていること

Closes #111