### PR TITLE
ロード時スケルトンを現行レイアウトに合わせて調整

### DIFF
--- a/src/components/skeletons/DashboardSkeleton.module.css
+++ b/src/components/skeletons/DashboardSkeleton.module.css
@@ -1,0 +1,63 @@
+.container {
+  padding: var(--spacing-l);
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--spacing-xl);
+  gap: var(--spacing-m);
+}
+
+.metricsGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: var(--spacing-m);
+  margin-bottom: var(--spacing-xl);
+}
+
+.metricCard {
+  background: rgb(255 255 255 / 5%);
+  border: 1px solid rgb(255 255 255 / 10%);
+  border-radius: var(--border-radius-m);
+  min-height: 84px;
+  padding: var(--spacing-m);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.chartSection {
+  background: rgb(255 255 255 / 5%);
+  border-radius: var(--border-radius-l);
+  padding: var(--spacing-l);
+}
+
+.chartBody {
+  display: block;
+  height: 200px;
+}
+
+@media (max-width: 768px) {
+  .container {
+    padding: var(--spacing-m);
+  }
+
+  .header {
+    flex-wrap: wrap;
+    margin-bottom: var(--spacing-l);
+  }
+
+  .metricsGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    margin-bottom: var(--spacing-l);
+  }
+
+  .chartSection {
+    padding: var(--spacing-m);
+  }
+}

--- a/src/components/skeletons/DashboardSkeleton.tsx
+++ b/src/components/skeletons/DashboardSkeleton.tsx
@@ -1,69 +1,26 @@
 import { Skeleton } from '../ui/Skeleton';
+import styles from './DashboardSkeleton.module.css';
 
 export const DashboardSkeleton = () => {
   return (
-    <div
-      style={{
-        padding: '24px',
-        maxWidth: '800px',
-        margin: '0 auto',
-      }}
-    >
-      {/* Header */}
-      <div
-        style={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          marginBottom: '32px',
-        }}
-      >
+    <div className={styles.container}>
+      <div className={styles.header}>
         <Skeleton width={200} height={32} borderRadius={4} />
-        <Skeleton width={100} height={40} borderRadius={8} />
+        <Skeleton width={96} height={40} borderRadius={8} />
       </div>
 
-      {/* Helper for Metric Card */}
-      {/* Metrics Grid */}
-      <div
-        style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))',
-          gap: '16px',
-          marginBottom: '32px',
-        }}
-      >
-        {Array.from({ length: 8 }).map((_, i) => (
-          <div
-            key={i}
-            style={{
-              background: 'var(--color-bg-card)', // Match card bg
-              padding: '16px',
-              borderRadius: '8px',
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'center',
-              justifyContent: 'center',
-              border: '1px solid rgba(255,255,255,0.1)',
-              height: '84px', // Approximate height of content
-            }}
-          >
-            <Skeleton width={60} height={16} borderRadius={4} style={{ marginBottom: 8 }} />
+      <div className={styles.metricsGrid}>
+        {Array.from({ length: 9 }).map((_, index) => (
+          <div key={index} className={styles.metricCard}>
+            <Skeleton width={64} height={16} borderRadius={4} style={{ marginBottom: 8 }} />
             <Skeleton width={80} height={24} borderRadius={4} />
           </div>
         ))}
       </div>
 
-      {/* Chart Section */}
-      <div
-        style={{
-          background: 'rgba(255,255,255,0.05)',
-          padding: '24px',
-          borderRadius: '12px',
-          height: '300px',
-        }}
-      >
-        <Skeleton width={250} height={24} borderRadius={4} style={{ marginBottom: 24 }} />
-        <Skeleton width="100%" height={200} borderRadius={8} />
+      <div className={styles.chartSection}>
+        <Skeleton width={256} height={24} borderRadius={4} style={{ marginBottom: 24 }} />
+        <Skeleton width="100%" borderRadius={8} className={styles.chartBody} />
       </div>
     </div>
   );

--- a/src/components/skeletons/HistorySkeleton.module.css
+++ b/src/components/skeletons/HistorySkeleton.module.css
@@ -1,0 +1,61 @@
+.container {
+  padding: var(--spacing-m);
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--spacing-l);
+  gap: var(--spacing-m);
+}
+
+.roomList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-m);
+}
+
+.roomCard {
+  background: rgb(255 255 255 / 5%);
+  border: 1px solid rgb(255 255 255 / 10%);
+  border-radius: var(--border-radius-m);
+  padding: var(--spacing-m);
+}
+
+.rowBetween {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--spacing-m);
+  margin-bottom: var(--spacing-s);
+}
+
+.roomName {
+  display: block;
+  margin-bottom: var(--spacing-s);
+}
+
+.playerLine {
+  display: block;
+  margin-bottom: 12px;
+}
+
+.footer {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: var(--spacing-s);
+}
+
+@media (max-width: 768px) {
+  .header {
+    flex-wrap: wrap;
+  }
+
+  .rowBetween {
+    flex-wrap: wrap;
+  }
+}

