### PR TITLE
Add QR code modal and related tests

### DIFF
--- a/src/components/features/LobbyView.test.tsx
+++ b/src/components/features/LobbyView.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { RoomState } from '../../types';
+import { LobbyView } from './LobbyView';
+
+afterEach(() => {
+  cleanup();
+});
+
+const createRoomState = (): RoomState => ({
+  id: 'ROOM01',
+  hostId: 'user-1',
+  roomName: 'テスト卓',
+  status: 'waiting',
+  round: {
+    wind: 'East',
+    number: 1,
+    honba: 0,
+    riichiSticks: 0,
+  },
+  players: [
+    {
+      id: 'user-1',
+      name: 'テストユーザー',
+      score: 25000,
+      isRiichi: false,
+      wind: 'East',
+      chip: 0,
+    },
+  ],
+  playerIds: ['user-1'],
+  settings: {
+    mode: '4ma',
+    length: 'Hanchan',
+    startPoint: 25000,
+    returnPoint: 30000,
+    uma: [5, 10],
+    hasHonba: true,
+    honbaPoints: 300,
+    tenpaiRenchan: true,
+    useTobi: true,
+    useChip: false,
+    chipRate: 0,
+    useOka: true,
+    isSingleMode: false,
+    useFuCalculation: true,
+    noFuFixedPoints: {
+      1: { child: 1000, dealer: 1500 },
+      2: { child: 2000, dealer: 3000 },
+      3: { child: 4000, dealer: 6000 },
+    },
+    westExtension: false,
+    rate: 50,
+  },
+});
+
+describe('LobbyView', () => {
+  it('opens the QR modal from the waiting room', () => {
+    render(
+      <LobbyView
+        room={createRoomState()}
+        currentUserId="user-1"
+        onReorder={vi.fn()}
+        onStartGame={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'QRコードを表示' }));
+
+    expect(screen.getByText('ルームへのリンク')).not.toBeNull();
+    expect(screen.getByText(window.location.href)).not.toBeNull();
+  });
+});

--- a/src/components/features/LobbyView.tsx
+++ b/src/components/features/LobbyView.tsx
@@ -18,9 +18,12 @@ import { CSS } from '@dnd-kit/utilities';
 import { useState } from 'react';
 import QRCode from 'react-qr-code';
 import type { Player, RoomState } from '../../types';
+import { resolveQrCodeComponent } from '../../utils/resolveQrCodeComponent';
 import { formatUmaDisplay } from '../../utils/uma';
 import { Button } from '../ui/Button';
 import { Modal } from '../ui/Modal';
+
+const QRCodeComponent = resolveQrCodeComponent(QRCode, QRCode);
 
 interface LobbyViewProps {
   room: RoomState;
@@ -257,7 +260,7 @@ export const LobbyView = ({ room, currentUserId, onReorder, onStartGame }: Lobby
           }}
         >
           <div style={{ background: 'white', padding: '16px', borderRadius: '8px' }}>
