### PR TITLE
Add auto-join organizer feature to competition creation

### DIFF
--- a/src/components/features/CompetitionForm.test.tsx
+++ b/src/components/features/CompetitionForm.test.tsx
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CompetitionForm } from './CompetitionForm';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('CompetitionForm', () => {
+  it('submits with organizer auto join enabled by default', () => {
+    const onSubmit = vi.fn();
+
+    render(<CompetitionForm onSubmit={onSubmit} />);
+
+    const nameInput = screen.getByPlaceholderText('例: 第1回麻雀大会');
+    fireEvent.change(nameInput, { target: { value: '春季大会' } });
+
+    fireEvent.click(screen.getByRole('button', { name: '大会を作成' }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit.mock.calls[0][0].autoJoinOrganizer).toBe(true);
+  });
+
+  it('submits with organizer auto join disabled when switch is off', () => {
+    const onSubmit = vi.fn();
+
+    render(<CompetitionForm onSubmit={onSubmit} />);
+
+    const nameInput = screen.getByPlaceholderText('例: 第1回麻雀大会');
+    fireEvent.change(nameInput, { target: { value: '春季大会' } });
+
+    fireEvent.click(screen.getByLabelText('大会に参加する'));
+    fireEvent.click(screen.getByRole('button', { name: '大会を作成' }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit.mock.calls[0][0].autoJoinOrganizer).toBe(false);
+  });
+});

--- a/src/components/features/CompetitionForm.tsx
+++ b/src/components/features/CompetitionForm.tsx
@@ -13,6 +13,7 @@ interface CompetitionFormProps {
     description: string;
     hasPasscode: boolean;
     passcode: string;
+    autoJoinOrganizer: boolean;
     settings: CompetitionSettings;
   }) => void;
   loading?: boolean;
@@ -23,13 +24,14 @@ export const CompetitionForm: React.FC<CompetitionFormProps> = ({ onSubmit, load
   const [description, setDescription] = useState('');
   const [hasPasscode, setHasPasscode] = useState(false);
   const [passcode, setPasscode] = useState('');
+  const [autoJoinOrganizer, setAutoJoinOrganizer] = useState(true);
   const [settings, setSettings] = useState<CompetitionSettings>({
     ...DEFAULT_COMPETITION_SETTINGS,
   });
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    onSubmit({ name, description, hasPasscode, passcode, settings });
+    onSubmit({ name, description, hasPasscode, passcode, autoJoinOrganizer, settings });
   };
 
   return (
@@ -71,6 +73,14 @@ export const CompetitionForm: React.FC<CompetitionFormProps> = ({ onSubmit, load
             />
           </div>
         )}
+      </div>
+
+      <div className={styles.fieldGroup}>
+        <Switch
+          checked={autoJoinOrganizer}
+          onChange={setAutoJoinOrganizer}
+          label="大会に参加する"
+        />
       </div>
 
       <hr className={styles.divider} />

--- a/src/pages/CompetitionNewPage.test.tsx
+++ b/src/pages/CompetitionNewPage.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CompetitionNewPage } from './CompetitionNewPage';
+
+const mockNavigate = vi.fn();
+const mockShowSnackbar = vi.fn();
+const mockCreateCompetition = vi.fn();
+const mockAddParticipant = vi.fn();
+const mockGenerateId = vi.fn(() => 'comp-1234567890');
+const mockHashPasscode = vi.fn();
+
+vi.mock('react-router-dom', () => ({
+  Link: ({ children, to }: { children: React.ReactNode; to: string }) => (
+    <a href={to}>{children}</a>
+  ),
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock('../contexts/SnackbarContext', () => ({
+  useSnackbar: () => ({ showSnackbar: mockShowSnackbar }),
+}));
+
+vi.mock('../services/competitionService', () => ({
+  createCompetition: (...args: unknown[]) => mockCreateCompetition(...args),
+  addParticipant: (...args: unknown[]) => mockAddParticipant(...args),
+}));
+
+vi.mock('../services/firebase', () => ({
+  auth: {
+    currentUser: {
+      uid: 'user-1',
+      isAnonymous: false,
+    },
+  },
+}));
+
+vi.mock('../utils/id', () => ({
+  generateId: () => mockGenerateId(),
+}));
+
+vi.mock('../utils/hash', () => ({
+  hashPasscode: (...args: unknown[]) => mockHashPasscode(...args),
+}));
+
+beforeEach(() => {
+  mockNavigate.mockReset();
+  mockShowSnackbar.mockReset();
+  mockCreateCompetition.mockReset();
+  mockAddParticipant.mockReset();
+  mockHashPasscode.mockReset();
+  mockHashPasscode.mockResolvedValue('hashed-passcode');
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('CompetitionNewPage', () => {
+  it('auto-adds organizer as participant when auto join switch is on', async () => {
+    render(<CompetitionNewPage />);
+
+    fireEvent.change(screen.getByPlaceholderText('例: 第1回麻雀大会'), {
+      target: { value: '春季大会' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: '大会を作成' }));
+
+    await waitFor(() => {
+      expect(mockCreateCompetition).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockAddParticipant).toHaveBeenCalledTimes(1);
+    expect(mockAddParticipant).toHaveBeenCalledWith(
+      'comp-1234567890',
+      expect.objectContaining({
+        id: 'user-1',
+        userId: 'user-1',
+        role: 'organizer',
+        status: 'idle',
+        isGuest: false,
+      }),
+    );
+
+    expect(mockNavigate).toHaveBeenCalledWith('/competitions/comp-1234567890');
+  });
+
+  it('does not auto-add organizer when auto join switch is off', async () => {
+    render(<CompetitionNewPage />);
+
+    fireEvent.change(screen.getByPlaceholderText('例: 第1回麻雀大会'), {
+      target: { value: '春季大会' },
+    });
+    fireEvent.click(screen.getByLabelText('大会に参加する'));
+
+    fireEvent.click(screen.getByRole('button', { name: '大会を作成' }));
+
+    await waitFor(() => {
+      expect(mockCreateCompetition).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockAddParticipant).not.toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith('/competitions/comp-1234567890');
+  });
+});

--- a/src/pages/CompetitionNewPage.tsx
+++ b/src/pages/CompetitionNewPage.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { CompetitionForm } from '../components/features/CompetitionForm';
 import { useSnackbar } from '../contexts/SnackbarContext';
-import { createCompetition } from '../services/competitionService';
+import { addParticipant, createCompetition } from '../services/competitionService';
 import { auth } from '../services/firebase';
 import type { CompetitionSettings } from '../types';
 import { hashPasscode } from '../utils/hash';
@@ -18,6 +18,7 @@ export const CompetitionNewPage = () => {
     description: string;
     hasPasscode: boolean;
     passcode: string;
+    autoJoinOrganizer: boolean;
     settings: CompetitionSettings;
   }) => {
     const currentUser = auth.currentUser;
@@ -45,6 +46,17 @@ export const CompetitionNewPage = () => {
         },
         hashedPasscode,
       );
+
+      if (data.autoJoinOrganizer) {
+        await addParticipant(id, {
+          id: currentUser.uid,
+          userId: currentUser.uid,
+          name: currentUser.displayName || '主催者',
+          isGuest: currentUser.isAnonymous,
+          status: 'idle',
+          role: 'organizer',
+        });
+      }
 
       navigate(`/competitions/${id}`);
     } catch (error) {


### PR DESCRIPTION
Introduce a feature that automatically adds the organizer as a participant when creating a competition, with an option to disable this functionality. Update the competition form and related components to support this feature.