--- a/src/components/skeletons/HistorySkeleton.tsx
+++ b/src/components/skeletons/HistorySkeleton.tsx
@@ -1,46 +1,26 @@
 import { Skeleton } from '../ui/Skeleton';
+import styles from './HistorySkeleton.module.css';
 
 export const HistorySkeleton = () => {
   return (
-    <div style={{ padding: '16px', maxWidth: '600px', margin: '0 auto' }}>
-      {/* Header */}
-      <div
-        style={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          marginBottom: '24px',
-        }}
-      >
+    <div className={styles.container}>
+      <div className={styles.header}>
         <Skeleton width={120} height={32} borderRadius={4} />
         <Skeleton width={80} height={32} borderRadius={4} />
       </div>
 
-      {/* Room List */}
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
-        {Array.from({ length: 4 }).map((_, i) => (
-          <div
-            key={i}
-            style={{
-              background: 'rgba(255,255,255,0.05)',
-              padding: '16px',
-              borderRadius: '8px',
-              border: '1px solid rgba(255,255,255,0.1)',
-            }}
-          >
-            <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '8px' }}>
+      <div className={styles.roomList}>
+        {Array.from({ length: 4 }).map((_, index) => (
+          <div key={index} className={styles.roomCard}>
+            <div className={styles.rowBetween}>
               <Skeleton width={80} height={20} borderRadius={4} />
               <Skeleton width={100} height={16} borderRadius={4} />
             </div>
-            <Skeleton width="80%" height={16} borderRadius={4} style={{ marginBottom: 12 }} />
-            <div
-              style={{
-                display: 'flex',
-                justifyContent: 'flex-end',
-                alignItems: 'center',
-                gap: '8px',
-              }}
-            >
+            {index % 2 === 0 && (
+              <Skeleton width="56%" height={18} borderRadius={4} className={styles.roomName} />
+            )}
+            <Skeleton width="88%" height={16} borderRadius={4} className={styles.playerLine} />
+            <div className={styles.footer}>
               <Skeleton width={60} height={20} borderRadius={4} />
               <Skeleton width={60} height={32} borderRadius={4} />
             </div>

--- a/src/components/skeletons/TopPageSkeleton.module.css
+++ b/src/components/skeletons/TopPageSkeleton.module.css
@@ -1,0 +1,79 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-l);
+  align-items: center;
+  margin-top: 100px;
+  padding: 0 var(--spacing-m);
+}
+
+.authArea {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+}
+
+.authUserRow {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-s);
+}
+
+.authAnonymous {
+  display: none;
+}
+
+.mainActions {
+  display: flex;
+  gap: var(--spacing-m);
+  width: auto;
+}
+
+.mainActionButton {
+  min-width: 124px;
+}
+
+.joinRoom {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-s);
+  margin-top: var(--spacing-xl);
+  width: min(100%, 288px);
+}
+
+.roomInput {
+  width: 100%;
+}
+
+@media (max-width: 768px) {
+  .container {
+    margin-top: 96px;
+  }
+
+  .authArea {
+    right: 16px;
+  }
+
+  .authUserRow {
+    display: none;
+  }
+
+  .authAnonymous {
+    display: block;
+  }
+
+  .mainActions {
+    flex-direction: column;
+    width: min(100%, 320px);
+  }
+
+  .mainActionButton {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .joinRoom {
+    width: min(100%, 320px);
+    margin-top: var(--spacing-l);
+  }
+}

--- a/src/components/skeletons/TopPageSkeleton.tsx
+++ b/src/components/skeletons/TopPageSkeleton.tsx
@@ -1,30 +1,28 @@
 import { Skeleton } from '../ui/Skeleton';
+import styles from './TopPageSkeleton.module.css';
 
 export const TopPageSkeleton = () => {
   return (
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        gap: '24px',
-        alignItems: 'center',
-        marginTop: '100px',
-      }}
-    >
-      {/* Title */}
-      <Skeleton width={200} height={40} borderRadius={8} />
-
-      {/* Action Buttons */}
-      <div style={{ display: 'flex', gap: '16px' }}>
-        <Skeleton width={100} height={40} borderRadius={8} />
-        <Skeleton width={100} height={40} borderRadius={8} />
-        <Skeleton width={140} height={40} borderRadius={8} />
+    <div className={styles.container}>
+      <div className={styles.authArea}>
+        <div className={styles.authUserRow}>
+          <Skeleton width={168} height={14} borderRadius={6} />
+          <Skeleton width={88} height={32} borderRadius={8} />
+        </div>
+        <Skeleton width={140} height={32} borderRadius={8} className={styles.authAnonymous} />
       </div>
 
-      {/* Join Room Section */}
-      <div style={{ display: 'flex', gap: '8px', marginTop: '32px' }}>
-        <Skeleton width={200} height={40} borderRadius={8} />
-        <Skeleton width={60} height={40} borderRadius={8} />
+      <Skeleton width={220} height={42} borderRadius={8} />
+
+      <div className={styles.mainActions}>
+        {Array.from({ length: 5 }).map((_, index) => (
+          <Skeleton key={index} height={40} borderRadius={8} className={styles.mainActionButton} />
+        ))}
+      </div>
+
+      <div className={styles.joinRoom}>
+        <Skeleton height={40} borderRadius={8} className={styles.roomInput} />
+        <Skeleton width={72} height={40} borderRadius={8} />
       </div>
     </div>
   );

--- a/src/components/ui/Skeleton.module.css
+++ b/src/components/ui/Skeleton.module.css
@@ -15,3 +15,9 @@
     opacity: 1;
   }
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton {
+    animation: none;
+  }
+}