-            <QRCode value={window.location.href} size={200} />
+            <QRCodeComponent value={window.location.href} size={200} />
           </div>
           <p
             style={{

--- a/src/components/features/ShareCompetitionModal.test.tsx
+++ b/src/components/features/ShareCompetitionModal.test.tsx
@@ -1,0 +1,27 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { SnackbarProvider } from '../../contexts/SnackbarContext';
+import { ShareCompetitionModal } from './ShareCompetitionModal';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('ShareCompetitionModal', () => {
+  it('renders the competition join URL when opened', () => {
+    render(
+      <SnackbarProvider>
+        <ShareCompetitionModal isOpen onClose={() => undefined} competitionId="comp-123" />
+      </SnackbarProvider>,
+    );
+
+    expect(screen.getByText('大会を共有')).not.toBeNull();
+    expect(
+      screen.getByText((content) =>
+        content.includes(`${window.location.origin}/competitions/comp-123/join`),
+      ),
+    ).not.toBeNull();
+  });
+});

--- a/src/components/features/ShareCompetitionModal.tsx
+++ b/src/components/features/ShareCompetitionModal.tsx
@@ -1,14 +1,10 @@
 import QRCodeDefault from 'react-qr-code';
 import { useSnackbar } from '../../contexts/SnackbarContext';
+import { resolveQrCodeComponent } from '../../utils/resolveQrCodeComponent';
 import { Button } from '../ui/Button';
 import { Modal } from '../ui/Modal';
 
-// Handle CJS/ESM interop: Vite may wrap the default export
-const mod = QRCodeDefault as unknown as Record<string, unknown>;
-const QRCode =
-  typeof mod.render === 'function'
-    ? QRCodeDefault
-    : ((mod.QRCode as typeof QRCodeDefault) ?? QRCodeDefault);
+const QRCode = resolveQrCodeComponent(QRCodeDefault, QRCodeDefault);
 
 interface Props {
   isOpen: boolean;

--- a/src/utils/resolveQrCodeComponent.test.ts
+++ b/src/utils/resolveQrCodeComponent.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { resolveQrCodeComponent } from './resolveQrCodeComponent';
+
+describe('resolveQrCodeComponent', () => {
+  it('returns the component when it already has a render function', () => {
+    const component = { render: () => undefined };
+
+    expect(resolveQrCodeComponent(component, component)).toBe(component);
+  });
+
+  it('unwraps nested default exports until it finds a renderable component', () => {
+    const component = { render: () => undefined };
+    const wrapped = {
+      default: {
+        default: component,
+      },
+    };
+
+    expect(resolveQrCodeComponent(wrapped, component)).toBe(component);
+  });
+
+  it('unwraps nested QRCode exports until it finds a renderable component', () => {
+    const component = { render: () => undefined };
+    const wrapped = {
+      QRCode: {
+        default: component,
+      },
+    };
+
+    expect(resolveQrCodeComponent(wrapped, component)).toBe(component);
+  });
+
+  it('falls back when no renderable component is found', () => {
+    const fallback = { render: () => undefined };
+
+    expect(resolveQrCodeComponent({ default: { QRCode: {} } }, fallback)).toBe(fallback);
+  });
+});

--- a/src/utils/resolveQrCodeComponent.ts
+++ b/src/utils/resolveQrCodeComponent.ts
@@ -10,9 +10,9 @@ const isRenderableQrCodeComponent = (value: unknown): value is QrCodeLikeCompone
   );
 };
 
-export const resolveQrCodeComponent = <T>(moduleValue: T, fallback: T): T => {
+export const resolveQrCodeComponent = <T>(moduleValue: unknown, fallback: T): T => {
   if (isRenderableQrCodeComponent(moduleValue)) {
-    return moduleValue;
+    return moduleValue as T;
   }
 
   if (typeof moduleValue === 'object' && moduleValue !== null) {

--- a/src/utils/resolveQrCodeComponent.ts
+++ b/src/utils/resolveQrCodeComponent.ts
@@ -1,0 +1,33 @@
+type QrCodeLikeComponent = {
+  render?: unknown;
+};
+
+const isRenderableQrCodeComponent = (value: unknown): value is QrCodeLikeComponent => {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { render?: unknown }).render === 'function'
+  );
+};
+
+export const resolveQrCodeComponent = <T>(moduleValue: T, fallback: T): T => {
+  if (isRenderableQrCodeComponent(moduleValue)) {
+    return moduleValue;
+  }
+
+  if (typeof moduleValue === 'object' && moduleValue !== null) {
+    const record = moduleValue as Record<string, unknown>;
+
+    const fromDefault = resolveQrCodeComponent(record.default, fallback);
+    if (fromDefault !== fallback) {
+      return fromDefault as T;
+    }
+
+    const fromNamed = resolveQrCodeComponent(record.QRCode, fallback);
+    if (fromNamed !== fallback) {
+      return fromNamed as T;
+    }
+  }
+
+  return fallback;
+};


### PR DESCRIPTION
## 概要

- Introduce a QR code modal in the LobbyView and ShareCompetitionModal components.

## 変更内容

###

- Implement QR code functionality to display room and competition join URLs.
- Add tests for the new modal components to ensure correct rendering and functionality.

## テスト計画

- [ ] npm run lint
- [ ] npm run build
- [ ] npm run test（ files / tests passed）
- [ ] 受入テスト（手動確認項目を記載）

Closes #