--- a/src/components/ui/Skeleton.tsx
+++ b/src/components/ui/Skeleton.tsx
@@ -19,6 +19,7 @@ export const Skeleton: React.FC<SkeletonProps> = ({
   return (
     <div
       className={`${styles.skeleton} ${className || ''}`}
+      aria-hidden="true"
       style={{
         width,
         height,


### PR DESCRIPTION
## 概要
- Top / Dashboard / History のロード中スケルトンが現行レイアウトとずれていたため、モバイル/PCで占有領域を合わせて遷移時のジャンプを抑制しました。
- スケルトンのスタイルを CSS Modules 化し、ページ側の主要レイアウト比率に合わせて骨組みを再構成しました。

## 変更内容
### skeleton component
- `src/components/skeletons/TopPageSkeleton.tsx`: 主要アクション群と入室導線を現行Topレイアウトに合わせて再構成。
- `src/components/skeletons/TopPageSkeleton.module.css`: モバイル縦積み/PC横並びを再現し、右上領域の占有を実画面寄りに調整。
- `src/components/skeletons/DashboardSkeleton.tsx`: ヘッダー・9枚メトリクス・チャート領域の骨組みに更新。
- `src/components/skeletons/DashboardSkeleton.module.css`: メトリクスグリッドとチャート領域の余白/比率をレスポンシブ対応で定義。
- `src/components/skeletons/HistorySkeleton.tsx`: 履歴カード構成を実画面に寄せ、roomName行を可変化してジャンプを抑制。
- `src/components/skeletons/HistorySkeleton.module.css`: ヘッダー/カード/フッター配置を現行カード構造に合わせて定義。

### ui
- `src/components/ui/Skeleton.tsx`: 補助技術向けに `aria-hidden` を追加。
- `src/components/ui/Skeleton.module.css`: `prefers-reduced-motion: reduce` でアニメーション停止を追加。

## テスト計画
- [x] npm run lint
- [x] npm run build
- [x] npm run test（38 files / 318 tests passed）
- [x] 受入テスト（統合ブラウザ）
  - [x] 390x844: Top / Dashboard / History の表示確認
  - [x] 1280x900: Top / Dashboard / History の表示確認
  - [x] ローディング表示確認（`mobile-dashboard.png` でスケルトン表示を確認）

Closes #124
