### PR TITLE
麻雀の詳細な状況分析・メモ機能（分析ノート）を追加

### DIFF
--- a/docs/detailed-analysing.md
+++ b/docs/detailed-analysing.md
@@ -1,0 +1,322 @@
+# 詳細分析機能 仕様書
+
+> 自分の麻雀を局単位で振り返り、手牌・待ち形・役構成・ドラ等の詳細データを残せるようにし、将来的な分析（傾向把握・改善点抽出）の土台を作る。
+
+## 1. 目的・背景
+
+各和了イベント時に、手牌の状況、一発の有無、待ちの形（リャンメン／ペンチャン／カンチャン／シャボ／単騎／変則多面など）、ドラ・裏ドラ・カンドラ・カン裏ドラ、赤5枚数、手役、その他フリーテキストなどを構造化して記録できるようにする。和了時だけでなく、後で自由なタイミング（対局終了後を含む）で編集可能とする。
+
+本仕様書のスコープは **入力・閲覧・編集** までを Phase 1 として定義する。集計・グラフ等の本格的な「分析」機能は Phase 2 以降の別Issueで切り出す。
+
+## 2. スコープ
+
+### 2.1 対象モード
+
+- 通常対局（`rooms` コレクション）
+- 競技モード（`competitions` コレクション）
+
+### 2.2 記録対象イベント
+
+| イベント種別  | 説明                                                 |
+| ------------- | ---------------------------------------------------- |
+| `win`         | 自分の和了                                           |
+| `deal-in`     | 自分が放銃した局（他家和了。自分視点のメモを残す）   |
+| `tenpai-draw` | 自分が流局時テンパイだった局（聴牌手牌・待ちを記録） |
+
+- Phase 1 では新しいイベントを手動作成しない。既存の `HandLog` / 対局履歴に記録済みのイベントを選択し、そのイベントに対して `AnalysisEntry` を紐付けて作成する。
+- `AnalysisEntry.context.eventType` は選択した `HandLog` の内容から自動判定し、入力UI上での手動変更は不可とする。
+
+### 2.3 所有モデル
+
+- **個人専用**。`userAnalyses/{uid}/entries/{entryId}` のサブコレクションに格納し、本人以外からは閲覧・編集できない。
+- 同卓者の手牌・メモは原則記録対象外（自分視点のメモのみ）。
+
+### 2.4 スコープ外（Phase 1）
+
+- 集計・グラフ・他者比較
+- 共有／公開機能
+- AIによる自動牌姿読み取り
+- 旧 `HandLog` の自動マイグレーション（既存の和了に対しては「空のエントリを後から作成」で対応）
+
+## 3. データモデル
+
+### 3.1 Firestore コレクション
+
+```
+userAnalyses/{uid}/entries/{entryId}
+```
+
+### 3.2 ドキュメント構造（型: `AnalysisEntry`）
+
+`src/types/analysis.ts` を新設して以下を定義する。
+
+```ts
+export interface AnalysisEntry {
+  id: string;
+  uid: string; // オーナー。Firestore Rules で照合
+  source: AnalysisSource;
+  context: AnalysisContext;
+  hand: AnalysisHand;
+  dora: AnalysisDora;
+  yaku: AnalysisYaku;
+  notes: string; // フリーテキスト
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface AnalysisSource {
+  kind: 'room' | 'competition';
+  roomId?: string;
+  competitionId?: string;
+  gameResultId?: string; // 半荘単位のID
+  handLogId: string; // HandLog.id と紐付け
+}
+
+export interface AnalysisContext {
+  round: { wind: Wind; number: number; honba: number };
+  seatWind: Wind; // 自家風
+  roundWind: Wind; // 場風
+  eventType: 'win' | 'deal-in' | 'tenpai-draw'; // HandLog から自動決定
+  isDealer: boolean;
+}
+
+export interface AnalysisHand {
+  concealed: TileCode[]; // 手牌（門前部分）。13 または 14 枚
+  melds: Meld[]; // 鳴き
+  winningTile?: TileCode; // 和了牌（win / deal-in 時）
+  wait: WaitShape[]; // 複数選択可
+}
+
+export interface AnalysisDora {
+  doraIndicators: TileCode[];
+  uraIndicators: TileCode[];
+  kanDoraIndicators: TileCode[];
+  kanUraIndicators: TileCode[];
+  redFiveCount: number;
+}
+
+export interface AnalysisYaku {
+  list: YakuId[]; // 立直/平和/タンヤオ等
+  yakuman: YakumanId[]; // 国士/四暗刻/大三元等
+  ippatsu: boolean;
+  riichi: 'none' | 'normal' | 'double';
+  special: SpecialEnd | null; // 海底/河底/嶺上/槍槓
+  han?: number; // HandLog から自動同期、上書き可
+  fu?: number; // 同上
+}
+```
+
+### 3.3 補助型
+
+#### `TileCode`（MPSZ 表記）
+
+```ts
+export type TileCode =
+  | `${1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9}m`
+  | `${1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9}p`
+  | `${1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9}s`
+  | `${1 | 2 | 3 | 4 | 5 | 6 | 7}z`
+  | '0m'
+  | '0p'
+  | '0s'; // 0 は赤5
+```
+
+- 字牌の対応: `1z`=東 / `2z`=南 / `3z`=西 / `4z`=北 / `5z`=白 / `6z`=發 / `7z`=中。
+
+#### `Meld`
+
+```ts
+export type Meld =
+  | { kind: 'chi'; tiles: [TileCode, TileCode, TileCode]; from: 'kamicha' }
+  | { kind: 'pon'; tiles: [TileCode, TileCode, TileCode]; from: RelativePosition }
+  | { kind: 'minkan'; tiles: [TileCode, TileCode, TileCode, TileCode]; from: RelativePosition }
+  | { kind: 'ankan'; tiles: [TileCode, TileCode, TileCode, TileCode] };
+
+export type RelativePosition = 'kamicha' | 'toimen' | 'shimocha';
+```
+
+#### `WaitShape`
+
+```ts
+export type WaitShape =
+  | 'ryanmen'
+  | 'penchan'
+  | 'kanchan'
+  | 'shanpon'
+  | 'tanki'
+  | 'nobetan'
+  | 'sanmenchan'
+  | 'multi-other';
+```
+
+#### `YakuId` / `YakumanId` / `SpecialEnd`
+
+- `YakuId`: 立直／門前清自摸和／平和／タンヤオ／役牌（場風／自風／白／發／中）／一盃口／三色同順／一気通貫／混全帯么九／七対子／対々和／三暗刻／三色同刻／三槓子／小三元／混老頭／純全帯么九／混一色／二盃口／清一色／ダブル立直 等を列挙。
+- `YakumanId`: 国士無双（13面）／四暗刻（単騎）／大三元／小四喜／大四喜／字一色／緑一色／清老頭／九蓮宝燈（純正）／四槓子／天和／地和 等。
+- `SpecialEnd`: `'haitei' | 'houtei' | 'rinshan' | 'chankan'`。
+
+正式な enum 値の一覧は `src/types/analysis.ts` 内の `YAKU_DEFS` / `YAKUMAN_DEFS` 定数で日本語表示名と翻数付きで定義する。
+
+### 3.4 既存 `HandLog` への影響
+
+- `HandLog`（[src/types/index.ts](../src/types/index.ts)）の構造は **変更しない**。共有データを汚染せず、`AnalysisEntry.source.handLogId` で論理的に結合する。
+- 既存 HandLog から `han` / `fu` / `yaku 名称` が取得可能であれば、初回入力時の初期値として `AnalysisEntry` に流し込む（自動下書き）。
+
+## 4. 画面・UI
+
+### 4.1 共通モーダル `AnalysisDetailModal`
+
+モバイルファーストで縦スクロールの 1 画面構成。セクション順序:
+
+1. **対象イベント概要**: 局情報、和了/放銃/流局テンパイ種別、和了者/放銃者などを読み取り専用で表示
+2. **手牌入力**:
+   - 萬子 / 筒子 / 索子 / 字牌 のタブ切替
+   - 牌アイコンタップで追加、選択済み手牌の牌タップで削除
+   - 赤5トグル
+   - 13 枚 or 14 枚（鳴き含む）でのバリデーション
+3. **鳴き**: メルド追加ボタン → チー / ポン / 明槓 / 暗槓を選択 → 牌指定
+4. **和了牌**: `win` / `deal-in` 時のみ。手牌の中から1枚指定
+5. **待ち形**: チップ複数選択
+6. **ドラ**: 表ドラ / 裏ドラ / カン表 / カン裏 を別グループで指定。赤5枚数を数値入力
+7. **役**:
+   - 1飜 / 2飜 / 3飜 / 6飜 / 役満 のセクション分けチェックリスト
+   - 一発 / 海底 / 河底 / 嶺上 / 槍槓 / ダブル立直 / 立直 のトグル群
+8. **メモ**: テキストエリア（複数行、最大 2000 文字）
+9. **アクション**: 保存 / キャンセル / 削除（編集時のみ）
+
+### 4.2 バリデーション
+
+- 必須は **紐付け先イベントの選択** のみ。
+- 手牌枚数や役整合性は警告レベル（保存は可能、ハイライト表示）。
+- 段階的入力を許容し、未完成のままでも保存できる（後で追記する運用）。
+
+### 4.3 入力導線
+
+| 起点                                                    | 動作                                                                                                                                                                                                      |
+| ------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ScoringModal` 確定直後                                 | 和了履歴はこの時点で `HandLog` として作成済みであるため、`SnackbarContext` で「詳細分析を残しますか？」トーストを表示。タップで、直前に作成された `HandLog` に紐付いた `AnalysisDetailModal` を直接開く。 |
+| `MatchPage` / `CompetitionTablePage` の局履歴行         | 各 `HandLog` 行に「📝」アイコンを表示し、対象イベントに紐付く詳細入力モーダルを開く。                                                                                                                     |
+| `SessionDetailPage` / `CompetitionReportPage`           | 当該対局で発生したイベント一覧を表示し、クリックした `HandLog` に対する詳細入力・編集を行う。                                                                                                             |
+| 専用ページ `AnalysisListPage`（新設、パス `/analysis`） | 既存の `AnalysisEntry` 一覧を表示。行タップで読取モード起動、編集ボタンで編集モードに切替。                                                                                                               |
+
+### 4.4 対局後のイベント一覧導線
+
+- 対局終了後に詳細を入力する場合は、新規エントリを空で作成するのではなく、対象の対局に紐付く `HandLog` 一覧を先に表示する。
+- 一覧には、局情報、イベント種別、和了者、放銃者、点数移動の要約、既に `AnalysisEntry` が存在するかどうかを表示する。
+- ユーザーがイベントをクリックすると、その `HandLog` をコンテキストとして `AnalysisDetailModal` を開く。
+- 既に `AnalysisEntry` が存在する場合は編集モード、存在しない場合は新規作成モードで開く。
+- 一覧は少なくとも `SessionDetailPage` と `CompetitionReportPage` から利用できること。必要に応じて専用のイベント選択ダイアログとして共通化する。
+
+### 4.5 ナビゲーション
+
+- `TopPage` または `DashboardPage` の主要メニューに「分析ノート」エントリを追加し `/analysis` へ遷移。
+
+### 4.6 一覧ページ（Phase 1 簡易版）
+
+- 自分の `AnalysisEntry` を `updatedAt` 降順で表示。
+- 行表示: 日時 / モード（room/competition）/ 場風・局・本場 / イベント種別 / 役の先頭2件 / メモ冒頭。
+- フィルタは Phase 1 では「期間」「イベント種別」のみ。詳細フィルタ（役・待ち形）は Phase 2。
+
+## 5. 牌表示方針
+
+- Phase 1 では外部 SVG アセットは導入せず、`src/components/ui/TileImage.tsx` で牌コードから牌面を描画する CSS ベースの UI コンポーネントを採用する。
+- この方針により、追加の画像ライセンス表記や `docs/credits.md` の新設は不要とする。
+- 共通コンポーネント `src/components/ui/TileImage.tsx`:
+  - props: `code: TileCode`, `size?: 'sm' | 'md' | 'lg'`, `selected?: boolean`, `onClick?: () => void`
+  - CSS Modules + `src/visuals/tokens.css` のサイズトークンを使用。
+- 牌セレクタ用の配列ヘルパは `src/utils/tiles.ts` にまとめる。
+- 将来的に実画像アセットへ差し替える場合も、各画面からは `TileImage` を経由して利用することで差分を局所化する。
+
+## 6. データアクセス層
+
+### 6.1 サービス `src/services/analysisService.ts`
+
+```ts
+export function subscribeAnalysisEntries(
+  uid: string,
+  callback: (entries: AnalysisEntry[]) => void,
+): Unsubscribe;
+
+export function getAnalysisEntry(uid: string, entryId: string): Promise<AnalysisEntry | null>;
+
+export function findAnalysisEntryByHandLog(
+  uid: string,
+  source: AnalysisSource,
+): Promise<AnalysisEntry | null>;
+
+export function saveAnalysisEntry(uid: string, entry: AnalysisEntry): Promise<void>; // setDoc(..., { merge: true })
+
+export function deleteAnalysisEntry(uid: string, entryId: string): Promise<void>;
+```
+
+実装パターンは [src/services/userSettingsService.ts](../src/services/userSettingsService.ts) を踏襲する。
+
+### 6.2 フック
+
+- `src/hooks/useAnalysisEntries.ts` — `subscribeAnalysisEntries` でリアルタイム購読、配列で返却。
+- `src/hooks/useAnalysisEntry.ts` — 単一エントリの取得 + ドラフト編集状態管理。
+  - `react-hooks/set-state-in-effect` 対応として、props 同期を `useEffect` に書かず「draft state（null時はprops派生）」パターンを使う。
+
+## 7. Firestore セキュリティルール
+
+[firestore.rules](../firestore.rules) に以下を追記:
+
+```
+match /userAnalyses/{uid} {
+  match /entries/{entryId} {
+    allow read, write: if request.auth != null && request.auth.uid == uid;
+  }
+}
+```
+
+インデックスは `updatedAt desc` の単一フィールドで初期実装は十分。複合フィルタ追加時に `firestore.indexes.json` を更新する。
+
+## 8. 既存処理への影響
+
+- `HandLog` 型・既存サービスは変更しない。
+- `ScoringModal` の確定処理では、作成済み `HandLog` のIDを受け取って「成功時にトースト + 当該イベントへ紐付くモーダル起動候補を提示する」フックを追加する。
+- `MatchPage`, `CompetitionTablePage`, `SessionDetailPage`, `CompetitionReportPage` では、局履歴またはイベント一覧から `HandLog` 単位で詳細入力に遷移する共通導線を差し込む。
+
+## 9. 非機能要件
+
+- モバイルファースト。`mobile-portrait` 1画面で完結する操作性。
+- スタイルは CSS Modules + [src/visuals/tokens.css](../src/visuals/tokens.css) のトークンを使用。色・余白・フォントのハードコードは禁止。
+- 日本語UIコピー。
+- 1 エントリのドキュメントサイズは数KB想定。Firestore の 1MB 上限に十分収まる。
+- オフライン入力の対応は Phase 1 では行わない（オンライン前提）。
+
+## 10. テスト方針
+
+[docs/coding_guidelines.md](./coding_guidelines.md) と Vitest 既存設定に従う。
+
+| テスト対象 | ファイル                                    | 観点                                                         |
+| ---------- | ------------------------------------------- | ------------------------------------------------------------ |
+| サービス   | `analysisService.test.ts`                   | CRUD / サブスクリプション / Firestore モック                 |
+| ヘルパ     | `utils/tiles.test.ts`, `utils/yaku.test.ts` | TileCode 変換、役整合性                                      |
+| モーダル   | `AnalysisDetailModal.test.tsx`              | 牌選択 / メルド追加 / 役選択 / バリデーション / 保存呼び出し |
+| フック     | `useAnalysisEntry.test.ts`                  | ドラフト編集と props 派生（set-state-in-effect 回避）        |
+| ページ     | `AnalysisListPage.test.tsx`                 | 一覧表示 / フィルタ                                          |
+
+カバレッジ 80% 以上を維持。
+
+## 11. 段階リリース（参考、本仕様書外）
+
+| Phase | 内容                                                                            |
+| ----- | ------------------------------------------------------------------------------- |
+| 1     | データモデル + 入力モーダル + 各画面からの編集導線 + 一覧ページ簡易版 ←本仕様書 |
+| 2     | 一覧ページのフィルタ拡充、CSV エクスポート、役/待ち形の出現頻度集計             |
+| 3     | 放銃傾向グラフ、月次/年次レポート、共有モード                                   |
+
+## 12. オープン事項
+
+- 役 enum の最終リスト（ローカルルール役の扱い: 流し満貫など）。
+- HandLog から `AnalysisEntry` への自動下書き精度（既存 `ScorePayment.name` を解析するか、ScoringModal 入力値を直接渡すか）。
+
+---
+
+関連ドキュメント:
+
+- [docs/specification.md](./specification.md) — 製品全体仕様
+- [docs/internal_design.md](./internal_design.md) — 内部設計
+- [docs/coding_guidelines.md](./coding_guidelines.md) — コーディング規約
+- [docs/game_rules.md](./game_rules.md) — 採用ルール詳細

--- a/firebase.test.json
+++ b/firebase.test.json
@@ -1,0 +1,18 @@
+{
+  "firestore": {
+    "database": "(default)",
+    "location": "asia-northeast2",
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
+  },
+  "emulators": {
+    "firestore": {
+      "host": "127.0.0.1",
+      "port": 8780
+    },
+    "ui": {
+      "enabled": false
+    },
+    "singleProjectMode": true
+  }
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -160,5 +160,22 @@ service cloud.firestore {
     match /userSettings/{userId} {
       allow read, create, update, delete: if request.auth != null && request.auth.uid == userId;
     }
+
+    match /userAnalyses/{uid} {
+      match /entries/{entryId} {
+        allow read, delete: if request.auth != null && request.auth.uid == uid;
+        allow create: if request.auth != null
+          && request.auth.uid == uid
+          && request.resource.data.uid == uid
+          && request.resource.data.id == entryId
+          && request.resource.data.source.handLogId == entryId;
+        allow update: if request.auth != null
+          && request.auth.uid == uid
+          && resource.data.uid == uid
+          && request.resource.data.uid == uid
+          && request.resource.data.id == entryId
+          && request.resource.data.source.handLogId == entryId;
+      }
+    }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@firebase/rules-unit-testing": "^5.0.0",
         "@testing-library/react": "^16.3.2",
         "@types/node": "^25.5.2",
         "@types/react": "^19.2.14",
@@ -549,31 +550,6 @@
       },
       "peerDependencies": {
         "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1311,6 +1287,19 @@
       "integrity": "sha512-vI3bqLoF14L/GchtgayMiFpZJF+Ao3uR8WCde0XpYNkSokDpAKca2DxvcfeZv7lZUqkUwQPL2wD83d3vQ4vvrg==",
       "license": "Apache-2.0"
     },
+    "node_modules/@firebase/rules-unit-testing": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@firebase/rules-unit-testing/-/rules-unit-testing-5.0.0.tgz",
+      "integrity": "sha512-C6+d3Msgjnqay2ml663ChvKYoD8VsQ+TIa0e+fGq0LFC0CKSPlacT1EVGL/ryo6Rc+wFs7Fpqz3fRlYdUEa2bA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "firebase": "^12.0.0"
+      }
+    },
     "node_modules/@firebase/storage": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.14.2.tgz",
@@ -1984,6 +1973,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -3403,6 +3393,7 @@
       "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.12.0.tgz",
       "integrity": "sha512-5Ap+pN5iEJUvBlQEZEmLuUm7Gvu6I5xv1jZ5SiSNyw4jrwlHo+4tmZv3OPPoKfN9eo1kBwyyBvi+pWHIPXwfYw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/ai": "2.11.0",
         "@firebase/analytics": "0.10.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,14 +44,15 @@
       }
     },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.9.tgz",
-      "integrity": "sha512-zd9c/Wdso6v1U7v6w3i/hbAr4K7NaSHImdpvmLt+Y9ea5BhilnIGNkfhOJ7FEIuPipAnE9tZeDOll05WDT0kgg==",
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@csstools/css-calc": "^3.1.1",
-        "@csstools/css-color-parser": "^4.0.2",
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
         "@csstools/css-parser-algorithms": "^4.0.0",
         "@csstools/css-tokenizer": "^4.0.0"
       },
@@ -60,17 +61,28 @@
       }
     },
     "node_modules/@asamuzakjp/dom-selector": {
-      "version": "7.0.9",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.9.tgz",
-      "integrity": "sha512-r3ElRr7y8ucyN2KdICwGsmj19RoN13CLCa/pvGydghWK6ZzeKQ+TcDjVdtEZz2ElpndM5jXw//B9CEee0mWnVg==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.0.tgz",
+      "integrity": "sha512-ASf825+5vsGuYWoyFyNsex2mNtPTXpCvYTR942+w/eNw7PqS0Lhl/PE1hC7bajneI3m/Oxi+yrP3vTOPxfwM8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
         "@asamuzakjp/nwsapi": "^2.3.9",
         "bidi-js": "^1.0.3",
         "css-tree": "^3.2.1",
         "is-potential-custom-element-name": "^1.0.1"
       },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
@@ -377,9 +389,9 @@
       }
     },
     "node_modules/@csstools/css-calc": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
-      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
       "dev": true,
       "funding": [
         {
@@ -401,9 +413,9 @@
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
-      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
       "dev": true,
       "funding": [
         {
@@ -418,7 +430,7 @@
       "license": "MIT",
       "dependencies": {
         "@csstools/color-helpers": "^6.0.2",
-        "@csstools/css-calc": "^3.1.1"
+        "@csstools/css-calc": "^3.2.0"
       },
       "engines": {
         "node": ">=20.19.0"
@@ -453,9 +465,9 @@
       }
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.2.tgz",
-      "integrity": "sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
       "dev": true,
       "funding": [
         {
@@ -550,6 +562,31 @@
       },
       "peerDependencies": {
         "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1398,25 +1435,39 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }
@@ -1506,9 +1557,9 @@
       "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
-      "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1973,7 +2024,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -2001,17 +2051,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.1.tgz",
-      "integrity": "sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.2.tgz",
+      "integrity": "sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.58.1",
-        "@typescript-eslint/type-utils": "8.58.1",
-        "@typescript-eslint/utils": "8.58.1",
-        "@typescript-eslint/visitor-keys": "8.58.1",
+        "@typescript-eslint/scope-manager": "8.58.2",
+        "@typescript-eslint/type-utils": "8.58.2",
+        "@typescript-eslint/utils": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -2024,7 +2074,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.58.1",
+        "@typescript-eslint/parser": "^8.58.2",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -2040,17 +2090,17 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.1.tgz",
-      "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.2.tgz",
+      "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.58.1",
-        "@typescript-eslint/types": "8.58.1",
-        "@typescript-eslint/typescript-estree": "8.58.1",
-        "@typescript-eslint/visitor-keys": "8.58.1",
+        "@typescript-eslint/scope-manager": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2066,14 +2116,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.1.tgz",
-      "integrity": "sha512-gfQ8fk6cxhtptek+/8ZIqw8YrRW5048Gug8Ts5IYcMLCw18iUgrZAEY/D7s4hkI0FxEfGakKuPK/XUMPzPxi5g==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.2.tgz",
+      "integrity": "sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.58.1",
-        "@typescript-eslint/types": "^8.58.1",
+        "@typescript-eslint/tsconfig-utils": "^8.58.2",
+        "@typescript-eslint/types": "^8.58.2",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2088,14 +2138,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.1.tgz",
-      "integrity": "sha512-TPYUEqJK6avLcEjumWsIuTpuYODTTDAtoMdt8ZZa93uWMTX13Nb8L5leSje1NluammvU+oI3QRr5lLXPgihX3w==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.2.tgz",
+      "integrity": "sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.1",
-        "@typescript-eslint/visitor-keys": "8.58.1"
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2106,9 +2156,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.1.tgz",
-      "integrity": "sha512-JAr2hOIct2Q+qk3G+8YFfqkqi7sC86uNryT+2i5HzMa2MPjw4qNFvtjnw1IiA1rP7QhNKVe21mSSLaSjwA1Olw==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.2.tgz",
+      "integrity": "sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2123,15 +2173,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.1.tgz",
-      "integrity": "sha512-HUFxvTJVroT+0rXVJC7eD5zol6ID+Sn5npVPWoFuHGg9Ncq5Q4EYstqR+UOqaNRFXi5TYkpXXkLhoCHe3G0+7w==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.2.tgz",
+      "integrity": "sha512-Z7EloNR/B389FvabdGeTo2XMs4W9TjtPiO9DAsmT0yom0bwlPyRjkJ1uCdW1DvrrrYP50AJZ9Xc3sByZA9+dcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.1",
-        "@typescript-eslint/typescript-estree": "8.58.1",
-        "@typescript-eslint/utils": "8.58.1",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2",
+        "@typescript-eslint/utils": "8.58.2",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -2148,9 +2198,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.1.tgz",
-      "integrity": "sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
+      "integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2162,16 +2212,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.1.tgz",
-      "integrity": "sha512-w4w7WR7GHOjqqPnvAYbazq+Y5oS68b9CzasGtnd6jIeOIeKUzYzupGTB2T4LTPSv4d+WPeccbxuneTFHYgAAWg==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.2.tgz",
+      "integrity": "sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.58.1",
-        "@typescript-eslint/tsconfig-utils": "8.58.1",
-        "@typescript-eslint/types": "8.58.1",
-        "@typescript-eslint/visitor-keys": "8.58.1",
+        "@typescript-eslint/project-service": "8.58.2",
+        "@typescript-eslint/tsconfig-utils": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -2242,16 +2292,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.1.tgz",
-      "integrity": "sha512-Ln8R0tmWC7pTtLOzgJzYTXSCjJ9rDNHAqTaVONF4FEi2qwce8mD9iSOxOpLFFvWp/wBFlew0mjM1L1ihYWfBdQ==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.2.tgz",
+      "integrity": "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.58.1",
-        "@typescript-eslint/types": "8.58.1",
-        "@typescript-eslint/typescript-estree": "8.58.1"
+        "@typescript-eslint/scope-manager": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2266,13 +2316,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.1.tgz",
-      "integrity": "sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.2.tgz",
+      "integrity": "sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/types": "8.58.2",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -2602,9 +2652,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.17",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.17.tgz",
-      "integrity": "sha512-HdrkN8eVG2CXxeifv/VdJ4A4RSra1DTW8dc/hdxzhGHN8QePs6gKaWM9pHPcpCoxYZJuOZ8drHmbdpLHjCYjLA==",
+      "version": "2.10.19",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz",
+      "integrity": "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2625,9 +2675,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2681,9 +2731,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001787",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
-      "integrity": "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==",
+      "version": "1.0.30001788",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
+      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
       "dev": true,
       "funding": [
         {
@@ -3012,9 +3062,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.334",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.334.tgz",
-      "integrity": "sha512-mgjZAz7Jyx1SRCwEpy9wefDS7GvNPazLthHg8eQMJ76wBdGQQDW33TCrUTvQ4wzpmOrv2zrFoD3oNufMdyMpog==",
+      "version": "1.5.340",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz",
+      "integrity": "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==",
       "dev": true,
       "license": "ISC"
     },
@@ -3157,9 +3207,9 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
-      "integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3173,7 +3223,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-plugin-react-refresh": {
@@ -3507,9 +3557,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.4.0.tgz",
-      "integrity": "sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.5.0.tgz",
+      "integrity": "sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3784,9 +3834,9 @@
       }
     },
     "node_modules/jsdom/node_modules/lru-cache": {
-      "version": "11.3.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
-      "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -4568,9 +4618,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {
@@ -4607,9 +4657,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.2.tgz",
-      "integrity": "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -4668,9 +4718,9 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -4761,9 +4811,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.0.tgz",
-      "integrity": "sha512-m/xR9N4LQLmAS0ZhkY2nkPA1N7gQ5TUVa5n8TgANuDTARbn1gt+zLPXEm7W0XDTbrQ2AJSJKhoa6yx1D8BcpxQ==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.1.tgz",
+      "integrity": "sha512-5BCvFskyAAVumqhEKh/iPhLOIkfxcEUz8WqFIARCkMg8hZZzDYX9CtwxXA0e+qT8zAxmMC0x3Ckb9iMONwc5jg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -4783,12 +4833,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.0.tgz",
-      "integrity": "sha512-2G3ajSVSZMEtmTjIklRWlNvo8wICEpLihfD/0YMDxbWK2UyP5EGfnoIn9AIQGnF3G/FX0MRbHXdFcD+rL1ZreQ==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.1.tgz",
+      "integrity": "sha512-ZkrQuwwhGibjQLqH1eCdyiZyLWglPxzxdl5tgwgKEyCSGC76vmAjleGocRe3J/MLfzMUIKwaFJWpFVJhK3d2xA==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.14.0"
+        "react-router": "7.14.1"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -5038,9 +5088,9 @@
       "license": "MIT"
     },
     "node_modules/std-env": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
-      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -5256,9 +5306,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -5271,16 +5321,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.1.tgz",
-      "integrity": "sha512-gf6/oHChByg9HJvhMO1iBexJh12AqqTfnuxscMDOVqfJW3htsdRJI/GfPpHTTcyeB8cSTUY2JcZmVgoyPqcrDg==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.2.tgz",
+      "integrity": "sha512-V8iSng9mRbdZjl54VJ9NKr6ZB+dW0J3TzRXRGcSbLIej9jV86ZRtlYeTKDR/QLxXykocJ5icNzbsl2+5TzIvcQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.58.1",
-        "@typescript-eslint/parser": "8.58.1",
-        "@typescript-eslint/typescript-estree": "8.58.1",
-        "@typescript-eslint/utils": "8.58.1"
+        "@typescript-eslint/eslint-plugin": "8.58.2",
+        "@typescript-eslint/parser": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2",
+        "@typescript-eslint/utils": "8.58.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5295,9 +5345,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
-      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "lint": "eslint . --fix",
     "preview": "vite preview",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:rules": "node ./scripts/run-firestore-vitest.mjs run src/services/firestoreRules.test.ts --reporter=verbose",
+    "test:coverage:emulators": "node ./scripts/run-firestore-vitest.mjs run --coverage",
     "format": "prettier --write .",
     "check-format": "prettier --check .",
     "prepare": "husky"
@@ -34,6 +37,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@firebase/rules-unit-testing": "^5.0.0",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^25.5.2",
     "@types/react": "^19.2.14",

--- a/scripts/run-firestore-vitest.mjs
+++ b/scripts/run-firestore-vitest.mjs
@@ -1,0 +1,128 @@
+import net from 'node:net';
+import { once } from 'node:events';
+import { spawn } from 'node:child_process';
+
+const emulatorHost = '127.0.0.1';
+const emulatorPort = 8780;
+const projectId = 'demo-mahjong-point-manager';
+
+const waitForPort = (host, port, timeoutMs) => {
+  const startedAt = Date.now();
+
+  return new Promise((resolve, reject) => {
+    const tryConnect = () => {
+      const socket = net.createConnection({ host, port });
+
+      socket.once('connect', () => {
+        socket.end();
+        resolve();
+      });
+
+      socket.once('error', () => {
+        socket.destroy();
+
+        if (Date.now() - startedAt >= timeoutMs) {
+          reject(new Error(`Timed out waiting for Firestore emulator on ${host}:${port}`));
+          return;
+        }
+
+        setTimeout(tryConnect, 250);
+      });
+    };
+
+    tryConnect();
+  });
+};
+
+const killPortListeners = async (port) => {
+  const lsof = spawn('lsof', ['-ti', `tcp:${port}`], {
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+
+  let stdout = '';
+  lsof.stdout.on('data', (chunk) => {
+    stdout += chunk.toString();
+  });
+
+  await once(lsof, 'exit');
+
+  const pids = stdout
+    .split(/\s+/)
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .map((value) => Number.parseInt(value, 10))
+    .filter((value) => Number.isInteger(value) && value !== process.pid);
+
+  for (const pid of pids) {
+    try {
+      process.kill(pid, 'SIGKILL');
+    } catch {
+      // Ignore processes that already exited.
+    }
+  }
+};
+
+const stopChild = async (child) => {
+  if (!child || child.exitCode !== null) {
+    await killPortListeners(emulatorPort);
+    return;
+  }
+
+  child.kill('SIGINT');
+  await once(child, 'exit');
+  await killPortListeners(emulatorPort);
+};
+
+const emulator = spawn(
+  'firebase',
+  ['emulators:start', '--config', 'firebase.test.json', '--only', 'firestore'],
+  {
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      GCLOUD_PROJECT: projectId,
+    },
+  },
+);
+
+let shuttingDown = false;
+
+const shutdown = async (exitCode = 0) => {
+  if (shuttingDown) {
+    return;
+  }
+
+  shuttingDown = true;
+  await stopChild(emulator);
+  process.exit(exitCode);
+};
+
+process.on('SIGINT', () => {
+  void shutdown(130);
+});
+
+process.on('SIGTERM', () => {
+  void shutdown(143);
+});
+
+try {
+  await waitForPort(emulatorHost, emulatorPort, 30000);
+
+  const vitestArgs = process.argv.slice(2);
+  const vitest = spawn(process.execPath, ['./node_modules/vitest/vitest.mjs', ...vitestArgs], {
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      GCLOUD_PROJECT: projectId,
+      FIRESTORE_EMULATOR_HOST: `${emulatorHost}:${emulatorPort}`,
+    },
+  });
+
+  const [vitestExitCode] = await once(vitest, 'exit');
+  await stopChild(emulator);
+  process.exit(vitestExitCode ?? 1);
+} catch (error) {
+  console.error(error instanceof Error ? error.message : error);
+  await stopChild(emulator);
+  process.exit(1);
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,6 +54,9 @@ const CompetitionReportPage = lazy(() =>
     default: module.CompetitionReportPage,
   })),
 );
+const AnalysisListPage = lazy(() =>
+  import('./pages/AnalysisListPage').then((module) => ({ default: module.AnalysisListPage })),
+);
 const UserSettingsPage = lazy(() =>
   import('./pages/UserSettingsPage').then((module) => ({ default: module.UserSettingsPage })),
 );
@@ -117,6 +120,14 @@ function App() {
             element={
               <Suspense fallback={<div style={{ padding: 20 }}>Loading Session...</div>}>
                 <SessionDetailPage />
+              </Suspense>
+            }
+          />
+          <Route
+            path="/analysis"
+            element={
+              <Suspense fallback={<div style={{ padding: 20 }}>Loading Analysis...</div>}>
+                <AnalysisListPage />
               </Suspense>
             }
           />

--- a/src/components/features/AnalysisDetailModal.module.css
+++ b/src/components/features/AnalysisDetailModal.module.css
@@ -1,0 +1,210 @@
+.layout {
+  display: grid;
+  gap: var(--spacing-m);
+}
+
+.section {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: var(--border-radius-l);
+  background: rgba(255, 255, 255, 0.03);
+  padding: var(--spacing-m);
+}
+
+.warningSection {
+  border-color: rgba(244, 67, 54, 0.45);
+  background: rgba(244, 67, 54, 0.08);
+}
+
+.sectionHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-s);
+  margin-bottom: var(--spacing-s);
+}
+
+.sectionHeader h3,
+.fieldHeader h4 {
+  margin: 0;
+  color: var(--color-text-primary);
+  font-size: var(--font-size-m);
+}
+
+.modeBadge {
+  border-radius: 999px;
+  background: rgba(76, 175, 80, 0.16);
+  color: var(--color-primary);
+  padding: 2px 10px;
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+}
+
+.summaryGrid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--spacing-s);
+}
+
+.summaryLabel {
+  margin: 0 0 2px;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-xs);
+}
+
+.summaryValue {
+  margin: 0;
+  color: var(--color-text-primary);
+  font-size: var(--font-size-m);
+  word-break: break-word;
+}
+
+.warningLead {
+  margin: 0 0 var(--spacing-s);
+  color: #ffb4ab;
+}
+
+.warningList {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--color-text-primary);
+}
+
+.tileEditorGrid {
+  display: grid;
+  gap: var(--spacing-m);
+}
+
+.tileEditor {
+  display: grid;
+  gap: var(--spacing-s);
+}
+
+.fieldHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-s);
+}
+
+.fieldHeader span {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-xs);
+}
+
+.tileList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-xs);
+}
+
+.tileTag,
+.tileButton {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: var(--border-radius-m);
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--color-text-primary);
+  min-height: 40px;
+  min-width: 40px;
+  padding: 0 10px;
+  font-family: var(--font-mono);
+}
+
+.tilePalette {
+  display: grid;
+  gap: var(--spacing-xs);
+}
+
+.tilePaletteGroup {
+  display: grid;
+  gap: var(--spacing-xs);
+}
+
+.tilePaletteLabel {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-xs);
+}
+
+.tilePaletteButtons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-xs);
+}
+
+.emptyText {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-s);
+}
+
+.inlineField {
+  display: grid;
+  gap: var(--spacing-xs);
+  margin-top: var(--spacing-m);
+}
+
+.inputLabel,
+.textareaLabel {
+  color: var(--color-text-primary);
+  font-size: var(--font-size-s);
+}
+
+.numberInput,
+.textarea {
+  width: 100%;
+  border: 1px solid var(--color-text-secondary);
+  border-radius: var(--border-radius-m);
+  background: var(--color-bg-card);
+  color: var(--color-text-primary);
+  padding: 10px 12px;
+  font: inherit;
+  box-sizing: border-box;
+}
+
+.textarea {
+  resize: vertical;
+  min-height: 120px;
+}
+
+.numberInput:disabled,
+.textarea:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.numberInput:focus,
+.textarea:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 2px rgba(76, 175, 80, 0.2);
+}
+
+.actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-s);
+}
+
+.actionGroup {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-s);
+}
+
+@media (min-width: 768px) {
+  .summaryGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .tileEditorGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .actions {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .actionGroup {
+    flex-direction: row;
+  }
+}

--- a/src/components/features/AnalysisDetailModal.test.tsx
+++ b/src/components/features/AnalysisDetailModal.test.tsx
@@ -1,0 +1,217 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { AnalysisEntry } from '../../types';
+import { AnalysisDetailModal } from './AnalysisDetailModal';
+
+afterEach(() => {
+  cleanup();
+});
+
+const createAnalysisEntry = (
+  overrides: Partial<AnalysisEntry> = {},
+  nestedOverrides?: {
+    source?: Partial<AnalysisEntry['source']>;
+    context?: Partial<AnalysisEntry['context']>;
+    round?: Partial<AnalysisEntry['context']['round']>;
+    hand?: Partial<AnalysisEntry['hand']>;
+    dora?: Partial<AnalysisEntry['dora']>;
+    yaku?: Partial<AnalysisEntry['yaku']>;
+  },
+): AnalysisEntry => ({
+  id: 'analysis-1',
+  uid: 'user-1',
+  source: {
+    kind: 'room',
+    roomId: 'room-1',
+    handLogId: 'hand-1',
+    ...nestedOverrides?.source,
+  },
+  context: {
+    round: {
+      wind: 'East',
+      number: 1,
+      honba: 1,
+      ...nestedOverrides?.round,
+    },
+    seatWind: 'South',
+    roundWind: 'East',
+    eventType: 'win',
+    isDealer: false,
+    ...nestedOverrides?.context,
+  },
+  hand: {
+    concealed: ['2m', '3m'],
+    melds: [],
+    winningTile: '4m',
+    wait: [],
+    ...nestedOverrides?.hand,
+  },
+  dora: {
+    doraIndicators: [],
+    uraIndicators: [],
+    kanDoraIndicators: [],
+    kanUraIndicators: [],
+    redFiveCount: 0,
+    ...nestedOverrides?.dora,
+  },
+  yaku: {
+    list: [],
+    yakuman: [],
+    ippatsu: false,
+    riichi: 'none',
+    special: null,
+    han: 3,
+    fu: 40,
+    ...nestedOverrides?.yaku,
+  },
+  notes: '',
+  createdAt: 1000,
+  updatedAt: 2000,
+  ...overrides,
+});
+
+describe('AnalysisDetailModal', () => {
+  it('shows the target event summary', () => {
+    render(
+      <AnalysisDetailModal
+        isOpen
+        mode="create"
+        entry={createAnalysisEntry()}
+        onClose={() => undefined}
+        onSave={() => Promise.resolve()}
+      />,
+    );
+
+    expect(screen.getByText('東1局 1本場')).not.toBeNull();
+    expect(screen.getByText('イベント')).not.toBeNull();
+    expect(screen.getByText('和了')).not.toBeNull();
+    expect(screen.getByText('自風: 南')).not.toBeNull();
+    expect(screen.getByText('ソース: room / hand-1')).not.toBeNull();
+  });
+
+  it('does not render a winning tile editor for tenpai-draw', () => {
+    render(
+      <AnalysisDetailModal
+        isOpen
+        mode="create"
+        entry={createAnalysisEntry(
+          {},
+          {
+            context: { eventType: 'tenpai-draw' },
+            hand: { winningTile: undefined },
+          },
+        )}
+        onClose={() => undefined}
+        onSave={() => Promise.resolve()}
+      />,
+    );
+
+    expect(screen.queryByText('和了牌')).toBeNull();
+  });
+
+  it('saves tile, wait shape, yaku, and memo changes', async () => {
+    const handleSave = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <AnalysisDetailModal
+        isOpen
+        mode="create"
+        entry={createAnalysisEntry()}
+        onClose={() => undefined}
+        onSave={handleSave}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '手牌に1mを追加' }));
+    fireEvent.click(screen.getByRole('button', { name: '待ち形 両面' }));
+    fireEvent.click(screen.getByRole('checkbox', { name: '立直' }));
+    fireEvent.change(screen.getByLabelText('メモ'), {
+      target: { value: '良いリーチ判断だった' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '保存' }));
+
+    await waitFor(() => {
+      expect(handleSave).toHaveBeenCalledTimes(1);
+    });
+
+    const savedEntry = handleSave.mock.calls[0][0] as AnalysisEntry;
+    expect(savedEntry.hand.concealed).toContain('1m');
+    expect(savedEntry.hand.wait).toContain('ryanmen');
+    expect(savedEntry.yaku.list).toContain('riichi');
+    expect(savedEntry.notes).toBe('良いリーチ判断だった');
+  });
+
+  it('shows warnings for incomplete input but still allows saving', async () => {
+    const handleSave = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <AnalysisDetailModal
+        isOpen
+        mode="create"
+        entry={createAnalysisEntry(
+          {},
+          {
+            hand: {
+              concealed: [],
+              melds: [],
+              winningTile: undefined,
+              wait: [],
+            },
+          },
+        )}
+        onClose={() => undefined}
+        onSave={handleSave}
+      />,
+    );
+
+    expect(screen.getByText('入力は未完成ですが保存できます。')).not.toBeNull();
+    expect(screen.getByText('和了牌が未入力です')).not.toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: '保存' }));
+
+    await waitFor(() => {
+      expect(handleSave).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('allows deleting in edit mode', async () => {
+    const handleDelete = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <AnalysisDetailModal
+        isOpen
+        mode="edit"
+        entry={createAnalysisEntry()}
+        onClose={() => undefined}
+        onSave={() => Promise.resolve()}
+        onDelete={handleDelete}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '削除' }));
+
+    await waitFor(() => {
+      expect(handleDelete).toHaveBeenCalledWith(expect.objectContaining({ id: 'analysis-1' }));
+    });
+  });
+
+  it('is read only in view mode', () => {
+    render(
+      <AnalysisDetailModal
+        isOpen
+        mode="view"
+        entry={createAnalysisEntry()}
+        onClose={() => undefined}
+      />,
+    );
+
+    expect((screen.getByLabelText('メモ') as HTMLTextAreaElement).readOnly).toBe(true);
+    expect(
+      (screen.getByRole('button', { name: '手牌に1mを追加' }) as HTMLButtonElement).disabled,
+    ).toBe(true);
+    expect(screen.queryByRole('button', { name: '保存' })).toBeNull();
+    expect(screen.queryByRole('button', { name: '削除' })).toBeNull();
+  });
+});

--- a/src/components/features/AnalysisDetailModal.test.tsx
+++ b/src/components/features/AnalysisDetailModal.test.tsx
@@ -143,6 +143,47 @@ describe('AnalysisDetailModal', () => {
     expect(savedEntry.notes).toBe('良いリーチ判断だった');
   });
 
+  it('saves dora changes, removes deleted tiles, and persists red five count', async () => {
+    const handleSave = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <AnalysisDetailModal
+        isOpen
+        mode="create"
+        entry={createAnalysisEntry(
+          {},
+          {
+            hand: {
+              concealed: ['2m', '3m', '4m'],
+              winningTile: '2m',
+            },
+          },
+        )}
+        onClose={() => undefined}
+        onSave={handleSave}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'ドラ表示牌に1mを追加' }));
+    fireEvent.click(screen.getByRole('button', { name: 'ドラ表示牌から1mを削除' }));
+    fireEvent.click(screen.getByRole('button', { name: '裏ドラ表示牌に2pを追加' }));
+    fireEvent.click(screen.getByRole('button', { name: '槓ドラ表示牌に3sを追加' }));
+    fireEvent.change(screen.getByLabelText('赤5枚数'), {
+      target: { value: '2' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '保存' }));
+
+    await waitFor(() => {
+      expect(handleSave).toHaveBeenCalledTimes(1);
+    });
+
+    const savedEntry = handleSave.mock.calls[0][0] as AnalysisEntry;
+    expect(savedEntry.dora.doraIndicators).toEqual([]);
+    expect(savedEntry.dora.uraIndicators).toEqual(['2p']);
+    expect(savedEntry.dora.kanDoraIndicators).toEqual(['3s']);
+    expect(savedEntry.dora.redFiveCount).toBe(2);
+  });
+
   it('shows warnings for incomplete input but still allows saving', async () => {
     const handleSave = vi.fn().mockResolvedValue(undefined);
 
@@ -195,6 +236,68 @@ describe('AnalysisDetailModal', () => {
     await waitFor(() => {
       expect(handleDelete).toHaveBeenCalledWith(expect.objectContaining({ id: 'analysis-1' }));
     });
+  });
+
+  it('disables editing controls while busy', () => {
+    render(
+      <AnalysisDetailModal
+        isOpen
+        mode="edit"
+        entry={createAnalysisEntry()}
+        isSaving
+        onClose={() => undefined}
+        onSave={() => Promise.resolve()}
+        onDelete={() => Promise.resolve()}
+      />,
+    );
+
+    expect((screen.getByRole('button', { name: '削除' }) as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByRole('button', { name: 'キャンセル' }) as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+    expect((screen.getByRole('button', { name: '保存中...' }) as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+    expect(
+      (screen.getByRole('button', { name: '手牌に1mを追加' }) as HTMLButtonElement).disabled,
+    ).toBe(true);
+    expect((screen.getByLabelText('赤5枚数') as HTMLInputElement).disabled).toBe(true);
+    expect((screen.getByLabelText('メモ') as HTMLTextAreaElement).disabled).toBe(true);
+  });
+
+  it('shows a winning tile selector for deal-in entries and saves the selected tile', async () => {
+    const handleSave = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <AnalysisDetailModal
+        isOpen
+        mode="create"
+        entry={createAnalysisEntry(
+          {},
+          {
+            context: { eventType: 'deal-in' },
+            hand: {
+              concealed: ['2m', '3m', '4m'],
+              winningTile: undefined,
+            },
+          },
+        )}
+        onClose={() => undefined}
+        onSave={handleSave}
+      />,
+    );
+
+    expect(screen.getByText('和了牌')).not.toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: '和了牌に2mを設定' }));
+    fireEvent.click(screen.getByRole('button', { name: '保存' }));
+
+    await waitFor(() => {
+      expect(handleSave).toHaveBeenCalledTimes(1);
+    });
+
+    const savedEntry = handleSave.mock.calls[0][0] as AnalysisEntry;
+    expect(savedEntry.hand.winningTile).toBe('2m');
   });
 
   it('is read only in view mode', () => {

--- a/src/components/features/AnalysisDetailModal.tsx
+++ b/src/components/features/AnalysisDetailModal.tsx
@@ -1,0 +1,558 @@
+import { useMemo, useState } from 'react';
+import type { AnalysisDora, AnalysisEntry, Meld, TileCode } from '../../types';
+import { TILE_GROUPS } from '../../utils/tiles';
+import { Button } from '../ui/Button';
+import { Modal } from '../ui/Modal';
+import { TileImage } from '../ui/TileImage';
+import { HandInputSection } from './analysis/HandInputSection';
+import { MeldEditor } from './analysis/MeldEditor';
+import { WaitShapeSelector } from './analysis/WaitShapeSelector';
+import { YakuSelector } from './analysis/YakuSelector';
+import styles from './AnalysisDetailModal.module.css';
+
+export type AnalysisDetailMode = 'create' | 'edit' | 'view';
+
+interface AnalysisDetailModalProps {
+  isOpen: boolean;
+  mode: AnalysisDetailMode;
+  entry: AnalysisEntry;
+  isSaving?: boolean;
+  isDeleting?: boolean;
+  onClose: () => void;
+  onSave?: (entry: AnalysisEntry) => Promise<void> | void;
+  onDelete?: (entry: AnalysisEntry) => Promise<void> | void;
+}
+
+const EVENT_LABELS: Record<AnalysisEntry['context']['eventType'], string> = {
+  win: '和了',
+  'deal-in': '放銃',
+  'tenpai-draw': 'テンパイ流局',
+};
+
+const WIND_LABELS: Record<AnalysisEntry['context']['round']['wind'], string> = {
+  East: '東',
+  South: '南',
+  West: '西',
+  North: '北',
+};
+
+const SPECIAL_LABELS: Record<NonNullable<AnalysisEntry['yaku']['special']>, string> = {
+  haitei: '海底',
+  houtei: '河底',
+  rinshan: '嶺上開花',
+  chankan: '槍槓',
+};
+
+const cloneMeld = (meld: Meld): Meld => {
+  switch (meld.kind) {
+    case 'chi':
+    case 'pon':
+      return {
+        ...meld,
+        tiles: [...meld.tiles] as typeof meld.tiles,
+      };
+    case 'minkan':
+    case 'ankan':
+      return {
+        ...meld,
+        tiles: [...meld.tiles] as typeof meld.tiles,
+      };
+  }
+};
+
+const cloneEntry = (entry: AnalysisEntry): AnalysisEntry => ({
+  ...entry,
+  source: { ...entry.source },
+  context: {
+    ...entry.context,
+    round: { ...entry.context.round },
+  },
+  hand: {
+    concealed: [...entry.hand.concealed],
+    melds: entry.hand.melds.map(cloneMeld),
+    ...(entry.hand.winningTile ? { winningTile: entry.hand.winningTile } : {}),
+    wait: [...entry.hand.wait],
+  },
+  dora: {
+    doraIndicators: [...entry.dora.doraIndicators],
+    uraIndicators: [...entry.dora.uraIndicators],
+    kanDoraIndicators: [...entry.dora.kanDoraIndicators],
+    kanUraIndicators: [...entry.dora.kanUraIndicators],
+    redFiveCount: entry.dora.redFiveCount,
+  },
+  yaku: {
+    ...entry.yaku,
+    list: [...entry.yaku.list],
+    yakuman: [...entry.yaku.yakuman],
+  },
+});
+
+const getEntryIdentity = (entry: AnalysisEntry) => {
+  return [entry.id, entry.source.kind, entry.source.handLogId].join(':');
+};
+
+const getTileCount = (entry: AnalysisEntry) => {
+  const meldTileCount = entry.hand.melds.reduce((total, meld) => total + meld.tiles.length, 0);
+  return entry.hand.concealed.length + meldTileCount;
+};
+
+const getWarnings = (entry: AnalysisEntry): string[] => {
+  const warnings: string[] = [];
+  const tileCount = getTileCount(entry);
+  const expectedTileCount = entry.context.eventType === 'tenpai-draw' ? 13 : 14;
+
+  if (tileCount === 0) {
+    warnings.push('手牌が未入力です');
+  }
+
+  if (entry.context.eventType !== 'tenpai-draw' && !entry.hand.winningTile) {
+    warnings.push('和了牌が未入力です');
+  }
+
+  if (
+    entry.context.eventType !== 'tenpai-draw' &&
+    entry.hand.winningTile &&
+    !entry.hand.concealed.includes(entry.hand.winningTile)
+  ) {
+    warnings.push('和了牌は手牌内の牌から選択してください');
+  }
+
+  if (tileCount > 0 && tileCount !== expectedTileCount) {
+    warnings.push(`牌数が ${tileCount} 枚です（目安: ${expectedTileCount} 枚）`);
+  }
+
+  return warnings;
+};
+
+const updateTileList = (tiles: TileCode[], tile: TileCode): TileCode[] => {
+  return [...tiles, tile];
+};
+
+const removeTileAt = (tiles: TileCode[], index: number): TileCode[] => {
+  return tiles.filter((_, currentIndex) => currentIndex !== index);
+};
+
+interface TileCollectionEditorProps {
+  label: string;
+  tiles: TileCode[];
+  readOnly: boolean;
+  onAdd: (tile: TileCode) => void;
+  onRemove: (index: number) => void;
+}
+
+const TileCollectionEditor = ({
+  label,
+  tiles,
+  readOnly,
+  onAdd,
+  onRemove,
+}: TileCollectionEditorProps) => {
+  return (
+    <div className={styles.tileEditor}>
+      <div className={styles.fieldHeader}>
+        <h4>{label}</h4>
+        <span>{tiles.length}枚</span>
+      </div>
+      <div className={styles.tileList}>
+        {tiles.length === 0 ? <span className={styles.emptyText}>未入力</span> : null}
+        {tiles.map((tile, index) => (
+          <TileImage
+            key={`${label}-${tile}-${index}`}
+            code={tile}
+            size="sm"
+            selected
+            onClick={() => onRemove(index)}
+            disabled={readOnly}
+            ariaLabel={`${label}から${tile}を削除`}
+          />
+        ))}
+      </div>
+      <div className={styles.tilePalette}>
+        {TILE_GROUPS.map((group) => (
+          <div key={group.label} className={styles.tilePaletteGroup}>
+            <span className={styles.tilePaletteLabel}>{group.label}</span>
+            <div className={styles.tilePaletteButtons}>
+              {group.tiles.map((tile) => (
+                <TileImage
+                  key={`${label}-${tile}`}
+                  code={tile}
+                  size="sm"
+                  onClick={() => onAdd(tile)}
+                  disabled={readOnly}
+                  ariaLabel={`${label}に${tile}を追加`}
+                />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+interface AnalysisDetailModalContentProps extends AnalysisDetailModalProps {
+  entryIdentity: string;
+}
+
+const AnalysisDetailModalContent = ({
+  isOpen,
+  mode,
+  entry,
+  isSaving = false,
+  isDeleting = false,
+  onClose,
+  onSave,
+  onDelete,
+}: AnalysisDetailModalContentProps) => {
+  const [draft, setDraft] = useState<AnalysisEntry>(() => cloneEntry(entry));
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isRemoving, setIsRemoving] = useState(false);
+  const readOnly = mode === 'view';
+
+  const warnings = useMemo(() => getWarnings(draft), [draft]);
+
+  const isBusy = isSaving || isDeleting || isSubmitting || isRemoving;
+
+  const updateDraft = (updater: (current: AnalysisEntry) => AnalysisEntry) => {
+    setDraft((current) => updater(current));
+  };
+
+  const updateDoraSection = (key: keyof AnalysisDora, nextTiles: TileCode[]) => {
+    updateDraft((current) => ({
+      ...current,
+      dora: {
+        ...current.dora,
+        [key]: nextTiles,
+      },
+    }));
+  };
+
+  const handleClose = () => {
+    if (isBusy) {
+      return;
+    }
+
+    setDraft(cloneEntry(entry));
+    onClose();
+  };
+
+  const handleSave = async () => {
+    if (readOnly || !onSave || isBusy) {
+      return;
+    }
+
+    const nextEntry = cloneEntry({
+      ...draft,
+      hand: {
+        ...draft.hand,
+        ...(draft.context.eventType === 'tenpai-draw'
+          ? { winningTile: undefined }
+          : draft.hand.winningTile && draft.hand.concealed.includes(draft.hand.winningTile)
+            ? { winningTile: draft.hand.winningTile }
+            : {}),
+      },
+      notes: draft.notes.trim(),
+    });
+
+    setIsSubmitting(true);
+    try {
+      await onSave(nextEntry);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (mode !== 'edit' || !onDelete || isBusy) {
+      return;
+    }
+
+    setIsRemoving(true);
+    try {
+      await onDelete(cloneEntry(draft));
+    } finally {
+      setIsRemoving(false);
+    }
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={handleClose}
+      title={mode === 'create' ? '分析メモを作成' : mode === 'edit' ? '分析メモを編集' : '分析メモ'}
+      width="min(960px, calc(100vw - 16px))"
+    >
+      <div className={styles.layout}>
+        <section className={styles.section}>
+          <div className={styles.sectionHeader}>
+            <h3>対象イベント概要</h3>
+            <span className={styles.modeBadge}>{mode}</span>
+          </div>
+          <div className={styles.summaryGrid}>
+            <div>
+              <p className={styles.summaryLabel}>局面</p>
+              <p className={styles.summaryValue}>
+                {WIND_LABELS[draft.context.round.wind]}
+                {draft.context.round.number}局 {draft.context.round.honba}本場
+              </p>
+            </div>
+            <div>
+              <p className={styles.summaryLabel}>イベント</p>
+              <p className={styles.summaryValue}>{EVENT_LABELS[draft.context.eventType]}</p>
+            </div>
+            <div>
+              <p className={styles.summaryLabel}>自風</p>
+              <p className={styles.summaryValue}>自風: {WIND_LABELS[draft.context.seatWind]}</p>
+            </div>
+            <div>
+              <p className={styles.summaryLabel}>場風</p>
+              <p className={styles.summaryValue}>{WIND_LABELS[draft.context.roundWind]}</p>
+            </div>
+            <div>
+              <p className={styles.summaryLabel}>ソース</p>
+              <p className={styles.summaryValue}>
+                ソース: {draft.source.kind} / {draft.source.handLogId}
+              </p>
+            </div>
+            <div>
+              <p className={styles.summaryLabel}>打点メモ</p>
+              <p className={styles.summaryValue}>
+                {draft.yaku.han ? `${draft.yaku.han}翻` : '翻数未入力'}
+                {' / '}
+                {draft.yaku.fu ? `${draft.yaku.fu}符` : '符未入力'}
+                {' / '}
+                {draft.yaku.special ? SPECIAL_LABELS[draft.yaku.special] : '通常'}
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {warnings.length > 0 ? (
+          <section className={`${styles.section} ${styles.warningSection}`}>
+            <div className={styles.sectionHeader}>
+              <h3>警告</h3>
+            </div>
+            <p className={styles.warningLead}>入力は未完成ですが保存できます。</p>
+            <ul className={styles.warningList}>
+              {warnings.map((warning) => (
+                <li key={warning}>{warning}</li>
+              ))}
+            </ul>
+          </section>
+        ) : null}
+
+        <HandInputSection
+          concealed={draft.hand.concealed}
+          winningTile={draft.hand.winningTile}
+          eventType={draft.context.eventType}
+          readOnly={readOnly || isBusy}
+          onConcealedChange={(concealed) => {
+            updateDraft((current) => ({
+              ...current,
+              hand: {
+                ...current.hand,
+                concealed,
+              },
+            }));
+          }}
+          onWinningTileChange={(winningTile) => {
+            updateDraft((current) => ({
+              ...current,
+              hand: {
+                ...current.hand,
+                ...(winningTile ? { winningTile } : { winningTile: undefined }),
+              },
+            }));
+          }}
+        />
+
+        <MeldEditor
+          melds={draft.hand.melds}
+          readOnly={readOnly || isBusy}
+          onChange={(melds) => {
+            updateDraft((current) => ({
+              ...current,
+              hand: {
+                ...current.hand,
+                melds,
+              },
+            }));
+          }}
+        />
+
+        <section className={styles.section}>
+          <div className={styles.sectionHeader}>
+            <h3>待ち形</h3>
+          </div>
+          <WaitShapeSelector
+            selected={draft.hand.wait}
+            readOnly={readOnly || isBusy}
+            onChange={(wait) => {
+              updateDraft((current) => ({
+                ...current,
+                hand: {
+                  ...current.hand,
+                  wait,
+                },
+              }));
+            }}
+          />
+        </section>
+
+        <section className={styles.section}>
+          <div className={styles.sectionHeader}>
+            <h3>ドラ</h3>
+          </div>
+          <div className={styles.tileEditorGrid}>
+            <TileCollectionEditor
+              label="ドラ表示牌"
+              tiles={draft.dora.doraIndicators}
+              readOnly={readOnly || isBusy}
+              onAdd={(tile) =>
+                updateDoraSection('doraIndicators', updateTileList(draft.dora.doraIndicators, tile))
+              }
+              onRemove={(index) =>
+                updateDoraSection('doraIndicators', removeTileAt(draft.dora.doraIndicators, index))
+              }
+            />
+            <TileCollectionEditor
+              label="裏ドラ表示牌"
+              tiles={draft.dora.uraIndicators}
+              readOnly={readOnly || isBusy}
+              onAdd={(tile) =>
+                updateDoraSection('uraIndicators', updateTileList(draft.dora.uraIndicators, tile))
+              }
+              onRemove={(index) =>
+                updateDoraSection('uraIndicators', removeTileAt(draft.dora.uraIndicators, index))
+              }
+            />
+            <TileCollectionEditor
+              label="槓ドラ表示牌"
+              tiles={draft.dora.kanDoraIndicators}
+              readOnly={readOnly || isBusy}
+              onAdd={(tile) =>
+                updateDoraSection(
+                  'kanDoraIndicators',
+                  updateTileList(draft.dora.kanDoraIndicators, tile),
+                )
+              }
+              onRemove={(index) =>
+                updateDoraSection(
+                  'kanDoraIndicators',
+                  removeTileAt(draft.dora.kanDoraIndicators, index),
+                )
+              }
+            />
+            <TileCollectionEditor
+              label="槓裏ドラ表示牌"
+              tiles={draft.dora.kanUraIndicators}
+              readOnly={readOnly || isBusy}
+              onAdd={(tile) =>
+                updateDoraSection(
+                  'kanUraIndicators',
+                  updateTileList(draft.dora.kanUraIndicators, tile),
+                )
+              }
+              onRemove={(index) =>
+                updateDoraSection(
+                  'kanUraIndicators',
+                  removeTileAt(draft.dora.kanUraIndicators, index),
+                )
+              }
+            />
+          </div>
+          <div className={styles.inlineField}>
+            <label className={styles.inputLabel} htmlFor="analysis-red-five-count">
+              赤5枚数
+            </label>
+            <input
+              id="analysis-red-five-count"
+              className={styles.numberInput}
+              type="number"
+              min={0}
+              value={draft.dora.redFiveCount}
+              onChange={(event) => {
+                const nextValue = Number.parseInt(event.target.value, 10);
+                updateDraft((current) => ({
+                  ...current,
+                  dora: {
+                    ...current.dora,
+                    redFiveCount: Number.isFinite(nextValue) && nextValue >= 0 ? nextValue : 0,
+                  },
+                }));
+              }}
+              disabled={readOnly || isBusy}
+            />
+          </div>
+        </section>
+
+        <section className={styles.section}>
+          <div className={styles.sectionHeader}>
+            <h3>役</h3>
+          </div>
+          <YakuSelector
+            value={draft.yaku}
+            readOnly={readOnly || isBusy}
+            onChange={(yaku) => {
+              updateDraft((current) => ({
+                ...current,
+                yaku,
+              }));
+            }}
+          />
+        </section>
+
+        <section className={styles.section}>
+          <div className={styles.sectionHeader}>
+            <h3>メモ</h3>
+          </div>
+          <label className={styles.textareaLabel} htmlFor="analysis-notes">
+            メモ
+          </label>
+          <textarea
+            id="analysis-notes"
+            className={styles.textarea}
+            value={draft.notes}
+            onChange={(event) => {
+              updateDraft((current) => ({
+                ...current,
+                notes: event.target.value,
+              }));
+            }}
+            rows={5}
+            readOnly={readOnly}
+            disabled={isBusy}
+            aria-label="メモ"
+            placeholder="気づきや打牌理由を残す"
+          />
+        </section>
+
+        <div className={styles.actions}>
+          {mode === 'edit' && onDelete ? (
+            <Button variant="danger" onClick={handleDelete} disabled={isBusy}>
+              {isRemoving || isDeleting ? '削除中...' : '削除'}
+            </Button>
+          ) : null}
+          <div className={styles.actionGroup}>
+            <Button variant="secondary" onClick={handleClose} disabled={isBusy}>
+              {readOnly ? '閉じる' : 'キャンセル'}
+            </Button>
+            {!readOnly && onSave ? (
+              <Button variant="primary" onClick={handleSave} disabled={isBusy}>
+                {isSubmitting || isSaving ? '保存中...' : '保存'}
+              </Button>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export const AnalysisDetailModal = (props: AnalysisDetailModalProps) => {
+  const entryIdentity = getEntryIdentity(props.entry);
+
+  return (
+    <AnalysisDetailModalContent key={entryIdentity} entryIdentity={entryIdentity} {...props} />
+  );
+};

--- a/src/components/features/AnalysisEventList.module.css
+++ b/src/components/features/AnalysisEventList.module.css
@@ -1,0 +1,116 @@
+.list {
+  display: grid;
+  gap: var(--spacing-s);
+}
+
+.empty {
+  padding: var(--spacing-l);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--border-radius-m);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--color-text-secondary);
+  text-align: center;
+}
+
+.item {
+  display: grid;
+  gap: var(--spacing-xs);
+  width: 100%;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: var(--border-radius-m);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--color-text-primary);
+  padding: var(--spacing-m);
+  text-align: left;
+}
+
+.item:hover {
+  border-color: rgba(76, 175, 80, 0.4);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-s);
+}
+
+.title {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-s);
+  flex-wrap: wrap;
+}
+
+.round {
+  font-size: var(--font-size-m);
+  font-weight: var(--font-weight-bold);
+}
+
+.eventBadge,
+.entryBadge {
+  border-radius: 999px;
+  padding: 2px 10px;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
+}
+
+.eventBadge {
+  background: rgba(76, 175, 80, 0.16);
+  color: var(--color-text-accent);
+}
+
+.entrySaved {
+  background: rgba(33, 150, 243, 0.18);
+  color: var(--color-info);
+}
+
+.entryMissing {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--color-text-secondary);
+}
+
+.meta,
+.summaryRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-s);
+}
+
+.meta {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-s);
+}
+
+.summary {
+  font-size: var(--font-size-m);
+}
+
+.score {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-s);
+  font-weight: var(--font-weight-bold);
+}
+
+.positive {
+  color: var(--color-success);
+}
+
+.negative {
+  color: var(--color-danger);
+}
+
+.zero {
+  color: var(--color-text-secondary);
+}
+
+@media (max-width: 600px) {
+  .header,
+  .meta,
+  .summaryRow {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/src/components/features/AnalysisEventList.test.tsx
+++ b/src/components/features/AnalysisEventList.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { HandLog } from '../../types';
+import type { AnalysisEventSummary } from '../../utils/analysisEvents';
+import { AnalysisEventList } from './AnalysisEventList';
+import styles from './AnalysisEventList.module.css';
+
+afterEach(() => {
+  cleanup();
+});
+
+const baseHandLog: HandLog = {
+  id: 'hand-1',
+  timestamp: 1710000000000,
+  round: {
+    wind: 'East',
+    number: 1,
+    honba: 0,
+    riichiSticks: 0,
+  },
+  result: {
+    type: 'Win',
+    winners: [
+      {
+        id: 'player-1',
+        payment: {
+          basePoints: 2000,
+          name: '40符3翻',
+          ron: 7700,
+        },
+      },
+    ],
+    loserId: 'player-2',
+    scoreDeltas: {
+      'player-1': 7700,
+      'player-2': -7700,
+    },
+  },
+};
+
+const createEvent = ({
+  id = 'event-1',
+  handLogId = 'hand-1',
+  eventLabel = '和了',
+  roundLabel = '東1局 0本場',
+  locationLabel = '第1戦',
+  summary = '対面から和了',
+  scoreDeltaLabel = '+7,700',
+}: {
+  id?: string;
+  handLogId?: string;
+  eventLabel?: string;
+  roundLabel?: string;
+  locationLabel?: string;
+  summary?: string;
+  scoreDeltaLabel?: string;
+} = {}): AnalysisEventSummary => ({
+  id,
+  source: {
+    kind: 'room',
+    roomId: 'room-1',
+    handLogId,
+  },
+  handLog: {
+    ...baseHandLog,
+    id: handLogId,
+  },
+  players: [
+    { id: 'player-1', name: '自分', wind: 'East' },
+    { id: 'player-2', name: '対面', wind: 'South' },
+  ],
+  eventType: eventLabel === '放銃' ? 'deal-in' : 'win',
+  eventLabel,
+  roundLabel,
+  locationLabel,
+  summary,
+  scoreDeltaLabel,
+  timestamp: 1710000000000,
+});
+
+describe('AnalysisEventList', () => {
+  it('renders the empty state message', () => {
+    render(
+      <AnalysisEventList
+        events={[]}
+        emptyMessage="保存済みの分析イベントはありません。"
+        onSelect={vi.fn()}
+      />,
+    );
+
+    const emptyState = screen.getByText('保存済みの分析イベントはありません。');
+    expect(emptyState.className).toContain(styles.empty);
+  });
+
+  it('renders saved badges, score classes, and calls onSelect', () => {
+    const handleSelect = vi.fn();
+    const savedEvent = createEvent();
+    const negativeEvent = createEvent({
+      id: 'event-2',
+      handLogId: 'hand-2',
+      eventLabel: '放銃',
+      roundLabel: '東2局 0本場',
+      summary: '自分が放銃',
+      scoreDeltaLabel: '-1,000',
+    });
+    const zeroEvent = createEvent({
+      id: 'event-3',
+      handLogId: 'hand-3',
+      roundLabel: '東3局 0本場',
+      summary: '移動なし',
+      scoreDeltaLabel: '0',
+    });
+
+    render(
+      <AnalysisEventList
+        events={[savedEvent, negativeEvent, zeroEvent]}
+        savedHandLogIds={new Set(['hand-1'])}
+        onSelect={handleSelect}
+      />,
+    );
+
+    expect(screen.getByText('ノートあり')).not.toBeNull();
+    expect(screen.getAllByText('未入力')).toHaveLength(2);
+    expect(screen.getByText('+7,700').className).toContain(styles.positive);
+    expect(screen.getByText('-1,000').className).toContain(styles.negative);
+    expect(screen.getByText('0').className).toContain(styles.zero);
+
+    fireEvent.click(screen.getByRole('button', { name: '東1局 0本場 和了' }));
+
+    expect(handleSelect).toHaveBeenCalledTimes(1);
+    expect(handleSelect).toHaveBeenCalledWith(savedEvent);
+  });
+});

--- a/src/components/features/AnalysisEventList.tsx
+++ b/src/components/features/AnalysisEventList.tsx
@@ -1,0 +1,71 @@
+import type { AnalysisEventSummary } from '../../utils/analysisEvents';
+import styles from './AnalysisEventList.module.css';
+
+interface AnalysisEventListProps {
+  events: AnalysisEventSummary[];
+  savedHandLogIds?: Set<string>;
+  emptyMessage?: string;
+  onSelect: (event: AnalysisEventSummary) => void;
+}
+
+const getScoreClassName = (scoreDeltaLabel: string): string => {
+  if (scoreDeltaLabel.startsWith('+')) {
+    return styles.positive;
+  }
+
+  if (scoreDeltaLabel.startsWith('-')) {
+    return styles.negative;
+  }
+
+  return styles.zero;
+};
+
+export const AnalysisEventList = ({
+  events,
+  savedHandLogIds,
+  emptyMessage = '分析対象のイベントはありません。',
+  onSelect,
+}: AnalysisEventListProps) => {
+  if (events.length === 0) {
+    return <div className={styles.empty}>{emptyMessage}</div>;
+  }
+
+  return (
+    <div className={styles.list}>
+      {events.map((event) => {
+        const hasEntry = savedHandLogIds?.has(event.source.handLogId) ?? false;
+
+        return (
+          <button
+            key={event.id}
+            type="button"
+            className={styles.item}
+            onClick={() => onSelect(event)}
+            aria-label={`${event.roundLabel} ${event.eventLabel}`}
+          >
+            <div className={styles.header}>
+              <div className={styles.title}>
+                <span className={styles.round}>{event.roundLabel}</span>
+                <span className={styles.eventBadge}>{event.eventLabel}</span>
+              </div>
+              <span
+                className={`${styles.entryBadge} ${hasEntry ? styles.entrySaved : styles.entryMissing}`}
+              >
+                {hasEntry ? 'ノートあり' : '未入力'}
+              </span>
+            </div>
+            <div className={styles.meta}>
+              <span>{event.locationLabel}</span>
+              <span className={`${styles.score} ${getScoreClassName(event.scoreDeltaLabel)}`}>
+                {event.scoreDeltaLabel}
+              </span>
+            </div>
+            <div className={styles.summaryRow}>
+              <span className={styles.summary}>{event.summary}</span>
+            </div>
+          </button>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/components/features/AnalysisEventModalLauncher.module.css
+++ b/src/components/features/AnalysisEventModalLauncher.module.css
@@ -1,0 +1,5 @@
+.loadingState {
+  padding: var(--spacing-l);
+  color: var(--color-text-secondary);
+  text-align: center;
+}

--- a/src/components/features/AnalysisEventModalLauncher.test.tsx
+++ b/src/components/features/AnalysisEventModalLauncher.test.tsx
@@ -65,6 +65,7 @@ afterEach(() => {
 });
 
 const mockUseAnalysisEntry = vi.mocked(useAnalysisEntry);
+type UseAnalysisEntryResult = ReturnType<typeof useAnalysisEntry>;
 
 const createHandLog = (id = 'hand-1'): HandLog => ({
   id,
@@ -150,11 +151,8 @@ const createEntry = (): AnalysisEntry => ({
   updatedAt: 1710000001000,
 });
 
-const mockSaveAnalysisEntry = vi.fn<
-  Parameters<NonNullable<ReturnType<typeof useAnalysisEntry>['saveAnalysisEntry']>>,
-  ReturnType<NonNullable<ReturnType<typeof useAnalysisEntry>['saveAnalysisEntry']>>
->();
-const mockDeleteAnalysisEntry = vi.fn<[], Promise<void>>();
+const mockSaveAnalysisEntry = vi.fn(async (_entry: AnalysisEntry) => undefined);
+const mockDeleteAnalysisEntry = vi.fn(async () => undefined);
 
 const mockHookResult = ({
   uid = 'user-1',
@@ -168,19 +166,20 @@ const mockHookResult = ({
   loading?: boolean;
   saving?: boolean;
   deleting?: boolean;
-} = {}) => ({
-  uid,
-  analysisEntry,
-  draftAnalysisEntry: analysisEntry,
-  hasDraftChanges: false,
-  loading,
-  saving,
-  deleting,
-  setDraftAnalysisEntry: vi.fn(),
-  resetDraftAnalysisEntry: vi.fn(),
-  saveAnalysisEntry: mockSaveAnalysisEntry,
-  deleteAnalysisEntry: mockDeleteAnalysisEntry,
-});
+} = {}) =>
+  ({
+    uid,
+    analysisEntry,
+    draftAnalysisEntry: analysisEntry,
+    hasDraftChanges: false,
+    loading,
+    saving,
+    deleting,
+    setDraftAnalysisEntry: vi.fn(),
+    resetDraftAnalysisEntry: vi.fn(),
+    saveAnalysisEntry: mockSaveAnalysisEntry,
+    deleteAnalysisEntry: mockDeleteAnalysisEntry,
+  }) satisfies UseAnalysisEntryResult;
 
 describe('AnalysisEventModalLauncher', () => {
   beforeEach(() => {

--- a/src/components/features/AnalysisEventModalLauncher.test.tsx
+++ b/src/components/features/AnalysisEventModalLauncher.test.tsx
@@ -1,0 +1,272 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAnalysisEntry } from '../../hooks/useAnalysisEntry';
+import type { HandLog } from '../../types';
+import type { AnalysisEntry } from '../../types/analysis';
+import {
+  AnalysisEventModalLauncher,
+  type AnalysisModalSelection,
+} from './AnalysisEventModalLauncher';
+
+vi.mock('../../hooks/useAnalysisEntry', () => ({
+  useAnalysisEntry: vi.fn(),
+}));
+
+vi.mock('./AnalysisDetailModal', () => ({
+  AnalysisDetailModal: ({
+    isOpen,
+    mode,
+    entry,
+    onClose,
+    onSave,
+    onDelete,
+  }: {
+    isOpen: boolean;
+    mode: string;
+    entry: AnalysisEntry;
+    onClose: () => void;
+    onSave?: (entry: AnalysisEntry) => Promise<void> | void;
+    onDelete?: (entry: AnalysisEntry) => Promise<void> | void;
+  }) => {
+    if (!isOpen) {
+      return null;
+    }
+
+    return (
+      <div>
+        <span>mode:{mode}</span>
+        <span>entry-id:{entry.id}</span>
+        <span>entry-uid:{entry.uid}</span>
+        <span>entry-source:{entry.source.handLogId}</span>
+        <span>entry-event:{entry.context.eventType}</span>
+        <span>entry-riichi:{entry.yaku.riichi}</span>
+        {onSave ? (
+          <button type="button" onClick={() => onSave(entry)}>
+            save
+          </button>
+        ) : null}
+        {onDelete ? (
+          <button type="button" onClick={() => onDelete(entry)}>
+            delete
+          </button>
+        ) : null}
+        <button type="button" onClick={onClose}>
+          close
+        </button>
+      </div>
+    );
+  },
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+const mockUseAnalysisEntry = vi.mocked(useAnalysisEntry);
+
+const createHandLog = (id = 'hand-1'): HandLog => ({
+  id,
+  timestamp: 1710000000000,
+  round: {
+    wind: 'East',
+    number: 1,
+    honba: 0,
+    riichiSticks: 1,
+  },
+  result: {
+    type: 'Win',
+    winners: [
+      {
+        id: 'user-1',
+        payment: {
+          basePoints: 2000,
+          name: '40符3翻',
+          ron: 7700,
+        },
+      },
+    ],
+    loserId: 'player-2',
+    riichiPlayerIds: ['user-1'],
+    scoreDeltas: {
+      'user-1': 7700,
+      'player-2': -7700,
+    },
+  },
+});
+
+const createSelection = (): AnalysisModalSelection => ({
+  handLog: createHandLog(),
+  source: {
+    kind: 'room',
+    roomId: 'room-1',
+    handLogId: 'hand-1',
+  },
+  players: [
+    { id: 'user-1', name: '自分', wind: 'East' },
+    { id: 'player-2', name: '相手', wind: 'South' },
+  ],
+});
+
+const createEntry = (): AnalysisEntry => ({
+  id: 'entry-1',
+  uid: 'user-1',
+  source: {
+    kind: 'room',
+    roomId: 'room-1',
+    handLogId: 'hand-1',
+  },
+  context: {
+    round: { wind: 'East', number: 1, honba: 0 },
+    seatWind: 'East',
+    roundWind: 'East',
+    eventType: 'win',
+    isDealer: true,
+  },
+  hand: {
+    concealed: [],
+    melds: [],
+    wait: [],
+  },
+  dora: {
+    doraIndicators: [],
+    uraIndicators: [],
+    kanDoraIndicators: [],
+    kanUraIndicators: [],
+    redFiveCount: 0,
+  },
+  yaku: {
+    list: [],
+    yakuman: [],
+    ippatsu: false,
+    riichi: 'normal',
+    special: null,
+    han: 3,
+    fu: 40,
+  },
+  notes: '',
+  createdAt: 1710000000000,
+  updatedAt: 1710000001000,
+});
+
+const mockSaveAnalysisEntry = vi.fn<
+  Parameters<NonNullable<ReturnType<typeof useAnalysisEntry>['saveAnalysisEntry']>>,
+  ReturnType<NonNullable<ReturnType<typeof useAnalysisEntry>['saveAnalysisEntry']>>
+>();
+const mockDeleteAnalysisEntry = vi.fn<[], Promise<void>>();
+
+const mockHookResult = ({
+  uid = 'user-1',
+  analysisEntry = null,
+  loading = false,
+  saving = false,
+  deleting = false,
+}: {
+  uid?: string | null;
+  analysisEntry?: AnalysisEntry | null;
+  loading?: boolean;
+  saving?: boolean;
+  deleting?: boolean;
+} = {}) => ({
+  uid,
+  analysisEntry,
+  draftAnalysisEntry: analysisEntry,
+  hasDraftChanges: false,
+  loading,
+  saving,
+  deleting,
+  setDraftAnalysisEntry: vi.fn(),
+  resetDraftAnalysisEntry: vi.fn(),
+  saveAnalysisEntry: mockSaveAnalysisEntry,
+  deleteAnalysisEntry: mockDeleteAnalysisEntry,
+});
+
+describe('AnalysisEventModalLauncher', () => {
+  beforeEach(() => {
+    mockUseAnalysisEntry.mockReset();
+    mockSaveAnalysisEntry.mockReset();
+    mockDeleteAnalysisEntry.mockReset();
+    mockSaveAnalysisEntry.mockResolvedValue(undefined);
+    mockDeleteAnalysisEntry.mockResolvedValue(undefined);
+  });
+
+  it('renders a loading state while the analysis entry is being prepared', () => {
+    mockUseAnalysisEntry.mockReturnValue(mockHookResult({ loading: true }));
+
+    render(<AnalysisEventModalLauncher isOpen selection={createSelection()} onClose={vi.fn()} />);
+
+    expect(screen.getByText('分析メモを読み込んでいます...')).not.toBeNull();
+    expect(screen.queryByText(/mode:/)).toBeNull();
+  });
+
+  it('opens an existing entry in edit mode by default', () => {
+    mockUseAnalysisEntry.mockReturnValue(mockHookResult({ analysisEntry: createEntry() }));
+
+    render(<AnalysisEventModalLauncher isOpen selection={createSelection()} onClose={vi.fn()} />);
+
+    expect(screen.getByText('mode:edit')).not.toBeNull();
+    expect(screen.getByText('entry-id:entry-1')).not.toBeNull();
+    expect(screen.getByRole('button', { name: 'save' })).not.toBeNull();
+    expect(screen.getByRole('button', { name: 'delete' })).not.toBeNull();
+  });
+
+  it('opens an existing entry in view mode without edit actions', () => {
+    mockUseAnalysisEntry.mockReturnValue(mockHookResult({ analysisEntry: createEntry() }));
+
+    render(
+      <AnalysisEventModalLauncher
+        isOpen
+        selection={createSelection()}
+        initialMode="view"
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('mode:view')).not.toBeNull();
+    expect(screen.queryByRole('button', { name: 'save' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'delete' })).toBeNull();
+  });
+
+  it('creates a seed entry when no existing entry is found', () => {
+    mockUseAnalysisEntry.mockReturnValue(mockHookResult());
+
+    render(<AnalysisEventModalLauncher isOpen selection={createSelection()} onClose={vi.fn()} />);
+
+    expect(screen.getByText('mode:create')).not.toBeNull();
+    expect(screen.getByText('entry-id:hand-1')).not.toBeNull();
+    expect(screen.getByText('entry-uid:user-1')).not.toBeNull();
+    expect(screen.getByText('entry-source:hand-1')).not.toBeNull();
+    expect(screen.getByText('entry-event:win')).not.toBeNull();
+    expect(screen.getByText('entry-riichi:normal')).not.toBeNull();
+  });
+
+  it('calls onClose after saving an entry', async () => {
+    const onClose = vi.fn();
+    const entry = createEntry();
+    mockUseAnalysisEntry.mockReturnValue(mockHookResult({ analysisEntry: entry }));
+
+    render(<AnalysisEventModalLauncher isOpen selection={createSelection()} onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'save' }));
+
+    await waitFor(() => {
+      expect(mockSaveAnalysisEntry).toHaveBeenCalledWith(entry);
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose after deleting an entry', async () => {
+    const onClose = vi.fn();
+    mockUseAnalysisEntry.mockReturnValue(mockHookResult({ analysisEntry: createEntry() }));
+
+    render(<AnalysisEventModalLauncher isOpen selection={createSelection()} onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'delete' }));
+
+    await waitFor(() => {
+      expect(mockDeleteAnalysisEntry).toHaveBeenCalledTimes(1);
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/features/AnalysisEventModalLauncher.tsx
+++ b/src/components/features/AnalysisEventModalLauncher.tsx
@@ -1,0 +1,106 @@
+import { useMemo } from 'react';
+import { useAnalysisEntry } from '../../hooks/useAnalysisEntry';
+import type { HandLog, Player } from '../../types';
+import type { AnalysisDetailMode } from './AnalysisDetailModal';
+import { AnalysisDetailModal } from './AnalysisDetailModal';
+import { Modal } from '../ui/Modal';
+import { createAnalysisEntrySeed } from '../../utils/analysis';
+import type { AnalysisSource } from '../../types/analysis';
+import styles from './AnalysisEventModalLauncher.module.css';
+
+const isSameSource = (left: AnalysisSource, right: AnalysisSource): boolean => {
+  return (
+    left.kind === right.kind &&
+    left.handLogId === right.handLogId &&
+    left.roomId === right.roomId &&
+    left.competitionId === right.competitionId &&
+    left.gameResultId === right.gameResultId
+  );
+};
+
+export interface AnalysisModalSelection {
+  handLog: HandLog;
+  source: AnalysisSource;
+  players: Pick<Player, 'id' | 'name' | 'wind'>[];
+}
+
+interface AnalysisEventModalLauncherProps {
+  isOpen: boolean;
+  selection: AnalysisModalSelection | null;
+  initialMode?: Extract<AnalysisDetailMode, 'edit' | 'view'>;
+  onClose: () => void;
+}
+
+export const AnalysisEventModalLauncher = ({
+  isOpen,
+  selection,
+  initialMode = 'edit',
+  onClose,
+}: AnalysisEventModalLauncherProps) => {
+  const { uid, analysisEntry, loading, saving, deleting, saveAnalysisEntry, deleteAnalysisEntry } =
+    useAnalysisEntry({ source: selection?.source ?? null });
+
+  const selectedAnalysisEntry =
+    selection && analysisEntry && isSameSource(analysisEntry.source, selection.source)
+      ? analysisEntry
+      : null;
+
+  const entry = useMemo(() => {
+    if (!selection || !uid) {
+      return null;
+    }
+
+    if (selectedAnalysisEntry) {
+      return selectedAnalysisEntry;
+    }
+
+    return createAnalysisEntrySeed({
+      uid,
+      handLog: selection.handLog,
+      playerId: uid,
+      players: selection.players,
+      source: selection.source,
+    });
+  }, [selectedAnalysisEntry, selection, uid]);
+
+  if (!isOpen || !selection) {
+    return null;
+  }
+
+  if (!entry || (loading && !selectedAnalysisEntry)) {
+    return (
+      <Modal isOpen onClose={onClose} title="分析メモを準備中">
+        <div className={styles.loadingState}>分析メモを読み込んでいます...</div>
+      </Modal>
+    );
+  }
+
+  const mode: AnalysisDetailMode = selectedAnalysisEntry ? initialMode : 'create';
+
+  return (
+    <AnalysisDetailModal
+      isOpen
+      mode={mode}
+      entry={entry}
+      isSaving={saving}
+      isDeleting={deleting}
+      onClose={onClose}
+      onSave={
+        mode === 'view'
+          ? undefined
+          : async (nextEntry) => {
+              await saveAnalysisEntry(nextEntry);
+              onClose();
+            }
+      }
+      onDelete={
+        mode === 'edit'
+          ? async () => {
+              await deleteAnalysisEntry();
+              onClose();
+            }
+          : undefined
+      }
+    />
+  );
+};

--- a/src/components/features/analysis/HandInputSection.module.css
+++ b/src/components/features/analysis/HandInputSection.module.css
@@ -1,0 +1,56 @@
+.section {
+  display: grid;
+  gap: var(--spacing-s);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: var(--border-radius-l);
+  background: rgba(255, 255, 255, 0.03);
+  padding: var(--spacing-m);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-s);
+}
+
+.header h3,
+.header h4 {
+  margin: 0;
+  color: var(--color-text-primary);
+}
+
+.header span {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-xs);
+}
+
+.currentTiles,
+.tileButtons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-xs);
+}
+
+.palette {
+  display: grid;
+  gap: var(--spacing-s);
+}
+
+.paletteGroup {
+  display: grid;
+  gap: var(--spacing-xs);
+}
+
+.paletteLabel,
+.emptyText {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-s);
+}
+
+.winningTileSection {
+  display: grid;
+  gap: var(--spacing-s);
+  padding-top: var(--spacing-s);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}

--- a/src/components/features/analysis/HandInputSection.test.tsx
+++ b/src/components/features/analysis/HandInputSection.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { AnalysisEventType, TileCode } from '../../../types';
+import { HandInputSection } from './HandInputSection';
+
+afterEach(() => {
+  cleanup();
+});
+
+interface HandInputSectionHarnessProps {
+  initialConcealed?: TileCode[];
+  initialWinningTile?: TileCode;
+  eventType?: AnalysisEventType;
+  readOnly?: boolean;
+}
+
+const HandInputSectionHarness = ({
+  initialConcealed = [],
+  initialWinningTile,
+  eventType = 'win',
+  readOnly = false,
+}: HandInputSectionHarnessProps) => {
+  const [concealed, setConcealed] = useState<TileCode[]>(initialConcealed);
+  const [winningTile, setWinningTile] = useState<TileCode | undefined>(initialWinningTile);
+
+  return (
+    <>
+      <HandInputSection
+        concealed={concealed}
+        winningTile={winningTile}
+        eventType={eventType}
+        readOnly={readOnly}
+        onConcealedChange={setConcealed}
+        onWinningTileChange={setWinningTile}
+      />
+      <output aria-label="concealed-state">{concealed.join(',') || 'none'}</output>
+      <output aria-label="winning-tile-state">{winningTile ?? 'none'}</output>
+    </>
+  );
+};
+
+describe('HandInputSection', () => {
+  it('adds and removes concealed tiles', () => {
+    render(<HandInputSectionHarness initialConcealed={['2m']} />);
+
+    fireEvent.click(screen.getByRole('button', { name: '手牌に1mを追加' }));
+    expect(screen.getByLabelText('concealed-state').textContent).toBe('2m,1m');
+
+    fireEvent.click(screen.getByRole('button', { name: '手牌から2mを削除' }));
+    expect(screen.getByLabelText('concealed-state').textContent).toBe('1m');
+  });
+
+  it('sets and clears the winning tile', () => {
+    render(<HandInputSectionHarness initialConcealed={['1m', '2m']} />);
+
+    fireEvent.click(screen.getByRole('button', { name: '和了牌に2mを設定' }));
+    expect(screen.getByLabelText('winning-tile-state').textContent).toBe('2m');
+
+    fireEvent.click(screen.getByRole('button', { name: '和了牌から2mを削除' }));
+    expect(screen.getByLabelText('winning-tile-state').textContent).toBe('none');
+  });
+
+  it('deduplicates winning tile candidates from concealed tiles', () => {
+    render(<HandInputSectionHarness initialConcealed={['1m', '1m', '2m']} />);
+
+    expect(screen.getAllByRole('button', { name: '和了牌に1mを設定' })).toHaveLength(1);
+    expect(screen.getAllByRole('button', { name: '和了牌に2mを設定' })).toHaveLength(1);
+  });
+
+  it('clears the winning tile when the last matching concealed tile is removed', () => {
+    render(<HandInputSectionHarness initialConcealed={['1m', '2m']} initialWinningTile="1m" />);
+
+    fireEvent.click(screen.getByRole('button', { name: '手牌から1mを削除' }));
+
+    expect(screen.getByLabelText('concealed-state').textContent).toBe('2m');
+    expect(screen.getByLabelText('winning-tile-state').textContent).toBe('none');
+  });
+
+  it('disables tile editing in readOnly mode', () => {
+    render(<HandInputSectionHarness initialConcealed={['1m']} initialWinningTile="1m" readOnly />);
+
+    const addButton = screen.getByRole('button', { name: '手牌に2mを追加' });
+    const removeButton = screen.getByRole('button', { name: '手牌から1mを削除' });
+    const winningTileButton = screen.getByRole('button', { name: '和了牌から1mを削除' });
+
+    expect((addButton as HTMLButtonElement).disabled).toBe(true);
+    expect((removeButton as HTMLButtonElement).disabled).toBe(true);
+    expect((winningTileButton as HTMLButtonElement).disabled).toBe(true);
+
+    expect(screen.getByLabelText('concealed-state').textContent).toBe('1m');
+    expect(screen.getByLabelText('winning-tile-state').textContent).toBe('1m');
+  });
+});

--- a/src/components/features/analysis/HandInputSection.tsx
+++ b/src/components/features/analysis/HandInputSection.tsx
@@ -1,0 +1,121 @@
+import type { AnalysisEventType, TileCode } from '../../../types';
+import { TileImage } from '../../ui/TileImage';
+import { TILE_GROUPS } from '../../../utils/tiles';
+import styles from './HandInputSection.module.css';
+
+interface HandInputSectionProps {
+  concealed: TileCode[];
+  winningTile?: TileCode;
+  eventType: AnalysisEventType;
+  readOnly: boolean;
+  onConcealedChange: (tiles: TileCode[]) => void;
+  onWinningTileChange: (tile: TileCode | undefined) => void;
+}
+
+export const HandInputSection = ({
+  concealed,
+  winningTile,
+  eventType,
+  readOnly,
+  onConcealedChange,
+  onWinningTileChange,
+}: HandInputSectionProps) => {
+  const winningTileOptions = concealed.filter((tile, index) => concealed.indexOf(tile) === index);
+
+  const handleRemoveConcealedTile = (index: number) => {
+    const nextConcealed = concealed.filter((_, currentIndex) => currentIndex !== index);
+    onConcealedChange(nextConcealed);
+
+    if (winningTile && !nextConcealed.includes(winningTile)) {
+      onWinningTileChange(undefined);
+    }
+  };
+
+  return (
+    <section className={styles.section}>
+      <div className={styles.header}>
+        <h3>手牌入力</h3>
+        <span>{concealed.length}枚</span>
+      </div>
+
+      <div className={styles.currentTiles}>
+        {concealed.length === 0 ? <span className={styles.emptyText}>未入力</span> : null}
+        {concealed.map((tile, index) => (
+          <TileImage
+            key={`concealed-${tile}-${index}`}
+            code={tile}
+            size="sm"
+            selected
+            onClick={() => handleRemoveConcealedTile(index)}
+            disabled={readOnly}
+            ariaLabel={`手牌から${tile}を削除`}
+          />
+        ))}
+      </div>
+
+      <div className={styles.palette}>
+        {TILE_GROUPS.map((group) => (
+          <div key={group.label} className={styles.paletteGroup}>
+            <span className={styles.paletteLabel}>{group.label}</span>
+            <div className={styles.tileButtons}>
+              {group.tiles.map((tile) => (
+                <TileImage
+                  key={`concealed-add-${tile}`}
+                  code={tile}
+                  size="sm"
+                  onClick={() => onConcealedChange([...concealed, tile])}
+                  disabled={readOnly}
+                  ariaLabel={`手牌に${tile}を追加`}
+                />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {eventType !== 'tenpai-draw' ? (
+        <div className={styles.winningTileSection}>
+          <div className={styles.header}>
+            <h4>和了牌</h4>
+            <span>{winningTile ?? '未入力'}</span>
+          </div>
+          {winningTile ? (
+            <TileImage
+              code={winningTile}
+              size="sm"
+              selected
+              onClick={() => onWinningTileChange(undefined)}
+              disabled={readOnly}
+              ariaLabel={`和了牌から${winningTile}を削除`}
+            />
+          ) : (
+            <span className={styles.emptyText}>未入力</span>
+          )}
+          {winningTileOptions.length > 0 ? (
+            <div className={styles.palette}>
+              <div className={styles.paletteGroup}>
+                <span className={styles.paletteLabel}>手牌から選択</span>
+                <div className={styles.tileButtons}>
+                  {winningTileOptions.map((tile) => (
+                    <TileImage
+                      key={`winning-${tile}`}
+                      code={tile}
+                      size="sm"
+                      selected={winningTile === tile}
+                      pressed={winningTile === tile}
+                      onClick={() => onWinningTileChange(tile)}
+                      disabled={readOnly}
+                      ariaLabel={`和了牌に${tile}を設定`}
+                    />
+                  ))}
+                </div>
+              </div>
+            </div>
+          ) : (
+            <span className={styles.emptyText}>和了牌は手牌から選択します</span>
+          )}
+        </div>
+      ) : null}
+    </section>
+  );
+};

--- a/src/components/features/analysis/MeldEditor.module.css
+++ b/src/components/features/analysis/MeldEditor.module.css
@@ -1,0 +1,98 @@
+.section {
+  display: grid;
+  gap: var(--spacing-s);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: var(--border-radius-l);
+  background: rgba(255, 255, 255, 0.03);
+  padding: var(--spacing-m);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-s);
+}
+
+.header h3 {
+  margin: 0;
+  color: var(--color-text-primary);
+}
+
+.header span,
+.emptyText,
+.paletteLabel,
+.helperText {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-s);
+}
+
+.currentMelds,
+.tileButtons,
+.tileInputs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-xs);
+}
+
+.meldRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-s);
+  width: 100%;
+  border-radius: var(--border-radius-m);
+  background: rgba(255, 255, 255, 0.04);
+  padding: var(--spacing-s);
+}
+
+.meldText {
+  color: var(--color-text-primary);
+  font-family: var(--font-mono);
+}
+
+.removeButton,
+.addButton {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: var(--border-radius-m);
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--color-text-primary);
+  min-height: 40px;
+  padding: 0 12px;
+}
+
+.editorGrid,
+.palette {
+  display: grid;
+  gap: var(--spacing-s);
+}
+
+.field {
+  display: grid;
+  gap: var(--spacing-xs);
+  color: var(--color-text-primary);
+}
+
+.select {
+  border: 1px solid var(--color-text-secondary);
+  border-radius: var(--border-radius-m);
+  background: var(--color-bg-card);
+  color: var(--color-text-primary);
+  min-height: 42px;
+  padding: 0 12px;
+}
+
+.warning {
+  margin: 0;
+  color: #ffb4ab;
+}
+
+@media (min-width: 768px) {
+  .editorGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .tileInputs {
+    flex-wrap: nowrap;
+  }
+}

--- a/src/components/features/analysis/MeldEditor.test.tsx
+++ b/src/components/features/analysis/MeldEditor.test.tsx
@@ -1,0 +1,151 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { Meld } from '../../../types';
+import { MeldEditor } from './MeldEditor';
+
+afterEach(() => {
+  cleanup();
+});
+
+interface MeldEditorHarnessProps {
+  initialMelds?: Meld[];
+  readOnly?: boolean;
+}
+
+const MeldEditorHarness = ({ initialMelds = [], readOnly = false }: MeldEditorHarnessProps) => {
+  const [melds, setMelds] = useState<Meld[]>(initialMelds);
+
+  return (
+    <>
+      <MeldEditor melds={melds} readOnly={readOnly} onChange={setMelds} />
+      <output aria-label="meld-count">{String(melds.length)}</output>
+    </>
+  );
+};
+
+const setTileDraft = (index: number, value: string) => {
+  fireEvent.change(screen.getByLabelText(`鳴き牌 ${index}`), {
+    target: { value },
+  });
+};
+
+describe('MeldEditor', () => {
+  it('adds chi, pon, minkan, and ankan melds', () => {
+    render(<MeldEditorHarness />);
+
+    setTileDraft(1, '1m');
+    setTileDraft(2, '2m');
+    setTileDraft(3, '3m');
+    fireEvent.click(screen.getByRole('button', { name: '鳴きを追加' }));
+    expect(screen.getByText(/chi \/ 1m 2m 3m \/ kamicha/)).not.toBeNull();
+
+    fireEvent.change(screen.getByLabelText('種類'), { target: { value: 'pon' } });
+    fireEvent.change(screen.getByLabelText('鳴いた方向'), { target: { value: 'toimen' } });
+    setTileDraft(1, '5p');
+    setTileDraft(2, '5p');
+    setTileDraft(3, '5p');
+    fireEvent.click(screen.getByRole('button', { name: '鳴きを追加' }));
+    expect(screen.getByText(/pon \/ 5p 5p 5p \/ toimen/)).not.toBeNull();
+
+    fireEvent.change(screen.getByLabelText('種類'), { target: { value: 'minkan' } });
+    fireEvent.change(screen.getByLabelText('鳴いた方向'), { target: { value: 'shimocha' } });
+    setTileDraft(1, '9s');
+    setTileDraft(2, '9s');
+    setTileDraft(3, '9s');
+    setTileDraft(4, '9s');
+    fireEvent.click(screen.getByRole('button', { name: '鳴きを追加' }));
+    expect(screen.getByText(/minkan \/ 9s 9s 9s 9s \/ shimocha/)).not.toBeNull();
+
+    fireEvent.change(screen.getByLabelText('種類'), { target: { value: 'ankan' } });
+    setTileDraft(1, '1z');
+    setTileDraft(2, '1z');
+    setTileDraft(3, '1z');
+    setTileDraft(4, '1z');
+    fireEvent.click(screen.getByRole('button', { name: '鳴きを追加' }));
+    expect(screen.getByText(/ankan \/ 1z 1z 1z 1z/)).not.toBeNull();
+    expect(screen.getByLabelText('meld-count').textContent).toBe('4');
+  });
+
+  it('updates slot count and direction behavior when switching meld kind', () => {
+    render(<MeldEditorHarness />);
+
+    expect(screen.getAllByRole('textbox')).toHaveLength(3);
+    expect((screen.getByLabelText('鳴いた方向') as HTMLSelectElement).disabled).toBe(true);
+
+    fireEvent.change(screen.getByLabelText('種類'), { target: { value: 'minkan' } });
+    expect(screen.getAllByRole('textbox')).toHaveLength(4);
+    expect((screen.getByLabelText('鳴いた方向') as HTMLSelectElement).disabled).toBe(false);
+
+    fireEvent.change(screen.getByLabelText('鳴いた方向'), { target: { value: 'shimocha' } });
+    expect((screen.getByLabelText('鳴いた方向') as HTMLSelectElement).value).toBe('shimocha');
+
+    fireEvent.change(screen.getByLabelText('種類'), { target: { value: 'chi' } });
+    expect(screen.getAllByRole('textbox')).toHaveLength(3);
+    expect((screen.getByLabelText('鳴いた方向') as HTMLSelectElement).value).toBe('kamicha');
+    expect((screen.getByLabelText('鳴いた方向') as HTMLSelectElement).disabled).toBe(true);
+
+    fireEvent.change(screen.getByLabelText('種類'), { target: { value: 'ankan' } });
+    expect(screen.queryByLabelText('鳴いた方向')).toBeNull();
+  });
+
+  it('shows an incomplete draft warning before adding', () => {
+    render(<MeldEditorHarness />);
+
+    setTileDraft(1, '1m');
+
+    expect(screen.getByText('鳴き候補の入力が未完成です。')).not.toBeNull();
+  });
+
+  it('does not allow adding an invalid meld', () => {
+    render(<MeldEditorHarness />);
+
+    setTileDraft(1, '1m');
+    setTileDraft(2, '1m');
+    setTileDraft(3, '1m');
+
+    const addButton = screen.getByRole('button', { name: '鳴きを追加' });
+    expect((addButton as HTMLButtonElement).disabled).toBe(true);
+
+    fireEvent.click(addButton);
+
+    expect(screen.getByLabelText('meld-count').textContent).toBe('0');
+    expect(screen.getByText('未入力')).not.toBeNull();
+  });
+
+  it('removes an added meld', () => {
+    render(
+      <MeldEditorHarness
+        initialMelds={[{ kind: 'pon', tiles: ['3p', '3p', '3p'], from: 'toimen' }]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '鳴きを1件目から削除' }));
+
+    expect(screen.getByLabelText('meld-count').textContent).toBe('0');
+    expect(screen.getByText('未入力')).not.toBeNull();
+  });
+
+  it('disables editing in readOnly mode', () => {
+    render(
+      <MeldEditorHarness
+        initialMelds={[{ kind: 'chi', tiles: ['1m', '2m', '3m'], from: 'kamicha' }]}
+        readOnly
+      />,
+    );
+
+    const kindSelect = screen.getByLabelText('種類');
+    const tileInput = screen.getByLabelText('鳴き牌 1');
+    const paletteButton = screen.getByRole('button', { name: '鳴き候補に1mを追加' });
+    const addButton = screen.getByRole('button', { name: '鳴きを追加' });
+    const removeButton = screen.getByRole('button', { name: '鳴きを1件目から削除' });
+
+    expect((kindSelect as HTMLSelectElement).disabled).toBe(true);
+    expect((tileInput as HTMLInputElement).disabled).toBe(true);
+    expect((paletteButton as HTMLButtonElement).disabled).toBe(true);
+    expect((addButton as HTMLButtonElement).disabled).toBe(true);
+    expect((removeButton as HTMLButtonElement).disabled).toBe(true);
+  });
+});

--- a/src/components/features/analysis/MeldEditor.tsx
+++ b/src/components/features/analysis/MeldEditor.tsx
@@ -1,0 +1,276 @@
+import { useMemo, useState } from 'react';
+import type { Meld, TileCode } from '../../../types';
+import { normalizeTileCode } from '../../../utils/tiles';
+import { Input } from '../../ui/Input';
+import { TileImage } from '../../ui/TileImage';
+import { TILE_GROUPS } from '../../../utils/tiles';
+import styles from './MeldEditor.module.css';
+
+type MeldKind = Meld['kind'];
+type MeldFrom = 'kamicha' | 'toimen' | 'shimocha';
+
+interface MeldEditorProps {
+  melds: Meld[];
+  readOnly: boolean;
+  onChange: (melds: Meld[]) => void;
+}
+
+const getTileSlots = (kind: MeldKind) => {
+  return kind === 'minkan' || kind === 'ankan' ? 4 : 3;
+};
+
+const isTileCode = (value: string): value is TileCode => {
+  return /^(?:[1-9][mps]|[1-7]z|0[mps])$/.test(value);
+};
+
+const areSameTileKinds = (tiles: TileCode[]) => {
+  if (tiles.length === 0) {
+    return false;
+  }
+
+  const [firstTile, ...restTiles] = tiles.map(normalizeTileCode);
+  return restTiles.every((tile) => tile === firstTile);
+};
+
+const isValidChi = (tiles: [TileCode, TileCode, TileCode]) => {
+  const normalizedTiles = tiles.map(normalizeTileCode);
+  if (normalizedTiles.some((tile) => tile.endsWith('z'))) {
+    return false;
+  }
+
+  const suit = normalizedTiles[0][1];
+  if (!normalizedTiles.every((tile) => tile[1] === suit)) {
+    return false;
+  }
+
+  const ranks = normalizedTiles
+    .map((tile) => Number.parseInt(tile[0], 10))
+    .sort((left, right) => left - right);
+
+  return ranks[1] === ranks[0] + 1 && ranks[2] === ranks[1] + 1;
+};
+
+export const MeldEditor = ({ melds, readOnly, onChange }: MeldEditorProps) => {
+  const [kind, setKind] = useState<MeldKind>('chi');
+  const [from, setFrom] = useState<MeldFrom>('kamicha');
+  const [tileDrafts, setTileDrafts] = useState<string[]>(['', '', '']);
+
+  const hasIncompleteDraft = useMemo(() => {
+    return tileDrafts.some((tile) => tile.trim().length > 0) && !tileDrafts.every(isTileCode);
+  }, [tileDrafts]);
+
+  const buildMeld = (): Meld | null => {
+    if (!tileDrafts.every(isTileCode)) {
+      return null;
+    }
+
+    if (kind === 'chi') {
+      const tiles = [tileDrafts[0], tileDrafts[1], tileDrafts[2]] as [TileCode, TileCode, TileCode];
+      if (!isValidChi(tiles)) {
+        return null;
+      }
+
+      return {
+        kind,
+        tiles,
+        from: 'kamicha',
+      };
+    }
+
+    if (kind === 'pon') {
+      const tiles = [tileDrafts[0], tileDrafts[1], tileDrafts[2]] as [TileCode, TileCode, TileCode];
+      if (!areSameTileKinds(tiles)) {
+        return null;
+      }
+
+      return {
+        kind,
+        tiles,
+        from,
+      };
+    }
+
+    if (kind === 'minkan') {
+      const tiles = [tileDrafts[0], tileDrafts[1], tileDrafts[2], tileDrafts[3]] as [
+        TileCode,
+        TileCode,
+        TileCode,
+        TileCode,
+      ];
+      if (!areSameTileKinds(tiles)) {
+        return null;
+      }
+
+      return {
+        kind,
+        tiles,
+        from,
+      };
+    }
+
+    const tiles = [tileDrafts[0], tileDrafts[1], tileDrafts[2], tileDrafts[3]] as [
+      TileCode,
+      TileCode,
+      TileCode,
+      TileCode,
+    ];
+    if (!areSameTileKinds(tiles)) {
+      return null;
+    }
+
+    return {
+      kind,
+      tiles,
+    };
+  };
+
+  const handleAdd = () => {
+    const nextMeld = buildMeld();
+    if (!nextMeld) {
+      return;
+    }
+
+    onChange([...melds, nextMeld]);
+    setTileDrafts(Array.from({ length: getTileSlots(kind) }, () => ''));
+  };
+
+  const handleKindChange = (nextKind: MeldKind) => {
+    const slotCount = getTileSlots(nextKind);
+    setKind(nextKind);
+    setTileDrafts((current) => {
+      const nextDrafts = current.slice(0, slotCount);
+      while (nextDrafts.length < slotCount) {
+        nextDrafts.push('');
+      }
+      return nextDrafts;
+    });
+
+    if (nextKind === 'chi') {
+      setFrom('kamicha');
+    }
+  };
+
+  return (
+    <section className={styles.section}>
+      <div className={styles.header}>
+        <h3>鳴き</h3>
+        <span>{melds.length}組</span>
+      </div>
+
+      <div className={styles.currentMelds}>
+        {melds.length === 0 ? <span className={styles.emptyText}>未入力</span> : null}
+        {melds.map((meld, index) => (
+          <div key={`${meld.kind}-${index}`} className={styles.meldRow}>
+            <span className={styles.meldText}>
+              {meld.kind} / {meld.tiles.join(' ')}
+              {'from' in meld ? ` / ${meld.from}` : ''}
+            </span>
+            <button
+              type="button"
+              className={styles.removeButton}
+              onClick={() => onChange(melds.filter((_, currentIndex) => currentIndex !== index))}
+              disabled={readOnly}
+              aria-label={`鳴きを${index + 1}件目から削除`}
+            >
+              削除
+            </button>
+          </div>
+        ))}
+      </div>
+
+      <div className={styles.editorGrid}>
+        <label className={styles.field}>
+          <span>種類</span>
+          <select
+            className={styles.select}
+            value={kind}
+            onChange={(event) => handleKindChange(event.target.value as MeldKind)}
+            disabled={readOnly}
+          >
+            <option value="chi">チー</option>
+            <option value="pon">ポン</option>
+            <option value="minkan">明槓</option>
+            <option value="ankan">暗槓</option>
+          </select>
+        </label>
+
+        {kind !== 'ankan' ? (
+          <label className={styles.field}>
+            <span>鳴いた方向</span>
+            <select
+              className={styles.select}
+              value={from}
+              onChange={(event) => setFrom(event.target.value as MeldFrom)}
+              disabled={readOnly || kind === 'chi'}
+            >
+              <option value="kamicha">上家</option>
+              <option value="toimen">対面</option>
+              <option value="shimocha">下家</option>
+            </select>
+          </label>
+        ) : null}
+      </div>
+
+      <div className={styles.tileInputs}>
+        {tileDrafts.map((tile, index) => (
+          <Input
+            key={`tile-input-${index}`}
+            fullWidth
+            value={tile}
+            onChange={(event) => {
+              const nextDrafts = [...tileDrafts];
+              nextDrafts[index] = event.target.value;
+              setTileDrafts(nextDrafts);
+            }}
+            placeholder={`牌${index + 1} 例: 3m`}
+            aria-label={`鳴き牌 ${index + 1}`}
+            disabled={readOnly}
+          />
+        ))}
+      </div>
+
+      <div className={styles.palette}>
+        {TILE_GROUPS.map((group) => (
+          <div key={`meld-${group.label}`} className={styles.paletteGroup}>
+            <span className={styles.paletteLabel}>{group.label}</span>
+            <div className={styles.tileButtons}>
+              {group.tiles.map((tile) => (
+                <TileImage
+                  key={`meld-${tile}`}
+                  code={tile}
+                  size="sm"
+                  onClick={() => {
+                    const nextIndex = tileDrafts.findIndex((draft) => draft === '');
+                    if (nextIndex === -1) {
+                      return;
+                    }
+
+                    const nextDrafts = [...tileDrafts];
+                    nextDrafts[nextIndex] = tile;
+                    setTileDrafts(nextDrafts);
+                  }}
+                  disabled={readOnly}
+                  ariaLabel={`鳴き候補に${tile}を追加`}
+                />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <p className={styles.helperText}>
+        鳴き入力は追加前なら未完成でも保存できます。入力済みの鳴きだけ保存対象になります。
+      </p>
+      {hasIncompleteDraft ? <p className={styles.warning}>鳴き候補の入力が未完成です。</p> : null}
+
+      <button
+        type="button"
+        className={styles.addButton}
+        onClick={handleAdd}
+        disabled={readOnly || buildMeld() === null}
+      >
+        鳴きを追加
+      </button>
+    </section>
+  );
+};

--- a/src/components/features/analysis/WaitShapeSelector.module.css
+++ b/src/components/features/analysis/WaitShapeSelector.module.css
@@ -1,0 +1,20 @@
+.grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-xs);
+}
+
+.option {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--color-text-primary);
+  min-height: 40px;
+  padding: 0 14px;
+}
+
+.optionSelected {
+  border-color: var(--color-primary);
+  background: rgba(76, 175, 80, 0.16);
+  color: #dff6df;
+}

--- a/src/components/features/analysis/WaitShapeSelector.tsx
+++ b/src/components/features/analysis/WaitShapeSelector.tsx
@@ -1,0 +1,39 @@
+import type { WaitShape } from '../../../types';
+import { WAIT_SHAPE_DEFS, WAIT_SHAPES } from '../../../types';
+import styles from './WaitShapeSelector.module.css';
+
+interface WaitShapeSelectorProps {
+  selected: WaitShape[];
+  readOnly: boolean;
+  onChange: (waits: WaitShape[]) => void;
+}
+
+export const WaitShapeSelector = ({ selected, readOnly, onChange }: WaitShapeSelectorProps) => {
+  return (
+    <div className={styles.grid}>
+      {WAIT_SHAPES.map((waitShape) => {
+        const isSelected = selected.includes(waitShape);
+
+        return (
+          <button
+            key={waitShape}
+            type="button"
+            className={`${styles.option} ${isSelected ? styles.optionSelected : ''}`}
+            onClick={() => {
+              onChange(
+                isSelected
+                  ? selected.filter((currentWait) => currentWait !== waitShape)
+                  : [...selected, waitShape],
+              );
+            }}
+            disabled={readOnly}
+            aria-label={`待ち形 ${WAIT_SHAPE_DEFS[waitShape].label}`}
+            aria-pressed={isSelected}
+          >
+            {WAIT_SHAPE_DEFS[waitShape].label}
+          </button>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/components/features/analysis/YakuSelector.module.css
+++ b/src/components/features/analysis/YakuSelector.module.css
@@ -1,0 +1,59 @@
+.layout,
+.groupList {
+  display: grid;
+  gap: var(--spacing-m);
+}
+
+.metaGrid {
+  display: grid;
+  gap: var(--spacing-s);
+}
+
+.metaField {
+  display: grid;
+  gap: var(--spacing-xs);
+  color: var(--color-text-primary);
+}
+
+.select {
+  border: 1px solid var(--color-text-secondary);
+  border-radius: var(--border-radius-m);
+  background: var(--color-bg-card);
+  color: var(--color-text-primary);
+  min-height: 42px;
+  padding: 0 12px;
+}
+
+.groupSection {
+  display: grid;
+  gap: var(--spacing-s);
+}
+
+.groupSection h4 {
+  margin: 0;
+  color: var(--color-text-primary);
+}
+
+.checkboxGrid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--spacing-xs);
+}
+
+.checkboxLabel {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-s);
+  color: var(--color-text-primary);
+}
+
+@media (min-width: 768px) {
+  .metaGrid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    align-items: end;
+  }
+
+  .checkboxGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}

--- a/src/components/features/analysis/YakuSelector.test.tsx
+++ b/src/components/features/analysis/YakuSelector.test.tsx
@@ -1,0 +1,140 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { AnalysisYaku } from '../../../types';
+import { YakuSelector } from './YakuSelector';
+
+afterEach(() => {
+  cleanup();
+});
+
+interface YakuSelectorHarnessProps {
+  initialValue?: AnalysisYaku;
+  readOnly?: boolean;
+}
+
+const createYakuValue = (overrides: Partial<AnalysisYaku> = {}): AnalysisYaku => ({
+  list: [],
+  yakuman: [],
+  ippatsu: false,
+  riichi: 'none',
+  special: null,
+  ...overrides,
+});
+
+const YakuSelectorHarness = ({
+  initialValue = createYakuValue(),
+  readOnly = false,
+}: YakuSelectorHarnessProps) => {
+  const [value, setValue] = useState<AnalysisYaku>(initialValue);
+
+  return (
+    <>
+      <YakuSelector value={value} readOnly={readOnly} onChange={setValue} />
+      <output aria-label="riichi-state">{value.riichi}</output>
+      <output aria-label="yaku-list">{value.list.join(',') || 'none'}</output>
+      <output aria-label="ippatsu-state">{String(value.ippatsu)}</output>
+      <output aria-label="special-state">{value.special ?? 'none'}</output>
+      <output aria-label="yakuman-list">{value.yakuman.join(',') || 'none'}</output>
+    </>
+  );
+};
+
+describe('YakuSelector', () => {
+  it('syncs the riichi select value into the yaku list', () => {
+    render(<YakuSelectorHarness />);
+
+    fireEvent.change(screen.getByLabelText('立直状態'), { target: { value: 'normal' } });
+    expect(screen.getByLabelText('riichi-state').textContent).toBe('normal');
+    expect(screen.getByLabelText('yaku-list').textContent).toBe('riichi');
+
+    fireEvent.change(screen.getByLabelText('立直状態'), { target: { value: 'double' } });
+    expect(screen.getByLabelText('riichi-state').textContent).toBe('double');
+    expect(screen.getByLabelText('yaku-list').textContent).toBe('doubleRiichi');
+
+    fireEvent.change(screen.getByLabelText('立直状態'), { target: { value: 'none' } });
+    expect(screen.getByLabelText('riichi-state').textContent).toBe('none');
+    expect(screen.getByLabelText('yaku-list').textContent).toBe('none');
+  });
+
+  it('syncs riichi checkboxes back into the riichi state', () => {
+    render(<YakuSelectorHarness />);
+
+    fireEvent.click(screen.getByRole('checkbox', { name: '立直' }));
+    expect(screen.getByLabelText('riichi-state').textContent).toBe('normal');
+    expect(screen.getByLabelText('yaku-list').textContent).toBe('riichi');
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'ダブル立直' }));
+    expect(screen.getByLabelText('riichi-state').textContent).toBe('double');
+    expect(screen.getByLabelText('yaku-list').textContent).toBe('doubleRiichi');
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'ダブル立直' }));
+    expect(screen.getByLabelText('riichi-state').textContent).toBe('none');
+    expect(screen.getByLabelText('yaku-list').textContent).toBe('none');
+  });
+
+  it('toggles ippatsu', () => {
+    render(<YakuSelectorHarness />);
+
+    fireEvent.click(screen.getByRole('checkbox', { name: '一発' }));
+    expect(screen.getByLabelText('ippatsu-state').textContent).toBe('true');
+
+    fireEvent.click(screen.getByRole('checkbox', { name: '一発' }));
+    expect(screen.getByLabelText('ippatsu-state').textContent).toBe('false');
+  });
+
+  it('updates the special win selection', () => {
+    render(<YakuSelectorHarness />);
+
+    fireEvent.change(screen.getByLabelText('特殊和了'), { target: { value: 'rinshan' } });
+    expect(screen.getByLabelText('special-state').textContent).toBe('rinshan');
+
+    fireEvent.change(screen.getByLabelText('特殊和了'), { target: { value: 'none' } });
+    expect(screen.getByLabelText('special-state').textContent).toBe('none');
+  });
+
+  it('toggles yakuman selections', () => {
+    render(<YakuSelectorHarness />);
+
+    fireEvent.click(screen.getByRole('checkbox', { name: '国士無双' }));
+    expect(screen.getByLabelText('yakuman-list').textContent).toBe('kokushiMusou');
+
+    fireEvent.click(screen.getByRole('checkbox', { name: '国士無双' }));
+    expect(screen.getByLabelText('yakuman-list').textContent).toBe('none');
+  });
+
+  it('disables controls in readOnly mode', () => {
+    render(
+      <YakuSelectorHarness
+        initialValue={createYakuValue({
+          list: ['riichi'],
+          yakuman: ['kokushiMusou'],
+          ippatsu: true,
+          riichi: 'normal',
+          special: 'haitei',
+        })}
+        readOnly
+      />,
+    );
+
+    const riichiSelect = screen.getByLabelText('立直状態');
+    const specialSelect = screen.getByLabelText('特殊和了');
+    const ippatsu = screen.getByRole('checkbox', { name: '一発' });
+    const riichi = screen.getByRole('checkbox', { name: '立直' });
+    const kokushi = screen.getByRole('checkbox', { name: '国士無双' });
+
+    expect((riichiSelect as HTMLSelectElement).disabled).toBe(true);
+    expect((specialSelect as HTMLSelectElement).disabled).toBe(true);
+    expect((ippatsu as HTMLInputElement).disabled).toBe(true);
+    expect((riichi as HTMLInputElement).disabled).toBe(true);
+    expect((kokushi as HTMLInputElement).disabled).toBe(true);
+
+    expect(screen.getByLabelText('riichi-state').textContent).toBe('normal');
+    expect(screen.getByLabelText('yaku-list').textContent).toBe('riichi');
+    expect(screen.getByLabelText('ippatsu-state').textContent).toBe('true');
+    expect(screen.getByLabelText('special-state').textContent).toBe('haitei');
+    expect(screen.getByLabelText('yakuman-list').textContent).toBe('kokushiMusou');
+  });
+});

--- a/src/components/features/analysis/YakuSelector.tsx
+++ b/src/components/features/analysis/YakuSelector.tsx
@@ -1,0 +1,187 @@
+import type { AnalysisYaku, YakumanId, YakuId } from '../../../types';
+import { YAKUMAN_DEFS } from '../../../types';
+import { YAKU_GROUP_SECTIONS, YAKUMAN_GROUP_SECTIONS } from '../../../utils/yaku';
+import styles from './YakuSelector.module.css';
+
+interface YakuSelectorProps {
+  value: AnalysisYaku;
+  readOnly: boolean;
+  onChange: (value: AnalysisYaku) => void;
+}
+
+const SPECIAL_OPTIONS = [
+  { value: 'none', label: 'なし' },
+  { value: 'haitei', label: '海底' },
+  { value: 'houtei', label: '河底' },
+  { value: 'rinshan', label: '嶺上開花' },
+  { value: 'chankan', label: '槍槓' },
+] as const;
+
+const toggleValue = <T extends string>(values: T[], value: T): T[] => {
+  return values.includes(value)
+    ? values.filter((current) => current !== value)
+    : [...values, value];
+};
+
+const syncRiichiState = (
+  nextList: YakuId[],
+  nextRiichi: AnalysisYaku['riichi'],
+): AnalysisYaku['list'] => {
+  const withoutRiichi = nextList.filter((item) => item !== 'riichi' && item !== 'doubleRiichi');
+
+  if (nextRiichi === 'normal') {
+    return [...withoutRiichi, 'riichi'];
+  }
+
+  if (nextRiichi === 'double') {
+    return [...withoutRiichi, 'doubleRiichi'];
+  }
+
+  return withoutRiichi;
+};
+
+const getNextRiichiState = (
+  target: YakuId,
+  checked: boolean,
+  current: AnalysisYaku['riichi'],
+): AnalysisYaku['riichi'] => {
+  if (target === 'riichi') {
+    return checked ? 'normal' : current === 'normal' ? 'none' : current;
+  }
+
+  if (target === 'doubleRiichi') {
+    return checked ? 'double' : current === 'double' ? 'none' : current;
+  }
+
+  return current;
+};
+
+const renderCheckbox = <T extends YakuId | YakumanId>(
+  id: T,
+  label: string,
+  checked: boolean,
+  readOnly: boolean,
+  onToggle: () => void,
+) => {
+  return (
+    <label key={id} className={styles.checkboxLabel}>
+      <input type="checkbox" checked={checked} onChange={onToggle} disabled={readOnly} />
+      <span>{label}</span>
+    </label>
+  );
+};
+
+export const YakuSelector = ({ value, readOnly, onChange }: YakuSelectorProps) => {
+  return (
+    <div className={styles.layout}>
+      <div className={styles.metaGrid}>
+        <label className={styles.metaField}>
+          <span>立直状態</span>
+          <select
+            className={styles.select}
+            value={value.riichi}
+            onChange={(event) => {
+              const nextRiichi = event.target.value as AnalysisYaku['riichi'];
+              onChange({
+                ...value,
+                riichi: nextRiichi,
+                list: syncRiichiState(value.list, nextRiichi),
+              });
+            }}
+            disabled={readOnly}
+          >
+            <option value="none">なし</option>
+            <option value="normal">通常立直</option>
+            <option value="double">ダブル立直</option>
+          </select>
+        </label>
+
+        <label className={styles.metaField}>
+          <span>特殊和了</span>
+          <select
+            className={styles.select}
+            value={value.special ?? 'none'}
+            onChange={(event) => {
+              const nextValue = event.target.value;
+              onChange({
+                ...value,
+                special:
+                  nextValue === 'none' ? null : (nextValue as NonNullable<AnalysisYaku['special']>),
+              });
+            }}
+            disabled={readOnly}
+          >
+            {SPECIAL_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className={styles.checkboxLabel}>
+          <input
+            type="checkbox"
+            checked={value.ippatsu}
+            onChange={() => {
+              onChange({
+                ...value,
+                ippatsu: !value.ippatsu,
+              });
+            }}
+            disabled={readOnly}
+          />
+          <span>一発</span>
+        </label>
+      </div>
+
+      <div className={styles.groupList}>
+        {YAKU_GROUP_SECTIONS.map((section) => (
+          <section key={section.id} className={styles.groupSection}>
+            <h4>{section.label}役</h4>
+            <div className={styles.checkboxGrid}>
+              {section.items.map((option) =>
+                renderCheckbox(
+                  option.id,
+                  option.label,
+                  value.list.includes(option.id),
+                  readOnly,
+                  () => {
+                    const nextChecked = !value.list.includes(option.id);
+                    const nextRiichi = getNextRiichiState(option.id, nextChecked, value.riichi);
+                    const toggled = toggleValue(value.list, option.id);
+                    onChange({
+                      ...value,
+                      riichi: nextRiichi,
+                      list: syncRiichiState(toggled, nextRiichi),
+                    });
+                  },
+                ),
+              )}
+            </div>
+          </section>
+        ))}
+
+        <section className={styles.groupSection}>
+          <h4>役満</h4>
+          <div className={styles.checkboxGrid}>
+            {YAKUMAN_GROUP_SECTIONS.flatMap((section) => section.items).map((option) =>
+              renderCheckbox(
+                option.id,
+                YAKUMAN_DEFS[option.id].label,
+                value.yakuman.includes(option.id),
+                readOnly,
+                () => {
+                  onChange({
+                    ...value,
+                    yakuman: toggleValue(value.yakuman, option.id),
+                  });
+                },
+              ),
+            )}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+};

--- a/src/components/ui/Modal.test.tsx
+++ b/src/components/ui/Modal.test.tsx
@@ -24,6 +24,13 @@ const renderModal = (onClose = vi.fn()) => {
 };
 
 describe('Modal', () => {
+  it('exposes dialog semantics', () => {
+    renderModal();
+
+    const dialog = screen.getByRole('dialog', { name: 'テストモーダル' });
+    expect(dialog.getAttribute('aria-modal')).toBe('true');
+  });
+
   it('closes when pointer starts and ends on overlay', () => {
     const { onClose, overlay } = renderModal();
 
@@ -76,5 +83,63 @@ describe('Modal', () => {
     fireEvent.keyDown(window, { key: 'Escape' });
 
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('restores focus to the trigger when closed', () => {
+    const onClose = vi.fn();
+
+    const { rerender } = render(
+      <>
+        <button type="button">開く</button>
+        <Modal isOpen onClose={onClose} title="テストモーダル">
+          <div>モーダル内容</div>
+        </Modal>
+      </>,
+    );
+
+    const trigger = screen.getByRole('button', { name: '開く' });
+    trigger.focus();
+
+    rerender(
+      <>
+        <button type="button">開く</button>
+        <Modal isOpen={false} onClose={onClose} title="テストモーダル">
+          <div>モーダル内容</div>
+        </Modal>
+      </>,
+    );
+
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it('moves initial focus to the first interactive element', () => {
+    render(
+      <Modal isOpen onClose={vi.fn()} title="テストモーダル">
+        <button type="button">最初の操作</button>
+        <button type="button">次の操作</button>
+      </Modal>,
+    );
+
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: '最初の操作' }));
+  });
+
+  it('cycles focus within the modal with Tab and Shift+Tab', () => {
+    render(
+      <Modal isOpen onClose={vi.fn()} title="テストモーダル">
+        <button type="button">最初の操作</button>
+        <button type="button">最後の操作</button>
+      </Modal>,
+    );
+
+    const firstButton = screen.getByRole('button', { name: '最初の操作' });
+    const lastButton = screen.getByRole('button', { name: '最後の操作' });
+
+    firstButton.focus();
+    fireEvent.keyDown(window, { key: 'Tab', shiftKey: true });
+    expect(document.activeElement).toBe(lastButton);
+
+    lastButton.focus();
+    fireEvent.keyDown(window, { key: 'Tab' });
+    expect(document.activeElement).toBe(firstButton);
   });
 });

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useId, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import styles from './Modal.module.css';
 
@@ -10,9 +10,24 @@ interface ModalProps {
   width?: string;
 }
 
+const getFocusableElements = (container: HTMLDivElement | null): HTMLElement[] => {
+  if (!container) {
+    return [];
+  }
+
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(
+      'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    ),
+  );
+};
+
 export const Modal = ({ isOpen, onClose, title, children, width }: ModalProps) => {
   const [isVisible, setIsVisible] = useState(isOpen);
   const pointerStartedOnOverlayRef = useRef(false);
+  const modalRef = useRef<HTMLDivElement>(null);
+  const previouslyFocusedElementRef = useRef<HTMLElement | null>(null);
+  const titleId = useId();
 
   if (isOpen && !isVisible) {
     setIsVisible(true);
@@ -28,12 +43,69 @@ export const Modal = ({ isOpen, onClose, title, children, width }: ModalProps) =
   }, [isOpen]);
 
   useEffect(() => {
+    if (isOpen) {
+      previouslyFocusedElementRef.current = document.activeElement as HTMLElement | null;
+    }
+
     const handleEsc = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onClose();
     };
     if (isOpen) window.addEventListener('keydown', handleEsc);
     return () => window.removeEventListener('keydown', handleEsc);
   }, [isOpen, onClose]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      previouslyFocusedElementRef.current?.focus();
+      return;
+    }
+
+    const [firstFocusableElement] = getFocusableElements(modalRef.current);
+    (firstFocusableElement ?? modalRef.current)?.focus();
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const handleTabKey = (event: KeyboardEvent) => {
+      if (event.key !== 'Tab' || !modalRef.current) {
+        return;
+      }
+
+      const focusableElements = getFocusableElements(modalRef.current);
+
+      if (focusableElements.length === 0) {
+        event.preventDefault();
+        modalRef.current.focus();
+        return;
+      }
+
+      const firstElement = focusableElements[0];
+      const lastElement = focusableElements[focusableElements.length - 1];
+      const activeElement = document.activeElement as HTMLElement | null;
+
+      if (activeElement === modalRef.current) {
+        event.preventDefault();
+        (event.shiftKey ? lastElement : firstElement).focus();
+        return;
+      }
+
+      if (event.shiftKey && activeElement === firstElement) {
+        event.preventDefault();
+        lastElement.focus();
+      }
+
+      if (!event.shiftKey && activeElement === lastElement) {
+        event.preventDefault();
+        firstElement.focus();
+      }
+    };
+
+    window.addEventListener('keydown', handleTabKey);
+    return () => window.removeEventListener('keydown', handleTabKey);
+  }, [isOpen]);
 
   if (!isVisible && !isOpen) return null;
 
@@ -71,13 +143,18 @@ export const Modal = ({ isOpen, onClose, title, children, width }: ModalProps) =
       onPointerUp={handleOverlayPointerUp}
     >
       <div
+        ref={modalRef}
         className={`${styles.modal} ${!isOpen ? styles.modalClosing : ''}`}
         onClick={(e) => e.stopPropagation()}
         style={{ width: width }}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={title ? titleId : undefined}
+        tabIndex={-1}
       >
         {title && (
           <div className={styles.header}>
-            <h3>{title}</h3>
+            <h3 id={titleId}>{title}</h3>
           </div>
         )}
         <div className={styles.content}>{children}</div>

--- a/src/components/ui/Snackbar.module.css
+++ b/src/components/ui/Snackbar.module.css
@@ -2,10 +2,11 @@
   position: fixed;
   left: 50%;
   transform: translateX(-50%);
-  background-color: #323232;
-  color: white;
+  background-color: var(--color-bg-card);
+  color: var(--color-text-primary);
   padding: 14px 24px;
-  border-radius: 4px;
+  border-radius: var(--border-radius-m);
+  border: 1px solid rgba(255, 255, 255, 0.12);
   box-shadow:
     0 3px 5px -1px rgba(0, 0, 0, 0.2),
     0 6px 10px 0 rgba(0, 0, 0, 0.14),
@@ -49,6 +50,20 @@
 
 .closeButton:hover {
   background-color: rgba(255, 255, 255, 0.1);
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
+.actionButton {
+  color: var(--color-text-accent);
+}
+
+.actionButton:hover {
+  background-color: rgba(76, 175, 80, 0.12);
 }
 
 /* Animations based on position */

--- a/src/components/ui/Snackbar.test.tsx
+++ b/src/components/ui/Snackbar.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Snackbar } from './Snackbar';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
+  cleanup();
+});
+
+describe('Snackbar', () => {
+  it('renders an action button and closes after the action is invoked', () => {
+    const handleAction = vi.fn();
+    const handleClose = vi.fn();
+
+    render(
+      <Snackbar
+        message="分析メモを残しますか？"
+        isOpen
+        onClose={handleClose}
+        actionLabel="開く"
+        onAction={handleAction}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '開く' }));
+
+    expect(handleAction).toHaveBeenCalledTimes(1);
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not auto close while an action button is shown', () => {
+    const handleClose = vi.fn();
+
+    render(
+      <Snackbar
+        message="分析メモを残しますか？"
+        isOpen
+        onClose={handleClose}
+        actionLabel="開く"
+        onAction={vi.fn()}
+        autoHideDuration={3000}
+      />,
+    );
+
+    vi.advanceTimersByTime(3000);
+
+    expect(handleClose).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/ui/Snackbar.tsx
+++ b/src/components/ui/Snackbar.tsx
@@ -10,6 +10,8 @@ interface SnackbarProps {
   onClose: () => void;
   position?: SnackbarPosition;
   autoHideDuration?: number;
+  actionLabel?: string;
+  onAction?: () => void;
 }
 
 export const Snackbar: React.FC<SnackbarProps> = ({
@@ -18,15 +20,19 @@ export const Snackbar: React.FC<SnackbarProps> = ({
   onClose,
   position = 'bottom',
   autoHideDuration = 3000,
+  actionLabel,
+  onAction,
 }) => {
+  const shouldAutoHide = autoHideDuration > 0 && !(actionLabel && onAction);
+
   useEffect(() => {
-    if (isOpen && autoHideDuration > 0) {
+    if (isOpen && shouldAutoHide) {
       const timer = setTimeout(() => {
         onClose();
       }, autoHideDuration);
       return () => clearTimeout(timer);
     }
-  }, [isOpen, autoHideDuration, onClose]);
+  }, [isOpen, autoHideDuration, onClose, shouldAutoHide]);
 
   const positionClass = position === 'top' ? styles.top : styles.bottom;
   const visibilityClass = isOpen ? styles.open : '';
@@ -34,15 +40,30 @@ export const Snackbar: React.FC<SnackbarProps> = ({
   return (
     <div className={`${styles.snackbar} ${positionClass} ${visibilityClass}`} role="alert">
       <span>{message}</span>
-      <Button
-        variant="ghost"
-        size="small"
-        className={styles.closeButton}
-        onClick={onClose}
-        aria-label="Close"
-      >
-        ✕
-      </Button>
+      <div className={styles.actions}>
+        {actionLabel && onAction ? (
+          <Button
+            variant="ghost"
+            size="small"
+            className={styles.actionButton}
+            onClick={() => {
+              onAction();
+              onClose();
+            }}
+          >
+            {actionLabel}
+          </Button>
+        ) : null}
+        <Button
+          variant="ghost"
+          size="small"
+          className={styles.closeButton}
+          onClick={onClose}
+          aria-label="Close"
+        >
+          ✕
+        </Button>
+      </div>
     </div>
   );
 };

--- a/src/components/ui/TileImage.module.css
+++ b/src/components/ui/TileImage.module.css
@@ -1,0 +1,170 @@
+.tile {
+  --tile-accent: var(--color-text-secondary);
+  --tile-ink: var(--color-bg-main);
+  --tile-shadow: var(--color-bg-main);
+  appearance: none;
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--color-text-primary) 96%, transparent),
+    color-mix(in srgb, var(--color-text-primary) 84%, var(--color-bg-card) 16%)
+  );
+  border: 1px solid color-mix(in srgb, var(--tile-accent) 34%, var(--color-bg-main) 66%);
+  border-radius: var(--border-radius-m);
+  box-shadow:
+    0 var(--spacing-xs) var(--spacing-m) color-mix(in srgb, var(--tile-shadow) 24%, transparent),
+    inset 0 1px 0 color-mix(in srgb, var(--color-text-primary) 72%, transparent);
+  color: var(--tile-ink);
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+  font-family: var(--font-main);
+  padding: var(--spacing-xs);
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  vertical-align: middle;
+}
+
+.tile::before {
+  content: '';
+  position: absolute;
+  top: var(--spacing-xs);
+  left: var(--spacing-xs);
+  right: var(--spacing-xs);
+  height: var(--spacing-xs);
+  border-radius: 999px;
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--tile-accent) 88%, var(--color-text-primary) 12%),
+    color-mix(in srgb, var(--tile-accent) 38%, var(--color-text-primary) 62%)
+  );
+  opacity: 0.92;
+}
+
+.clickable {
+  cursor: pointer;
+  transition:
+    transform 0.12s ease,
+    box-shadow 0.12s ease,
+    border-color 0.12s ease;
+}
+
+.clickable:hover {
+  transform: translateY(-1px);
+  box-shadow:
+    0 calc(var(--spacing-xs) + 2px) calc(var(--spacing-m) + 2px)
+      color-mix(in srgb, var(--tile-shadow) 30%, transparent),
+    inset 0 1px 0 color-mix(in srgb, var(--color-text-primary) 72%, transparent);
+}
+
+.clickable:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--tile-accent) 74%, var(--color-text-primary) 26%);
+  outline-offset: 2px;
+}
+
+.clickable:active {
+  transform: translateY(0);
+}
+
+.selected {
+  border-color: color-mix(in srgb, var(--tile-accent) 72%, var(--color-text-primary) 28%);
+  box-shadow:
+    0 calc(var(--spacing-xs) + 2px) calc(var(--spacing-m) + 4px)
+      color-mix(in srgb, var(--tile-shadow) 34%, transparent),
+    0 0 0 2px color-mix(in srgb, var(--tile-accent) 20%, transparent),
+    inset 0 1px 0 color-mix(in srgb, var(--color-text-primary) 72%, transparent);
+}
+
+.sm {
+  width: calc(var(--spacing-xl) + var(--spacing-m));
+  height: calc(var(--spacing-xl) * 2 + var(--spacing-xs));
+}
+
+.md {
+  width: calc(var(--spacing-xl) + var(--spacing-l));
+  height: calc(var(--spacing-xl) * 2 + var(--spacing-m));
+}
+
+.lg {
+  width: calc(var(--spacing-xl) * 2);
+  height: calc(var(--spacing-xl) * 2 + var(--spacing-l));
+}
+
+.manzu {
+  --tile-accent: var(--color-danger);
+  --tile-ink: var(--color-danger);
+  --tile-shadow: var(--color-bg-main);
+}
+
+.pinzu {
+  --tile-accent: var(--color-info);
+  --tile-ink: var(--color-info);
+  --tile-shadow: var(--color-bg-main);
+}
+
+.souzu {
+  --tile-accent: var(--color-success);
+  --tile-ink: var(--color-success);
+  --tile-shadow: var(--color-bg-main);
+}
+
+.honor {
+  --tile-accent: var(--color-text-secondary);
+  --tile-ink: var(--color-bg-main);
+  --tile-shadow: var(--color-bg-main);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-xs);
+  padding-top: calc(var(--spacing-xs) + 2px);
+  width: 100%;
+}
+
+.cornerValue,
+.cornerLabel,
+.footerValue,
+.footerLabel {
+  color: inherit;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
+  line-height: 1;
+}
+
+.cornerLabel,
+.footerLabel {
+  color: color-mix(in srgb, var(--tile-ink) 70%, var(--color-text-secondary) 30%);
+}
+
+.footerLabel {
+  font-size: calc(var(--font-size-xs) - 1px);
+  padding-bottom: 1px;
+}
+
+.symbol {
+  color: inherit;
+  font-size: calc(var(--font-size-xl) + 6px);
+  font-weight: var(--font-weight-bold);
+  line-height: 1;
+}
+
+.honorSymbol {
+  font-size: calc(var(--font-size-xl) + 10px);
+}
+
+.redBadge {
+  background: color-mix(in srgb, var(--color-danger) 18%, var(--color-text-primary) 82%);
+  border-radius: 999px;
+  color: var(--color-danger);
+  font-size: calc(var(--font-size-xs) - 1px);
+  font-weight: var(--font-weight-bold);
+  line-height: 1;
+  padding: 2px var(--spacing-xs);
+}
+
+.redValue {
+  color: var(--color-danger);
+}

--- a/src/components/ui/TileImage.tsx
+++ b/src/components/ui/TileImage.tsx
@@ -1,0 +1,86 @@
+import type { TileCode } from '../../types/analysis';
+import { getTileMetadata } from '../../utils/tiles';
+import styles from './TileImage.module.css';
+
+interface TileImageProps {
+  code: TileCode;
+  size?: 'sm' | 'md' | 'lg';
+  selected?: boolean;
+  pressed?: boolean;
+  onClick?: () => void;
+  disabled?: boolean;
+  ariaLabel?: string;
+  className?: string;
+}
+
+const joinClassNames = (...values: Array<string | false | null | undefined>): string => {
+  return values.filter(Boolean).join(' ');
+};
+
+export const TileImage = ({
+  code,
+  size = 'md',
+  selected = false,
+  pressed,
+  onClick,
+  disabled = false,
+  ariaLabel,
+  className,
+}: TileImageProps) => {
+  const tile = getTileMetadata(code);
+  const tileClassName = joinClassNames(
+    styles.tile,
+    styles[size],
+    styles[tile.group],
+    selected && styles.selected,
+    onClick && styles.clickable,
+    className,
+  );
+
+  const content = (
+    <>
+      <span className={styles.header}>
+        {!tile.isHonor ? (
+          <span className={joinClassNames(styles.cornerValue, tile.isRed && styles.redValue)}>
+            {tile.rankLabel}
+          </span>
+        ) : (
+          <span className={styles.cornerLabel}>字牌</span>
+        )}
+        {tile.isRed ? <span className={styles.redBadge}>赤</span> : null}
+      </span>
+      <span className={joinClassNames(styles.symbol, tile.isHonor && styles.honorSymbol)}>
+        {tile.symbol}
+      </span>
+      {!tile.isHonor ? (
+        <span className={joinClassNames(styles.footerValue, tile.isRed && styles.redValue)}>
+          {tile.rankLabel}
+        </span>
+      ) : (
+        <span className={styles.footerLabel}>{tile.label}</span>
+      )}
+    </>
+  );
+
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        className={tileClassName}
+        aria-label={ariaLabel ?? tile.label}
+        aria-pressed={pressed}
+        title={tile.label}
+        onClick={onClick}
+        disabled={disabled}
+      >
+        {content}
+      </button>
+    );
+  }
+
+  return (
+    <span className={tileClassName} role="img" aria-label={tile.label} title={tile.label}>
+      {content}
+    </span>
+  );
+};

--- a/src/contexts/SnackbarContext.tsx
+++ b/src/contexts/SnackbarContext.tsx
@@ -1,11 +1,15 @@
 import React, { createContext, useCallback, useContext, useState, type ReactNode } from 'react';
 import { Snackbar, type SnackbarPosition } from '../components/ui/Snackbar';
 
+interface SnackbarOptions {
+  autoHideDuration?: number;
+  position?: SnackbarPosition;
+  actionLabel?: string;
+  onAction?: () => void;
+}
+
 interface SnackbarContextType {
-  showSnackbar: (
-    message: string,
-    options?: { autoHideDuration?: number; position?: SnackbarPosition },
-  ) => void;
+  showSnackbar: (message: string, options?: SnackbarOptions) => void;
 }
 
 const SnackbarContext = createContext<SnackbarContextType | undefined>(undefined);
@@ -34,15 +38,19 @@ export const SnackbarProvider: React.FC<SnackbarProviderProps> = ({
   const [message, setMessage] = useState('');
   const [position, setPosition] = useState<SnackbarPosition>(defaultPosition);
   const [duration, setDuration] = useState(defaultDuration);
+  const [actionLabel, setActionLabel] = useState<string | undefined>(undefined);
+  const [actionHandler, setActionHandler] = useState<(() => void) | undefined>(undefined);
 
   const showSnackbar = useCallback(
-    (msg: string, options?: { autoHideDuration?: number; position?: SnackbarPosition }) => {
+    (msg: string, options?: SnackbarOptions) => {
       setMessage(msg);
-      if (options?.position) setPosition(options.position);
-      if (options?.autoHideDuration) setDuration(options.autoHideDuration);
+      setPosition(options?.position ?? defaultPosition);
+      setDuration(options?.autoHideDuration ?? defaultDuration);
+      setActionLabel(options?.actionLabel);
+      setActionHandler(() => options?.onAction);
       setIsOpen(true);
     },
-    [],
+    [defaultDuration, defaultPosition],
   );
 
   const handleClose = useCallback(() => {
@@ -58,6 +66,8 @@ export const SnackbarProvider: React.FC<SnackbarProviderProps> = ({
         onClose={handleClose}
         position={position}
         autoHideDuration={duration}
+        actionLabel={actionLabel}
+        onAction={actionHandler}
       />
     </SnackbarContext.Provider>
   );

--- a/src/hooks/useAnalysisEntries.test.ts
+++ b/src/hooks/useAnalysisEntries.test.ts
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAnalysisEntries } from './useAnalysisEntries';
+
+const mocks = vi.hoisted(() => ({
+  mockAuth: {
+    currentUser: {
+      uid: 'user-1',
+    } as { uid: string } | null,
+  },
+  mockOnAuthStateChanged: vi.fn(),
+  mockSubscribeAnalysisEntries: vi.fn(),
+}));
+
+let authStateCallback: ((user: { uid: string } | null) => void) | null = null;
+
+const createAnalysisEntry = (id: string) => ({
+  id,
+  uid: 'user-1',
+  source: {
+    kind: 'room',
+    roomId: 'room-1',
+    handLogId: `hand-${id}`,
+  },
+  context: {
+    round: {
+      wind: 'East',
+      number: 1,
+      honba: 0,
+    },
+    seatWind: 'East',
+    roundWind: 'East',
+    eventType: 'win',
+    isDealer: true,
+  },
+  hand: {
+    concealed: [],
+    melds: [],
+    wait: [],
+  },
+  dora: {
+    doraIndicators: [],
+    uraIndicators: [],
+    kanDoraIndicators: [],
+    kanUraIndicators: [],
+    redFiveCount: 0,
+  },
+  yaku: {
+    list: [],
+    yakuman: [],
+    ippatsu: false,
+    riichi: 'none',
+    special: null,
+  },
+  notes: '',
+  createdAt: 1000,
+  updatedAt: 2000,
+});
+
+vi.mock('firebase/auth', () => ({
+  onAuthStateChanged: (...args: unknown[]) => mocks.mockOnAuthStateChanged(...args),
+}));
+
+vi.mock('../services/firebase', () => ({
+  auth: mocks.mockAuth,
+}));
+
+vi.mock('../services/analysisService', () => ({
+  subscribeAnalysisEntries: (...args: unknown[]) => mocks.mockSubscribeAnalysisEntries(...args),
+}));
+
+describe('useAnalysisEntries', () => {
+  beforeEach(() => {
+    mocks.mockAuth.currentUser = { uid: 'user-1' };
+    mocks.mockSubscribeAnalysisEntries.mockReset();
+    mocks.mockOnAuthStateChanged.mockReset();
+    mocks.mockOnAuthStateChanged.mockImplementation((_auth, callback) => {
+      authStateCallback = callback;
+      callback(mocks.mockAuth.currentUser);
+      return vi.fn();
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('subscribes for the authenticated user and exposes streamed entries', async () => {
+    const streamedEntries = [createAnalysisEntry('entry-2'), createAnalysisEntry('entry-1')];
+
+    mocks.mockSubscribeAnalysisEntries.mockImplementation((_uid, callback) => {
+      callback(streamedEntries);
+      return vi.fn();
+    });
+
+    const { result } = renderHook(() => useAnalysisEntries());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(mocks.mockSubscribeAnalysisEntries).toHaveBeenCalledWith('user-1', expect.any(Function));
+    expect(result.current.uid).toBe('user-1');
+    expect(result.current.entries).toEqual(streamedEntries);
+  });
+
+  it('stays empty when the user is signed out', async () => {
+    mocks.mockAuth.currentUser = null;
+    mocks.mockOnAuthStateChanged.mockImplementation((_auth, callback) => {
+      callback(null);
+      return vi.fn();
+    });
+
+    const { result } = renderHook(() => useAnalysisEntries());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(mocks.mockSubscribeAnalysisEntries).not.toHaveBeenCalled();
+    expect(result.current.uid).toBeNull();
+    expect(result.current.entries).toEqual([]);
+  });
+
+  it('clears streamed entries immediately when auth changes to signed out', async () => {
+    const streamedEntries = [createAnalysisEntry('entry-1')];
+    mocks.mockSubscribeAnalysisEntries.mockImplementation((_uid, callback) => {
+      callback(streamedEntries);
+      return vi.fn();
+    });
+
+    const { result } = renderHook(() => useAnalysisEntries());
+
+    await waitFor(() => {
+      expect(result.current.entries).toEqual(streamedEntries);
+    });
+
+    authStateCallback?.(null);
+
+    await waitFor(() => {
+      expect(result.current.uid).toBeNull();
+    });
+
+    expect(result.current.entries).toEqual([]);
+  });
+});

--- a/src/hooks/useAnalysisEntries.ts
+++ b/src/hooks/useAnalysisEntries.ts
@@ -1,0 +1,52 @@
+import { onAuthStateChanged } from 'firebase/auth';
+import { useEffect, useState } from 'react';
+import type { AnalysisEntry } from '../types/analysis';
+import { subscribeAnalysisEntries } from '../services/analysisService';
+import { auth } from '../services/firebase';
+
+interface UseAnalysisEntriesResult {
+  uid: string | null;
+  entries: AnalysisEntry[];
+  loading: boolean;
+}
+
+export const useAnalysisEntries = (): UseAnalysisEntriesResult => {
+  const [uid, setUid] = useState<string | null>(auth.currentUser?.uid ?? null);
+  const [entries, setEntries] = useState<AnalysisEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, (user) => {
+      setEntries([]);
+      setUid(user?.uid ?? null);
+
+      if (!user) {
+        setLoading(false);
+        return;
+      }
+
+      setLoading(true);
+    });
+
+    return () => unsubscribe();
+  }, []);
+
+  useEffect(() => {
+    if (!uid) {
+      return;
+    }
+
+    const unsubscribe = subscribeAnalysisEntries(uid, (nextEntries) => {
+      setEntries(nextEntries);
+      setLoading(false);
+    });
+
+    return () => unsubscribe();
+  }, [uid]);
+
+  return {
+    uid,
+    entries: uid ? entries : [],
+    loading,
+  };
+};

--- a/src/hooks/useAnalysisEntry.test.ts
+++ b/src/hooks/useAnalysisEntry.test.ts
@@ -1,0 +1,331 @@
+// @vitest-environment jsdom
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAnalysisEntry } from './useAnalysisEntry';
+import type { AnalysisSource } from '../types/analysis';
+
+const mocks = vi.hoisted(() => ({
+  mockAuth: {
+    currentUser: {
+      uid: 'user-1',
+    } as { uid: string } | null,
+  },
+  mockOnAuthStateChanged: vi.fn(),
+  mockDeleteAnalysisEntry: vi.fn(),
+  mockFindAnalysisEntryByHandLog: vi.fn(),
+  mockGetAnalysisEntry: vi.fn(),
+  mockSaveAnalysisEntry: vi.fn(),
+}));
+
+let authStateCallback: ((user: { uid: string } | null) => void) | null = null;
+
+const createAnalysisEntry = (id = 'entry-1') => ({
+  id,
+  uid: 'user-1',
+  source: {
+    kind: 'room' as const,
+    roomId: 'room-1',
+    handLogId: 'hand-1',
+  },
+  context: {
+    round: {
+      wind: 'East' as const,
+      number: 1,
+      honba: 0,
+    },
+    seatWind: 'East' as const,
+    roundWind: 'East' as const,
+    eventType: 'win' as const,
+    isDealer: true,
+  },
+  hand: {
+    concealed: [],
+    melds: [],
+    wait: [],
+  },
+  dora: {
+    doraIndicators: [],
+    uraIndicators: [],
+    kanDoraIndicators: [],
+    kanUraIndicators: [],
+    redFiveCount: 0,
+  },
+  yaku: {
+    list: [],
+    yakuman: [],
+    ippatsu: false,
+    riichi: 'none' as const,
+    special: null,
+  },
+  notes: '',
+  createdAt: 1000,
+  updatedAt: 2000,
+});
+
+vi.mock('firebase/auth', () => ({
+  onAuthStateChanged: (...args: unknown[]) => mocks.mockOnAuthStateChanged(...args),
+}));
+
+vi.mock('../services/firebase', () => ({
+  auth: mocks.mockAuth,
+}));
+
+vi.mock('../services/analysisService', () => ({
+  deleteAnalysisEntry: (...args: unknown[]) => mocks.mockDeleteAnalysisEntry(...args),
+  findAnalysisEntryByHandLog: (...args: unknown[]) => mocks.mockFindAnalysisEntryByHandLog(...args),
+  getAnalysisEntry: (...args: unknown[]) => mocks.mockGetAnalysisEntry(...args),
+  saveAnalysisEntry: (...args: unknown[]) => mocks.mockSaveAnalysisEntry(...args),
+}));
+
+describe('useAnalysisEntry', () => {
+  beforeEach(() => {
+    mocks.mockAuth.currentUser = { uid: 'user-1' };
+    mocks.mockDeleteAnalysisEntry.mockReset();
+    mocks.mockFindAnalysisEntryByHandLog.mockReset();
+    mocks.mockGetAnalysisEntry.mockReset();
+    mocks.mockSaveAnalysisEntry.mockReset();
+    mocks.mockOnAuthStateChanged.mockReset();
+    mocks.mockOnAuthStateChanged.mockImplementation((_auth, callback) => {
+      authStateCallback = callback;
+      callback(mocks.mockAuth.currentUser);
+      return vi.fn();
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('loads an entry by entryId for the authenticated user', async () => {
+    const entry = createAnalysisEntry();
+    mocks.mockGetAnalysisEntry.mockResolvedValue(entry);
+
+    const { result } = renderHook(() => useAnalysisEntry({ entryId: 'entry-1' }));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(mocks.mockGetAnalysisEntry).toHaveBeenCalledWith('user-1', 'entry-1');
+    expect(result.current.analysisEntry).toEqual(entry);
+  });
+
+  it('falls back to loading by source when no entryId is provided', async () => {
+    const entry = createAnalysisEntry('entry-2');
+    const source = {
+      kind: 'competition' as const,
+      competitionId: 'competition-1',
+      gameResultId: 'game-1',
+      handLogId: 'hand-2',
+    };
+    mocks.mockFindAnalysisEntryByHandLog.mockResolvedValue(entry);
+
+    const { result } = renderHook(() => useAnalysisEntry({ source }));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(mocks.mockFindAnalysisEntryByHandLog).toHaveBeenCalledWith('user-1', source);
+    expect(result.current.analysisEntry).toEqual(entry);
+  });
+
+  it('saves the current entry with the authenticated uid', async () => {
+    const entry = createAnalysisEntry();
+    mocks.mockGetAnalysisEntry.mockResolvedValue(entry);
+
+    const { result } = renderHook(() => useAnalysisEntry({ entryId: 'entry-1' }));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    const updatedEntry = {
+      ...entry,
+      notes: 'updated',
+    };
+
+    await act(async () => {
+      await result.current.saveAnalysisEntry(updatedEntry);
+    });
+
+    expect(mocks.mockSaveAnalysisEntry).toHaveBeenCalledWith('user-1', updatedEntry);
+    expect(result.current.analysisEntry).toEqual({
+      ...updatedEntry,
+      uid: 'user-1',
+    });
+  });
+
+  it('exposes a draft entry that can be reset independently from the loaded entry', async () => {
+    const entry = createAnalysisEntry();
+    mocks.mockGetAnalysisEntry.mockResolvedValue(entry);
+
+    const { result } = renderHook(() => useAnalysisEntry({ entryId: 'entry-1' }));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    act(() => {
+      result.current.setDraftAnalysisEntry({
+        ...entry,
+        notes: 'draft note',
+      });
+    });
+
+    expect(result.current.hasDraftChanges).toBe(true);
+    expect(result.current.draftAnalysisEntry?.notes).toBe('draft note');
+    expect(result.current.analysisEntry?.notes).toBe('');
+
+    act(() => {
+      result.current.resetDraftAnalysisEntry();
+    });
+
+    expect(result.current.hasDraftChanges).toBe(false);
+    expect(result.current.draftAnalysisEntry).toEqual(entry);
+  });
+
+  it('keeps draft changes when rerendered with an equivalent source object', async () => {
+    const entry = createAnalysisEntry('entry-2');
+    const source = {
+      kind: 'competition' as const,
+      competitionId: 'competition-1',
+      gameResultId: 'game-1',
+      handLogId: 'hand-2',
+    };
+    mocks.mockFindAnalysisEntryByHandLog.mockResolvedValue(entry);
+
+    const { result, rerender } = renderHook(
+      ({ nextSource }) => useAnalysisEntry({ source: nextSource }),
+      {
+        initialProps: { nextSource: source },
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    act(() => {
+      result.current.setDraftAnalysisEntry({
+        ...entry,
+        notes: 'local draft',
+      });
+    });
+
+    const callsBeforeRerender = mocks.mockFindAnalysisEntryByHandLog.mock.calls.length;
+
+    rerender({
+      nextSource: {
+        kind: 'competition',
+        competitionId: 'competition-1',
+        gameResultId: 'game-1',
+        handLogId: 'hand-2',
+      },
+    });
+
+    expect(mocks.mockFindAnalysisEntryByHandLog.mock.calls.length).toBe(callsBeforeRerender);
+    expect(result.current.hasDraftChanges).toBe(true);
+    expect(mocks.mockFindAnalysisEntryByHandLog).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the previous entry immediately when switching to a different source', async () => {
+    const firstEntry = createAnalysisEntry('entry-1');
+    const secondEntry = createAnalysisEntry('entry-2');
+    const firstSource: AnalysisSource = {
+      kind: 'room' as const,
+      roomId: 'room-1',
+      handLogId: 'hand-1',
+    };
+    const secondSource: AnalysisSource = {
+      kind: 'competition' as const,
+      competitionId: 'competition-1',
+      gameResultId: 'game-1',
+      handLogId: 'hand-2',
+    };
+
+    let resolveSecondEntry: ((entry: typeof secondEntry | null) => void) | undefined;
+
+    mocks.mockFindAnalysisEntryByHandLog.mockImplementation((_uid, source) => {
+      if (source.handLogId === 'hand-1') {
+        return Promise.resolve(firstEntry);
+      }
+
+      return new Promise((resolve) => {
+        resolveSecondEntry = resolve;
+      });
+    });
+
+    const { result, rerender } = renderHook(
+      ({ nextSource }: { nextSource: AnalysisSource }) => useAnalysisEntry({ source: nextSource }),
+      {
+        initialProps: { nextSource: firstSource },
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.analysisEntry?.id).toBe('entry-1');
+    });
+
+    rerender({ nextSource: secondSource });
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.analysisEntry).toBeNull();
+    expect(result.current.draftAnalysisEntry).toBeNull();
+
+    expect(resolveSecondEntry).toBeDefined();
+    resolveSecondEntry?.(secondEntry);
+
+    await waitFor(() => {
+      expect(result.current.analysisEntry?.id).toBe('entry-2');
+    });
+  });
+
+  it('deletes the currently loaded entry', async () => {
+    const entry = createAnalysisEntry();
+    mocks.mockGetAnalysisEntry.mockResolvedValue(entry);
+
+    const { result } = renderHook(() => useAnalysisEntry({ entryId: 'entry-1' }));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.deleteAnalysisEntry();
+    });
+
+    expect(mocks.mockDeleteAnalysisEntry).toHaveBeenCalledWith('user-1', 'entry-1');
+    expect(result.current.analysisEntry).toBeNull();
+    expect(result.current.draftAnalysisEntry).toBeNull();
+  });
+
+  it('clears loaded entry and draft immediately when auth changes to signed out', async () => {
+    const entry = createAnalysisEntry();
+    mocks.mockGetAnalysisEntry.mockResolvedValue(entry);
+
+    const { result } = renderHook(() => useAnalysisEntry({ entryId: 'entry-1' }));
+
+    await waitFor(() => {
+      expect(result.current.analysisEntry).toEqual(entry);
+    });
+
+    act(() => {
+      result.current.setDraftAnalysisEntry({
+        ...entry,
+        notes: 'draft note',
+      });
+    });
+
+    authStateCallback?.(null);
+
+    await waitFor(() => {
+      expect(result.current.uid).toBeNull();
+    });
+
+    expect(result.current.analysisEntry).toBeNull();
+    expect(result.current.draftAnalysisEntry).toBeNull();
+    expect(result.current.hasDraftChanges).toBe(false);
+  });
+});

--- a/src/hooks/useAnalysisEntry.ts
+++ b/src/hooks/useAnalysisEntry.ts
@@ -1,0 +1,205 @@
+import { onAuthStateChanged } from 'firebase/auth';
+import { useEffect, useMemo, useState } from 'react';
+import {
+  deleteAnalysisEntry as removeAnalysisEntry,
+  findAnalysisEntryByHandLog,
+  getAnalysisEntry,
+  saveAnalysisEntry as persistAnalysisEntry,
+} from '../services/analysisService';
+import { auth } from '../services/firebase';
+import type { AnalysisEntry, AnalysisSource } from '../types/analysis';
+
+interface UseAnalysisEntryOptions {
+  entryId?: string | null;
+  source?: AnalysisSource | null;
+}
+
+interface UseAnalysisEntryResult {
+  uid: string | null;
+  analysisEntry: AnalysisEntry | null;
+  draftAnalysisEntry: AnalysisEntry | null;
+  hasDraftChanges: boolean;
+  loading: boolean;
+  saving: boolean;
+  deleting: boolean;
+  setDraftAnalysisEntry: (entry: AnalysisEntry | null) => void;
+  resetDraftAnalysisEntry: () => void;
+  saveAnalysisEntry: (entry: AnalysisEntry) => Promise<void>;
+  deleteAnalysisEntry: () => Promise<void>;
+}
+
+const loadAnalysisEntry = async (
+  uid: string,
+  entryId?: string | null,
+  source?: AnalysisSource | null,
+): Promise<AnalysisEntry | null> => {
+  if (entryId) {
+    return getAnalysisEntry(uid, entryId);
+  }
+
+  if (source) {
+    return findAnalysisEntryByHandLog(uid, source);
+  }
+
+  return null;
+};
+
+const getSourceKey = (source?: AnalysisSource | null): string | null => {
+  if (!source) {
+    return null;
+  }
+
+  return [
+    source.kind,
+    source.handLogId,
+    source.roomId ?? '',
+    source.competitionId ?? '',
+    source.gameResultId ?? '',
+  ].join(':');
+};
+
+const getSourceFromKey = (sourceKey: string | null): AnalysisSource | null => {
+  if (!sourceKey) {
+    return null;
+  }
+
+  const [kind, handLogId, roomId, competitionId, gameResultId] = sourceKey.split(':');
+
+  if ((kind !== 'room' && kind !== 'competition') || !handLogId) {
+    return null;
+  }
+
+  return {
+    kind,
+    handLogId,
+    ...(roomId ? { roomId } : {}),
+    ...(competitionId ? { competitionId } : {}),
+    ...(gameResultId ? { gameResultId } : {}),
+  };
+};
+
+export const useAnalysisEntry = ({
+  entryId,
+  source,
+}: UseAnalysisEntryOptions): UseAnalysisEntryResult => {
+  const sourceKey = getSourceKey(source);
+  const stableSource = useMemo(() => getSourceFromKey(sourceKey), [sourceKey]);
+  const [uid, setUid] = useState<string | null>(auth.currentUser?.uid ?? null);
+  const [analysisEntry, setAnalysisEntry] = useState<AnalysisEntry | null>(null);
+  const [draftAnalysisEntry, setDraftAnalysisEntry] = useState<AnalysisEntry | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, (user) => {
+      setAnalysisEntry(null);
+      setDraftAnalysisEntry(null);
+      setUid(user?.uid ?? null);
+
+      if (!user) {
+        setLoading(false);
+        return;
+      }
+
+      setLoading(true);
+    });
+
+    return () => unsubscribe();
+  }, []);
+
+  useEffect(() => {
+    if (!uid) {
+      setAnalysisEntry(null);
+      setDraftAnalysisEntry(null);
+      setLoading(false);
+      return;
+    }
+
+    if (!entryId && !stableSource) {
+      setAnalysisEntry(null);
+      setDraftAnalysisEntry(null);
+      setLoading(false);
+      return;
+    }
+
+    let isCancelled = false;
+    setAnalysisEntry(null);
+    setDraftAnalysisEntry(null);
+    setLoading(true);
+
+    void loadAnalysisEntry(uid, entryId, stableSource)
+      .then((entry) => {
+        if (!isCancelled) {
+          setAnalysisEntry(entry);
+          setDraftAnalysisEntry(null);
+          setLoading(false);
+        }
+      })
+      .catch(() => {
+        if (!isCancelled) {
+          setAnalysisEntry(null);
+          setDraftAnalysisEntry(null);
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [entryId, stableSource, uid]);
+
+  const saveAnalysisEntry = async (entry: AnalysisEntry) => {
+    if (!uid) {
+      throw new Error('認証されていません');
+    }
+
+    setSaving(true);
+
+    try {
+      await persistAnalysisEntry(uid, entry);
+      setAnalysisEntry({
+        ...entry,
+        uid,
+      });
+      setDraftAnalysisEntry(null);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const deleteAnalysisEntry = async () => {
+    if (!uid) {
+      throw new Error('認証されていません');
+    }
+
+    const targetEntryId = analysisEntry?.id ?? entryId;
+    if (!targetEntryId) {
+      return;
+    }
+
+    setDeleting(true);
+
+    try {
+      await removeAnalysisEntry(uid, targetEntryId);
+      setAnalysisEntry(null);
+      setDraftAnalysisEntry(null);
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  return {
+    uid,
+    analysisEntry,
+    loading,
+    saving,
+    deleting,
+    draftAnalysisEntry: draftAnalysisEntry ?? analysisEntry,
+    hasDraftChanges: draftAnalysisEntry !== null,
+    setDraftAnalysisEntry,
+    resetDraftAnalysisEntry: () => setDraftAnalysisEntry(null),
+    saveAnalysisEntry,
+    deleteAnalysisEntry,
+  };
+};

--- a/src/hooks/useMatchGame.ts
+++ b/src/hooks/useMatchGame.ts
@@ -24,8 +24,8 @@ export interface UseMatchGameReturn {
       loserId: string | null;
       chips: number;
     }[],
-  ) => Promise<void>;
-  handleRyukyoku: (tenpaiIds: string[]) => Promise<void>;
+  ) => Promise<HandLog | null>;
+  handleRyukyoku: (tenpaiIds: string[]) => Promise<HandLog | null>;
   handleUndo: () => Promise<void>;
   handleRiichi: (playerId: string) => Promise<void>;
   handleStartGame: () => Promise<void>;
@@ -148,7 +148,7 @@ export const useMatchGame = ({ room, updateState }: UseMatchGameOptions): UseMat
         chips: number;
       }[],
     ) => {
-      if (!room) return;
+      if (!room) return null;
 
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { history: _h, ...currentStateSnapshot } = room;
@@ -295,13 +295,15 @@ export const useMatchGame = ({ room, updateState }: UseMatchGameOptions): UseMat
         gameResults: nextGameResults,
         currentLogs: nextState.isGameOver ? [] : nextLogs,
       });
+
+      return newLog;
     },
     [room, updateState, triggerGameEndTransition],
   );
 
   const handleRyukyoku = useCallback(
     async (tenpaiIds: string[]) => {
-      if (!room) return;
+      if (!room) return null;
 
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { history: _h, ...currentStateSnapshot } = room;
@@ -380,6 +382,8 @@ export const useMatchGame = ({ room, updateState }: UseMatchGameOptions): UseMat
         gameResults: nextGameResults,
         currentLogs: nextState.isGameOver ? [] : nextLogs,
       });
+
+      return newLog;
     },
     [room, updateState, triggerGameEndTransition],
   );

--- a/src/pages/AnalysisListPage.module.css
+++ b/src/pages/AnalysisListPage.module.css
@@ -1,0 +1,150 @@
+.container {
+  max-width: 880px;
+  margin: 0 auto;
+  padding: var(--spacing-m);
+  color: var(--color-text-primary);
+  display: grid;
+  gap: var(--spacing-l);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-m);
+}
+
+.titleArea {
+  display: grid;
+  gap: var(--spacing-xs);
+}
+
+.title {
+  margin: 0;
+  font-size: var(--font-size-xl);
+}
+
+.subtitle {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-s);
+}
+
+.filters {
+  display: grid;
+  gap: var(--spacing-s);
+  padding: var(--spacing-m);
+  border-radius: var(--border-radius-m);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.filterGrid {
+  display: grid;
+  gap: var(--spacing-s);
+}
+
+.field {
+  display: grid;
+  gap: var(--spacing-xs);
+  color: var(--color-text-primary);
+}
+
+.select {
+  min-height: 42px;
+  border-radius: var(--border-radius-m);
+  border: 1px solid var(--color-text-secondary);
+  background: var(--color-bg-card);
+  color: var(--color-text-primary);
+  padding: 0 12px;
+}
+
+.list {
+  display: grid;
+  gap: var(--spacing-s);
+}
+
+.item {
+  display: grid;
+  gap: var(--spacing-s);
+  padding: var(--spacing-m);
+  border-radius: var(--border-radius-m);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.viewButton {
+  display: grid;
+  gap: var(--spacing-s);
+  width: 100%;
+  border: none;
+  background: transparent;
+  color: var(--color-text-primary);
+  text-align: left;
+  padding: 0;
+}
+
+.itemHeader,
+.itemMeta,
+.itemFooter {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-s);
+}
+
+.itemHeader {
+  align-items: flex-start;
+}
+
+.itemTitle {
+  font-size: var(--font-size-m);
+  font-weight: var(--font-weight-bold);
+}
+
+.itemMeta {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-s);
+}
+
+.notes {
+  color: var(--color-text-primary);
+  font-size: var(--font-size-m);
+}
+
+.actions {
+  display: flex;
+  gap: var(--spacing-s);
+}
+
+.chip {
+  border-radius: 999px;
+  padding: 2px 10px;
+  background: rgba(76, 175, 80, 0.16);
+  color: var(--color-text-accent);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
+}
+
+.empty {
+  padding: var(--spacing-xl);
+  border-radius: var(--border-radius-m);
+  text-align: center;
+  color: var(--color-text-secondary);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+@media (min-width: 640px) {
+  .filterGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 600px) {
+  .header,
+  .itemHeader,
+  .itemMeta,
+  .itemFooter {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/src/pages/AnalysisListPage.test.tsx
+++ b/src/pages/AnalysisListPage.test.tsx
@@ -1,0 +1,193 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AnalysisEntry } from '../types';
+import { AnalysisListPage } from './AnalysisListPage';
+
+const mockNavigate = vi.fn();
+const mockSaveAnalysisEntry = vi.fn();
+const mockDeleteAnalysisEntry = vi.fn();
+
+const entries: AnalysisEntry[] = [
+  {
+    id: 'entry-1',
+    uid: 'user-1',
+    source: {
+      kind: 'room',
+      roomId: 'room-1',
+      handLogId: 'hand-1',
+    },
+    context: {
+      round: { wind: 'East', number: 1, honba: 0 },
+      seatWind: 'East',
+      roundWind: 'East',
+      eventType: 'win',
+      isDealer: true,
+    },
+    hand: { concealed: [], melds: [], wait: [] },
+    dora: {
+      doraIndicators: [],
+      uraIndicators: [],
+      kanDoraIndicators: [],
+      kanUraIndicators: [],
+      redFiveCount: 0,
+    },
+    yaku: {
+      list: ['riichi'],
+      yakuman: [],
+      ippatsu: false,
+      riichi: 'normal',
+      special: null,
+      han: 3,
+      fu: 40,
+    },
+    notes: 'リーチ判断',
+    createdAt: 1710000000000,
+    updatedAt: 1710000002000,
+  },
+  {
+    id: 'entry-2',
+    uid: 'user-1',
+    source: {
+      kind: 'competition',
+      competitionId: 'competition-1',
+      gameResultId: 'game-1',
+      handLogId: 'hand-2',
+    },
+    context: {
+      round: { wind: 'South', number: 2, honba: 1 },
+      seatWind: 'South',
+      roundWind: 'South',
+      eventType: 'deal-in',
+      isDealer: false,
+    },
+    hand: { concealed: [], melds: [], wait: [] },
+    dora: {
+      doraIndicators: [],
+      uraIndicators: [],
+      kanDoraIndicators: [],
+      kanUraIndicators: [],
+      redFiveCount: 0,
+    },
+    yaku: {
+      list: [],
+      yakuman: [],
+      ippatsu: false,
+      riichi: 'none',
+      special: null,
+    },
+    notes: '押し返し失敗',
+    createdAt: 1710000000000,
+    updatedAt: 1710000001000,
+  },
+];
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock('../hooks/useAnalysisEntries', () => ({
+  useAnalysisEntries: () => ({
+    uid: 'user-1',
+    entries,
+    loading: false,
+  }),
+}));
+
+vi.mock('../hooks/useAnalysisEntry', () => ({
+  useAnalysisEntry: ({ entryId }: { entryId?: string | null }) => ({
+    uid: 'user-1',
+    analysisEntry: entries.find((entry) => entry.id === entryId) ?? null,
+    draftAnalysisEntry: entries.find((entry) => entry.id === entryId) ?? null,
+    hasDraftChanges: false,
+    loading: false,
+    saving: false,
+    deleting: false,
+    setDraftAnalysisEntry: vi.fn(),
+    resetDraftAnalysisEntry: vi.fn(),
+    saveAnalysisEntry: mockSaveAnalysisEntry,
+    deleteAnalysisEntry: mockDeleteAnalysisEntry,
+  }),
+}));
+
+vi.mock('../components/features/AnalysisDetailModal', () => ({
+  AnalysisDetailModal: ({
+    isOpen,
+    mode,
+    entry,
+    onClose,
+    onSave,
+    onDelete,
+  }: {
+    isOpen: boolean;
+    mode: string;
+    entry: AnalysisEntry;
+    onClose: () => void;
+    onSave?: (entry: AnalysisEntry) => Promise<void> | void;
+    onDelete?: (entry: AnalysisEntry) => Promise<void> | void;
+  }) => {
+    if (!isOpen) {
+      return null;
+    }
+
+    return (
+      <div>
+        <span>modal:{mode}</span>
+        <span>{entry.id}</span>
+        <button type="button" onClick={() => onSave?.(entry)}>
+          save
+        </button>
+        <button type="button" onClick={() => onDelete?.(entry)}>
+          delete
+        </button>
+        <button type="button" onClick={onClose}>
+          close
+        </button>
+      </div>
+    );
+  },
+}));
+
+describe('AnalysisListPage', () => {
+  beforeEach(() => {
+    mockNavigate.mockReset();
+    mockSaveAnalysisEntry.mockReset();
+    mockDeleteAnalysisEntry.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('filters entries by event type and opens view mode from the list', async () => {
+    render(<AnalysisListPage />);
+
+    expect(screen.getByText('リーチ判断')).not.toBeNull();
+    expect(screen.getByText('押し返し失敗')).not.toBeNull();
+    expect(screen.getByText('立直')).not.toBeNull();
+
+    fireEvent.change(screen.getByLabelText('イベント種別'), {
+      target: { value: 'deal-in' },
+    });
+
+    expect(screen.queryByText('リーチ判断')).toBeNull();
+    expect(screen.getByText('押し返し失敗')).not.toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: '南2局 1本場 放銃' }));
+
+    expect(screen.getByText('modal:view')).not.toBeNull();
+    expect(screen.getByText('entry-2')).not.toBeNull();
+  });
+
+  it('opens edit mode and saves the selected entry', async () => {
+    render(<AnalysisListPage />);
+
+    fireEvent.click(screen.getAllByRole('button', { name: '編集' })[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'save' }));
+
+    await waitFor(() => {
+      expect(mockSaveAnalysisEntry).toHaveBeenCalledWith(entries[0]);
+    });
+  });
+});

--- a/src/pages/AnalysisListPage.tsx
+++ b/src/pages/AnalysisListPage.tsx
@@ -1,0 +1,225 @@
+import { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { AnalysisDetailModal } from '../components/features/AnalysisDetailModal';
+import { Button } from '../components/ui/Button';
+import { useAnalysisEntries } from '../hooks/useAnalysisEntries';
+import { useAnalysisEntry } from '../hooks/useAnalysisEntry';
+import {
+  YAKU_DEFS,
+  YAKUMAN_DEFS,
+  type AnalysisEventType,
+  type AnalysisEntry,
+} from '../types/analysis';
+import { getTimestampValue } from '../utils/analysisEvents';
+import styles from './AnalysisListPage.module.css';
+
+type FilterPeriod = 'all' | '7d' | '30d' | '90d';
+type ModalMode = 'view' | 'edit';
+
+const EVENT_LABELS: Record<AnalysisEventType, string> = {
+  win: '和了',
+  'deal-in': '放銃',
+  'tenpai-draw': 'テンパイ流局',
+};
+
+const PERIOD_LABELS: Record<FilterPeriod, string> = {
+  all: 'すべて',
+  '7d': '7日以内',
+  '30d': '30日以内',
+  '90d': '90日以内',
+};
+
+const PERIOD_TO_MS: Record<Exclude<FilterPeriod, 'all'>, number> = {
+  '7d': 7 * 24 * 60 * 60 * 1000,
+  '30d': 30 * 24 * 60 * 60 * 1000,
+  '90d': 90 * 24 * 60 * 60 * 1000,
+};
+
+const formatRoundLabel = (entry: ReturnType<typeof useAnalysisEntries>['entries'][number]) => {
+  const windLabel = { East: '東', South: '南', West: '西', North: '北' }[entry.context.round.wind];
+  return `${windLabel}${entry.context.round.number}局 ${entry.context.round.honba}本場`;
+};
+
+const formatUpdatedAtLabel = (updatedAt: number | object) => {
+  const timestamp = getTimestampValue(updatedAt);
+  if (timestamp === 0) {
+    return '更新日時不明';
+  }
+
+  return new Date(timestamp).toLocaleString('ja-JP');
+};
+
+const formatYakuPreview = (entry: AnalysisEntry) => {
+  const labels = [
+    ...entry.yaku.yakuman.map((yakumanId) => YAKUMAN_DEFS[yakumanId].label),
+    ...entry.yaku.list.map((yakuId) => YAKU_DEFS[yakuId].label),
+  ].slice(0, 2);
+
+  return labels.length > 0 ? labels.join(' / ') : '役未入力';
+};
+
+export const AnalysisListPage = () => {
+  const navigate = useNavigate();
+  const { entries, loading } = useAnalysisEntries();
+  const [currentTime] = useState(() => Date.now());
+  const [periodFilter, setPeriodFilter] = useState<FilterPeriod>('all');
+  const [eventFilter, setEventFilter] = useState<'all' | AnalysisEventType>('all');
+  const [selectedEntryId, setSelectedEntryId] = useState<string | null>(null);
+  const [modalMode, setModalMode] = useState<ModalMode>('view');
+
+  const {
+    analysisEntry,
+    loading: entryLoading,
+    saving,
+    deleting,
+    saveAnalysisEntry,
+    deleteAnalysisEntry,
+  } = useAnalysisEntry({ entryId: selectedEntryId });
+
+  const filteredEntries = useMemo(() => {
+    return [...entries]
+      .sort((left, right) => getTimestampValue(right.updatedAt) - getTimestampValue(left.updatedAt))
+      .filter((entry) => {
+        if (eventFilter !== 'all' && entry.context.eventType !== eventFilter) {
+          return false;
+        }
+
+        if (periodFilter === 'all') {
+          return true;
+        }
+
+        return currentTime - getTimestampValue(entry.updatedAt) <= PERIOD_TO_MS[periodFilter];
+      });
+  }, [currentTime, entries, eventFilter, periodFilter]);
+
+  const closeModal = () => {
+    setSelectedEntryId(null);
+    setModalMode('view');
+  };
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.header}>
+        <div className={styles.titleArea}>
+          <h1 className={styles.title}>分析ノート</h1>
+          <span className={styles.subtitle}>保存済みの局面メモを絞り込んで振り返れます。</span>
+        </div>
+        <Button variant="secondary" onClick={() => navigate('/')}>
+          トップへ
+        </Button>
+      </div>
+
+      <section className={styles.filters}>
+        <div className={styles.filterGrid}>
+          <label className={styles.field}>
+            <span>期間</span>
+            <select
+              className={styles.select}
+              value={periodFilter}
+              onChange={(event) => setPeriodFilter(event.target.value as FilterPeriod)}
+            >
+              {Object.entries(PERIOD_LABELS).map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className={styles.field}>
+            <span>イベント種別</span>
+            <select
+              className={styles.select}
+              aria-label="イベント種別"
+              value={eventFilter}
+              onChange={(event) => setEventFilter(event.target.value as 'all' | AnalysisEventType)}
+            >
+              <option value="all">すべて</option>
+              {Object.entries(EVENT_LABELS).map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      </section>
+
+      {loading ? <div className={styles.empty}>読み込み中...</div> : null}
+
+      {!loading ? (
+        <div className={styles.list}>
+          {filteredEntries.length === 0 ? (
+            <div className={styles.empty}>条件に一致する分析ノートはありません。</div>
+          ) : (
+            filteredEntries.map((entry) => (
+              <div key={entry.id} className={styles.item}>
+                <button
+                  type="button"
+                  className={styles.viewButton}
+                  onClick={() => {
+                    setSelectedEntryId(entry.id);
+                    setModalMode('view');
+                  }}
+                  aria-label={`${formatRoundLabel(entry)} ${EVENT_LABELS[entry.context.eventType]}`}
+                >
+                  <div className={styles.itemHeader}>
+                    <div>
+                      <div className={styles.itemTitle}>{formatRoundLabel(entry)}</div>
+                      <div className={styles.itemMeta}>
+                        <span>{entry.source.kind === 'competition' ? '大会対局' : '通常対局'}</span>
+                        <span>{formatUpdatedAtLabel(entry.updatedAt)}</span>
+                      </div>
+                    </div>
+                    <span className={styles.chip}>{EVENT_LABELS[entry.context.eventType]}</span>
+                  </div>
+                  <div className={styles.notes}>{entry.notes || 'メモなし'}</div>
+                </button>
+                <div className={styles.itemFooter}>
+                  <span className={styles.itemMeta}>{formatYakuPreview(entry)}</span>
+                  <div className={styles.actions}>
+                    <Button
+                      variant="secondary"
+                      size="small"
+                      onClick={() => {
+                        setSelectedEntryId(entry.id);
+                        setModalMode('edit');
+                      }}
+                    >
+                      編集
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      ) : null}
+      {selectedEntryId && analysisEntry && !entryLoading ? (
+        <AnalysisDetailModal
+          isOpen
+          mode={modalMode}
+          entry={analysisEntry}
+          isSaving={saving}
+          isDeleting={deleting}
+          onClose={closeModal}
+          onSave={
+            modalMode === 'edit'
+              ? async (entry) => {
+                  await saveAnalysisEntry(entry);
+                  closeModal();
+                }
+              : undefined
+          }
+          onDelete={
+            modalMode === 'edit'
+              ? async () => {
+                  await deleteAnalysisEntry();
+                  closeModal();
+                }
+              : undefined
+          }
+        />
+      ) : null}
+    </div>
+  );
+};

--- a/src/pages/CompetitionReportPage.tsx
+++ b/src/pages/CompetitionReportPage.tsx
@@ -1,6 +1,12 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
+import { AnalysisEventList } from '../components/features/AnalysisEventList';
+import {
+  AnalysisEventModalLauncher,
+  type AnalysisModalSelection,
+} from '../components/features/AnalysisEventModalLauncher';
 import { Button } from '../components/ui/Button';
+import { useAnalysisEntries } from '../hooks/useAnalysisEntries';
 import { useCompetition } from '../hooks/useCompetition';
 import {
   aggregateMatchDetails,
@@ -14,6 +20,7 @@ import {
   generateReportFilename,
 } from '../utils/exportReport';
 import { formatAverageRank, formatPoint } from '../utils/formatUtils';
+import { buildCompetitionAnalysisEvents } from '../utils/analysisEvents';
 import styles from './CompetitionReportPage.module.css';
 
 const pointClass = (pt: number): string => {
@@ -25,6 +32,8 @@ const pointClass = (pt: number): string => {
 export const CompetitionReportPage = () => {
   const { id } = useParams<{ id: string }>();
   const { competition, participants, tables, gameResults, loading } = useCompetition(id ?? '');
+  const { uid, entries: analysisEntries } = useAnalysisEntries();
+  const [analysisSelection, setAnalysisSelection] = useState<AnalysisModalSelection | null>(null);
 
   const standings = useMemo(
     () => aggregateOverallStandings(gameResults, participants),
@@ -40,6 +49,18 @@ export const CompetitionReportPage = () => {
     () => aggregateTableSummary(tables, participants, gameResults),
     [tables, participants, gameResults],
   );
+
+  const analysisEvents = useMemo(() => {
+    if (!id || !uid) {
+      return [];
+    }
+
+    return buildCompetitionAnalysisEvents(id, gameResults, participants, uid);
+  }, [gameResults, id, participants, uid]);
+
+  const savedHandLogIds = useMemo(() => {
+    return new Set(analysisEntries.map((entry) => entry.source.handLogId));
+  }, [analysisEntries]);
 
   const useChip = competition?.settings.useChip ?? false;
   const isInProgress = competition?.status === 'in_progress';
@@ -185,6 +206,22 @@ export const CompetitionReportPage = () => {
         )}
       </div>
 
+      <div className={styles.section}>
+        <h2 className={styles.sectionTitle}>詳細分析対象イベント</h2>
+        <AnalysisEventList
+          events={analysisEvents}
+          savedHandLogIds={savedHandLogIds}
+          emptyMessage="この大会で分析対象のイベントはまだありません。"
+          onSelect={(event) => {
+            setAnalysisSelection({
+              handLog: event.handLog,
+              source: event.source,
+              players: event.players,
+            });
+          }}
+        />
+      </div>
+
       {/* Table Summary */}
       <div className={styles.section}>
         <h2 className={styles.sectionTitle}>卓別サマリ</h2>
@@ -223,6 +260,12 @@ export const CompetitionReportPage = () => {
           <div className={styles.center}>卓がまだ作成されていません</div>
         )}
       </div>
+
+      <AnalysisEventModalLauncher
+        isOpen={analysisSelection !== null}
+        selection={analysisSelection}
+        onClose={() => setAnalysisSelection(null)}
+      />
     </div>
   );
 };

--- a/src/pages/CompetitionTablePage.module.css
+++ b/src/pages/CompetitionTablePage.module.css
@@ -101,6 +101,17 @@
   width: 100%;
 }
 
+.analysisSection {
+  display: grid;
+  gap: var(--spacing-s);
+}
+
+.sectionTitle {
+  margin: 0;
+  font-size: var(--font-size-m);
+  font-weight: var(--font-weight-bold);
+}
+
 .extensionOverlay {
   position: fixed;
   top: 0;

--- a/src/pages/CompetitionTablePage.tsx
+++ b/src/pages/CompetitionTablePage.tsx
@@ -15,8 +15,13 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
+import { AnalysisEventList } from '../components/features/AnalysisEventList';
+import {
+  AnalysisEventModalLauncher,
+  type AnalysisModalSelection,
+} from '../components/features/AnalysisEventModalLauncher';
 import { MatchFinishedModal } from '../components/features/MatchFinishedModal';
 import { ResultView } from '../components/features/ResultView';
 import { ScoreBoard } from '../components/features/ScoreBoard';
@@ -26,10 +31,13 @@ import { Button } from '../components/ui/Button';
 import { ConfirmationDialog } from '../components/ui/ConfirmationDialog';
 import { Modal } from '../components/ui/Modal';
 import { useSnackbar } from '../contexts/SnackbarContext';
+import { useAnalysisEntries } from '../hooks/useAnalysisEntries';
 import { useCompetitionMatch } from '../hooks/useCompetitionMatch';
 import { useMatchGame } from '../hooks/useMatchGame';
 import { useRoomSoundEffects } from '../hooks/useRoomSoundEffects';
 import { auth } from '../services/firebase';
+import { getAnalysisEventType } from '../utils/analysis';
+import { buildRoomAnalysisEvents } from '../utils/analysisEvents';
 import styles from './CompetitionTablePage.module.css';
 
 const WIND_LABELS: Record<string, string> = {
@@ -131,6 +139,35 @@ export const CompetitionTablePage = () => {
   // Seat arrangement for next match
   const [seatArrangementMode, setSeatArrangementMode] = useState(false);
   const [arrangedPlayerIds, setArrangedPlayerIds] = useState<string[]>([]);
+  const [analysisSelection, setAnalysisSelection] = useState<AnalysisModalSelection | null>(null);
+  const { entries: analysisEntries } = useAnalysisEntries();
+
+  const savedHandLogIds = useMemo(() => {
+    return new Set(analysisEntries.map((entry) => entry.source.handLogId));
+  }, [analysisEntries]);
+
+  const analysisEvents = useMemo(() => {
+    if (!room) {
+      return [];
+    }
+
+    return buildRoomAnalysisEvents(room, myPlayerId);
+  }, [myPlayerId, room]);
+
+  const promptAnalysisForHand = useCallback(
+    (selection: AnalysisModalSelection) => {
+      if (!getAnalysisEventType(selection.handLog, myPlayerId)) {
+        return;
+      }
+
+      showSnackbar('この局の分析メモを残せます。', {
+        actionLabel: '開く',
+        autoHideDuration: 5000,
+        onAction: () => setAnalysisSelection(selection),
+      });
+    },
+    [myPlayerId, showSnackbar],
+  );
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
@@ -343,14 +380,52 @@ export const CompetitionTablePage = () => {
           initialWinType={initialWinType}
           settings={room.settings}
           onConfirm={async (results) => {
-            await matchGame.handleScoreConfirm(results);
+            const handLog = await matchGame.handleScoreConfirm(results);
             setIsModalOpen(false);
+            if (handLog) {
+              promptAnalysisForHand({
+                handLog,
+                source: {
+                  kind: 'room',
+                  roomId: room.id,
+                  handLogId: handLog.id,
+                },
+                players: room.players,
+              });
+            }
           }}
           onRyukyoku={async (tenpaiIds) => {
-            await matchGame.handleRyukyoku(tenpaiIds);
+            const handLog = await matchGame.handleRyukyoku(tenpaiIds);
             setIsModalOpen(false);
+            if (handLog) {
+              promptAnalysisForHand({
+                handLog,
+                source: {
+                  kind: 'room',
+                  roomId: room.id,
+                  handLogId: handLog.id,
+                },
+                players: room.players,
+              });
+            }
           }}
         />
+
+        <section className={styles.analysisSection}>
+          <h2 className={styles.sectionTitle}>詳細分析対象イベント</h2>
+          <AnalysisEventList
+            events={analysisEvents}
+            savedHandLogIds={savedHandLogIds}
+            emptyMessage="分析対象のイベントはまだありません。"
+            onSelect={(event) => {
+              setAnalysisSelection({
+                handLog: event.handLog,
+                source: event.source,
+                players: event.players,
+              });
+            }}
+          />
+        </section>
 
         <MatchFinishedModal
           isOpen={matchGame.showFinishedModal}
@@ -394,6 +469,12 @@ export const CompetitionTablePage = () => {
             <span className={styles.extensionText}>{matchGame.extensionOverlay}</span>
           </div>
         )}
+
+        <AnalysisEventModalLauncher
+          isOpen={analysisSelection !== null}
+          selection={analysisSelection}
+          onClose={() => setAnalysisSelection(null)}
+        />
       </div>
     );
   }
@@ -458,6 +539,22 @@ export const CompetitionTablePage = () => {
 
         <ResultView room={room} />
 
+        <section className={styles.analysisSection}>
+          <h2 className={styles.sectionTitle}>詳細分析対象イベント</h2>
+          <AnalysisEventList
+            events={analysisEvents}
+            savedHandLogIds={savedHandLogIds}
+            emptyMessage="分析対象のイベントはまだありません。"
+            onSelect={(event) => {
+              setAnalysisSelection({
+                handLog: event.handLog,
+                source: event.source,
+                players: event.players,
+              });
+            }}
+          />
+        </section>
+
         <div className={styles.finishedActions}>
           {canManage && (
             <>
@@ -480,6 +577,12 @@ export const CompetitionTablePage = () => {
           message={`この卓を終了しますか？\n参加者は待機状態に戻ります。`}
           type="danger"
           confirmText="終了する"
+        />
+
+        <AnalysisEventModalLauncher
+          isOpen={analysisSelection !== null}
+          selection={analysisSelection}
+          onClose={() => setAnalysisSelection(null)}
         />
       </div>
     );

--- a/src/pages/MatchPage.tsx
+++ b/src/pages/MatchPage.tsx
@@ -1,5 +1,10 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Navigate, useNavigate, useParams } from 'react-router-dom';
+import { AnalysisEventList } from '../components/features/AnalysisEventList';
+import {
+  AnalysisEventModalLauncher,
+  type AnalysisModalSelection,
+} from '../components/features/AnalysisEventModalLauncher';
 import { LobbyView } from '../components/features/LobbyView';
 import { MatchFinishedModal } from '../components/features/MatchFinishedModal';
 import { ResultView } from '../components/features/ResultView';
@@ -13,10 +18,13 @@ import { ConfirmationDialog } from '../components/ui/ConfirmationDialog';
 import { Input } from '../components/ui/Input';
 import { Modal } from '../components/ui/Modal';
 import { useSnackbar } from '../contexts/SnackbarContext';
+import { useAnalysisEntries } from '../hooks/useAnalysisEntries';
 import { useRoomSoundEffects } from '../hooks/useRoomSoundEffects';
 import { useRoom } from '../hooks/useRoom';
 import { auth } from '../services/firebase';
 import type { HandLog, Player, RoomState, ScorePayment } from '../types';
+import { getAnalysisEventType } from '../utils/analysis';
+import { buildRoomAnalysisEvents } from '../utils/analysisEvents';
 import { processHandEnd } from '../utils/gameLogic';
 import { generateId } from '../utils/id';
 import { calculateFinalScores, distributeRemainingRiichiSticks } from '../utils/resultCalculator';
@@ -59,7 +67,43 @@ export const MatchPage = () => {
   const [isEndMatchConfirmOpen, setIsEndMatchConfirmOpen] = useState(false);
   const [isSettlementOpen, setIsSettlementOpen] = useState(false);
   const [isAbortConfirmOpen, setIsAbortConfirmOpen] = useState(false);
+  const [analysisSelection, setAnalysisSelection] = useState<AnalysisModalSelection | null>(null);
   const { isSoundEnabled, setIsSoundEnabled } = useRoomSoundEffects(room?.lastEvent);
+  const { entries: analysisEntries } = useAnalysisEntries();
+
+  const savedHandLogIds = useMemo(() => {
+    return new Set(analysisEntries.map((entry) => entry.source.handLogId));
+  }, [analysisEntries]);
+
+  const analysisEvents = useMemo(() => {
+    if (!room) {
+      return [];
+    }
+
+    return buildRoomAnalysisEvents(room, myPlayerId);
+  }, [myPlayerId, room]);
+
+  const promptAnalysisForHand = (handLog: HandLog, playersSnapshot: Player[]) => {
+    if (!room || !getAnalysisEventType(handLog, myPlayerId)) {
+      return;
+    }
+
+    const selection: AnalysisModalSelection = {
+      handLog,
+      source: {
+        kind: 'room',
+        roomId: room.id,
+        handLogId: handLog.id,
+      },
+      players: playersSnapshot,
+    };
+
+    showSnackbar('この局の分析メモを残せます。', {
+      actionLabel: '開く',
+      autoHideDuration: 5000,
+      onAction: () => setAnalysisSelection(selection),
+    });
+  };
 
   useEffect(() => {
     if (room && room.status === 'finished' && !hasHandledFinish) {
@@ -470,6 +514,8 @@ export const MatchPage = () => {
       currentLogs: nextState.isGameOver ? [] : nextLogs,
     });
 
+    promptAnalysisForHand(newLog, players);
+
     setIsModalOpen(false);
   };
 
@@ -595,6 +641,8 @@ export const MatchPage = () => {
       gameResults: nextGameResults,
       currentLogs: nextState.isGameOver ? [] : nextLogs,
     });
+
+    promptAnalysisForHand(newLog, room.players);
 
     setIsModalOpen(false);
   };
@@ -932,6 +980,21 @@ export const MatchPage = () => {
       {/* History Modal */}
       <Modal isOpen={isHistoryOpen} onClose={() => setIsHistoryOpen(false)} title="戦績履歴">
         <SessionHistoryTable room={room} />
+        <div style={{ marginTop: '24px', display: 'grid', gap: '12px' }}>
+          <h3 style={{ margin: 0, fontSize: '16px' }}>詳細分析対象イベント</h3>
+          <AnalysisEventList
+            events={analysisEvents}
+            savedHandLogIds={savedHandLogIds}
+            emptyMessage="分析対象のイベントはまだありません。"
+            onSelect={(event) => {
+              setAnalysisSelection({
+                handLog: event.handLog,
+                source: event.source,
+                players: event.players,
+              });
+            }}
+          />
+        </div>
         <div style={{ marginTop: '16px', textAlign: 'center' }}>
           <Button onClick={() => setIsHistoryOpen(false)}>閉じる</Button>
         </div>
@@ -962,6 +1025,12 @@ export const MatchPage = () => {
         players={room.players}
         gameResults={room.gameResults || []}
         rate={room.settings.rate || 0}
+      />
+
+      <AnalysisEventModalLauncher
+        isOpen={analysisSelection !== null}
+        selection={analysisSelection}
+        onClose={() => setAnalysisSelection(null)}
       />
 
       {/* Abort Game Modal */}

--- a/src/pages/SessionDetailPage.tsx
+++ b/src/pages/SessionDetailPage.tsx
@@ -1,15 +1,24 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import { AnalysisEventList } from '../components/features/AnalysisEventList';
+import {
+  AnalysisEventModalLauncher,
+  type AnalysisModalSelection,
+} from '../components/features/AnalysisEventModalLauncher';
 import { SessionHistoryTable } from '../components/features/SessionHistoryTable';
 import { Button } from '../components/ui/Button';
+import { useAnalysisEntries } from '../hooks/useAnalysisEntries';
 import { subscribeToRoom } from '../services/roomService';
 import type { RoomState } from '../types';
+import { buildRoomAnalysisEvents } from '../utils/analysisEvents';
 
 export const SessionDetailPage = () => {
   const { roomId } = useParams<{ roomId: string }>();
   const navigate = useNavigate();
   const [room, setRoom] = useState<RoomState | null>(null);
   const [loading, setLoading] = useState(true);
+  const [analysisSelection, setAnalysisSelection] = useState<AnalysisModalSelection | null>(null);
+  const { uid, entries: analysisEntries } = useAnalysisEntries();
 
   useEffect(() => {
     if (!roomId) return;
@@ -22,6 +31,9 @@ export const SessionDetailPage = () => {
 
   if (loading) return <div style={{ padding: 20 }}>Loading...</div>;
   if (!room) return <div style={{ padding: 20 }}>Room not found.</div>;
+
+  const savedHandLogIds = new Set(analysisEntries.map((entry) => entry.source.handLogId));
+  const analysisEvents = uid ? buildRoomAnalysisEvents(room, uid) : [];
 
   return (
     <div style={{ padding: '16px', maxWidth: '600px', margin: '0 auto' }}>
@@ -40,6 +52,28 @@ export const SessionDetailPage = () => {
       <div style={{ marginBottom: '32px' }}>
         <SessionHistoryTable room={room} />
       </div>
+
+      <h3 style={{ borderBottom: '1px solid #444', paddingBottom: '8px', marginBottom: '12px' }}>
+        詳細分析対象イベント
+      </h3>
+      <AnalysisEventList
+        events={analysisEvents}
+        savedHandLogIds={savedHandLogIds}
+        emptyMessage="分析対象のイベントはありません。"
+        onSelect={(event) => {
+          setAnalysisSelection({
+            handLog: event.handLog,
+            source: event.source,
+            players: event.players,
+          });
+        }}
+      />
+
+      <AnalysisEventModalLauncher
+        isOpen={analysisSelection !== null}
+        selection={analysisSelection}
+        onClose={() => setAnalysisSelection(null)}
+      />
 
       {/* Reuse ResultView for Final Totals reuse if convenient, or just simple table */}
       {/* ResultView has "Next Match" etc which we don't want here? ResultView handles "ended" properly now? */}

--- a/src/pages/TopPage.tsx
+++ b/src/pages/TopPage.tsx
@@ -154,6 +154,13 @@ export const TopPage = () => {
           ユーザー設定
         </Button>
         <Button
+          onClick={() => navigate('/analysis')}
+          variant="secondary"
+          className={styles.mainActionButton}
+        >
+          分析ノート
+        </Button>
+        <Button
           onClick={() => navigate('/history')}
           variant="secondary"
           className={styles.mainActionButton}

--- a/src/services/analysisService.test.ts
+++ b/src/services/analysisService.test.ts
@@ -1,0 +1,197 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  deleteAnalysisEntry,
+  findAnalysisEntryByHandLog,
+  getAnalysisEntry,
+  saveAnalysisEntry,
+  subscribeAnalysisEntries,
+  USER_ANALYSES_COLLECTION,
+} from './analysisService';
+
+const mocks = vi.hoisted(() => ({
+  mockCollection: vi.fn((_db: any, ...pathSegments: string[]) => ({
+    path: pathSegments.join('/'),
+  })),
+  mockDeleteDoc: vi.fn(),
+  mockDoc: vi.fn((_db: any, ...pathSegments: string[]) => ({
+    id: pathSegments[pathSegments.length - 1],
+    path: pathSegments.join('/'),
+  })),
+  mockGetDoc: vi.fn(),
+  mockOnSnapshot: vi.fn(),
+  mockOrderBy: vi.fn((...args: any[]) => ({ _orderBy: args })),
+  mockQuery: vi.fn((...args: any[]) => ({ _query: args })),
+  mockServerTimestamp: vi.fn(() => 'SERVER_TIMESTAMP'),
+  mockSetDoc: vi.fn(),
+}));
+
+vi.mock('firebase/firestore', () => ({
+  collection: mocks.mockCollection,
+  deleteDoc: mocks.mockDeleteDoc,
+  doc: mocks.mockDoc,
+  getDoc: mocks.mockGetDoc,
+  onSnapshot: mocks.mockOnSnapshot,
+  orderBy: mocks.mockOrderBy,
+  query: mocks.mockQuery,
+  serverTimestamp: mocks.mockServerTimestamp,
+  setDoc: mocks.mockSetDoc,
+}));
+
+vi.mock('./firebase', () => ({
+  db: {},
+}));
+
+const createAnalysisEntry = (overrides: Record<string, unknown> = {}) => ({
+  id: 'entry-1',
+  uid: 'user-1',
+  source: {
+    kind: 'competition',
+    competitionId: 'competition-1',
+    gameResultId: 'result-1',
+    handLogId: 'hand-1',
+  },
+  context: {
+    round: {
+      wind: 'East',
+      number: 1,
+      honba: 0,
+    },
+    seatWind: 'East',
+    roundWind: 'East',
+    eventType: 'win',
+    isDealer: true,
+  },
+  hand: {
+    concealed: [],
+    melds: [],
+    wait: [],
+  },
+  dora: {
+    doraIndicators: [],
+    uraIndicators: [],
+    kanDoraIndicators: [],
+    kanUraIndicators: [],
+    redFiveCount: 0,
+  },
+  yaku: {
+    list: [],
+    yakuman: [],
+    ippatsu: false,
+    riichi: 'none',
+    special: null,
+  },
+  notes: '',
+  createdAt: 1000,
+  updatedAt: 2000,
+  ...overrides,
+});
+
+describe('analysisService', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses the userAnalyses collection root', () => {
+    expect(USER_ANALYSES_COLLECTION).toBe('userAnalyses');
+  });
+
+  it('returns null when the requested analysis entry does not exist', async () => {
+    mocks.mockGetDoc.mockResolvedValue({
+      exists: () => false,
+    });
+
+    await expect(getAnalysisEntry('user-1', 'entry-1')).resolves.toBeNull();
+  });
+
+  it('saves an analysis entry with merge semantics and a server updatedAt timestamp', async () => {
+    const entry = createAnalysisEntry();
+
+    await saveAnalysisEntry('user-1', entry as any);
+
+    expect(mocks.mockDoc).toHaveBeenCalledWith(
+      expect.anything(),
+      'userAnalyses',
+      'user-1',
+      'entries',
+      'hand-1',
+    );
+    expect(mocks.mockSetDoc).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'hand-1' }),
+      expect.objectContaining({
+        ...entry,
+        id: 'hand-1',
+        uid: 'user-1',
+        updatedAt: 'SERVER_TIMESTAMP',
+      }),
+      { merge: true },
+    );
+  });
+
+  it('subscribes with updatedAt descending order', () => {
+    const callback = vi.fn();
+    const unsubscribe = vi.fn();
+    const newerEntry = createAnalysisEntry({ id: 'entry-2', updatedAt: 3000 });
+    const olderEntry = createAnalysisEntry({ id: 'entry-1', updatedAt: 2000 });
+
+    mocks.mockOnSnapshot.mockImplementation((_queryRef: any, onNext: any) => {
+      onNext({
+        docs: [
+          { id: 'entry-2', data: () => newerEntry },
+          { id: 'entry-1', data: () => olderEntry },
+        ],
+      });
+      return unsubscribe;
+    });
+
+    const result = subscribeAnalysisEntries('user-1', callback);
+
+    expect(mocks.mockCollection).toHaveBeenCalledWith(
+      expect.anything(),
+      'userAnalyses',
+      'user-1',
+      'entries',
+    );
+    expect(mocks.mockOrderBy).toHaveBeenCalledWith('updatedAt', 'desc');
+    expect(mocks.mockQuery).toHaveBeenCalled();
+    expect(callback).toHaveBeenCalledWith([newerEntry, olderEntry]);
+    expect(result).toBe(unsubscribe);
+  });
+
+  it('finds an entry by hand log source fields', async () => {
+    const matchingEntry = createAnalysisEntry();
+    mocks.mockGetDoc.mockResolvedValue({
+      id: 'hand-1',
+      exists: () => true,
+      data: () => ({
+        ...matchingEntry,
+        id: 'hand-1',
+      }),
+    });
+
+    const result = await findAnalysisEntryByHandLog('user-1', matchingEntry.source as any);
+
+    expect(mocks.mockDoc).toHaveBeenCalledWith(
+      expect.anything(),
+      'userAnalyses',
+      'user-1',
+      'entries',
+      'hand-1',
+    );
+    expect(result).toEqual({
+      ...matchingEntry,
+      id: 'hand-1',
+    });
+  });
+
+  it('deletes an analysis entry document', async () => {
+    await deleteAnalysisEntry('user-1', 'entry-1');
+
+    expect(mocks.mockDeleteDoc).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'entry-1',
+        path: 'userAnalyses/user-1/entries/entry-1',
+      }),
+    );
+  });
+});

--- a/src/services/analysisService.test.ts
+++ b/src/services/analysisService.test.ts
@@ -158,6 +158,28 @@ describe('analysisService', () => {
     expect(result).toBe(unsubscribe);
   });
 
+  it('returns an empty list when subscribeAnalysisEntries receives an onSnapshot error', () => {
+    const callback = vi.fn();
+    const unsubscribe = vi.fn();
+    const error = new Error('snapshot failed');
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    mocks.mockOnSnapshot.mockImplementation(
+      (_queryRef: any, _onNext: any, onError: (snapshotError: Error) => void) => {
+        onError(error);
+        return unsubscribe;
+      },
+    );
+
+    const result = subscribeAnalysisEntries('user-1', callback);
+
+    expect(callback).toHaveBeenCalledWith([]);
+    expect(errorSpy).toHaveBeenCalledWith('Analysis entries sync error:', error);
+    expect(result).toBe(unsubscribe);
+
+    errorSpy.mockRestore();
+  });
+
   it('finds an entry by hand log source fields', async () => {
     const matchingEntry = createAnalysisEntry();
     mocks.mockGetDoc.mockResolvedValue({

--- a/src/services/analysisService.ts
+++ b/src/services/analysisService.ts
@@ -1,0 +1,109 @@
+import {
+  collection,
+  deleteDoc,
+  doc,
+  getDoc,
+  onSnapshot,
+  orderBy,
+  query,
+  serverTimestamp,
+  setDoc,
+  type Unsubscribe,
+} from 'firebase/firestore';
+import type { AnalysisEntry, AnalysisSource } from '../types/analysis';
+import { normalizeAnalysisEntry as normalizeAnalysisDraft } from '../utils/analysis';
+import { sanitizeFirestoreData } from '../utils/gameSettings';
+import { db } from './firebase';
+
+export const USER_ANALYSES_COLLECTION = 'userAnalyses';
+export const ANALYSIS_ENTRIES_COLLECTION = 'entries';
+
+const getAnalysisEntriesCollection = (uid: string) => {
+  return collection(db, USER_ANALYSES_COLLECTION, uid, ANALYSIS_ENTRIES_COLLECTION);
+};
+
+const getAnalysisEntryDocument = (uid: string, entryId: string) => {
+  return doc(db, USER_ANALYSES_COLLECTION, uid, ANALYSIS_ENTRIES_COLLECTION, entryId);
+};
+
+const normalizeAnalysisEntry = (
+  uid: string,
+  entryId: string,
+  data: AnalysisEntry,
+): AnalysisEntry => {
+  return {
+    ...data,
+    id: data.id || entryId,
+    uid: data.uid || uid,
+  };
+};
+
+export const subscribeAnalysisEntries = (
+  uid: string,
+  callback: (entries: AnalysisEntry[]) => void,
+): Unsubscribe => {
+  const entriesQuery = query(getAnalysisEntriesCollection(uid), orderBy('updatedAt', 'desc'));
+
+  return onSnapshot(
+    entriesQuery,
+    (snapshot) => {
+      callback(
+        snapshot.docs.map((entrySnapshot) => {
+          return normalizeAnalysisEntry(
+            uid,
+            entrySnapshot.id,
+            entrySnapshot.data() as AnalysisEntry,
+          );
+        }),
+      );
+    },
+    (error) => {
+      console.error('Analysis entries sync error:', error);
+      callback([]);
+    },
+  );
+};
+
+export const getAnalysisEntry = async (
+  uid: string,
+  entryId: string,
+): Promise<AnalysisEntry | null> => {
+  const entrySnapshot = await getDoc(getAnalysisEntryDocument(uid, entryId));
+
+  if (!entrySnapshot.exists()) {
+    return null;
+  }
+
+  return normalizeAnalysisEntry(uid, entrySnapshot.id, entrySnapshot.data() as AnalysisEntry);
+};
+
+export const findAnalysisEntryByHandLog = async (
+  uid: string,
+  source: AnalysisSource,
+): Promise<AnalysisEntry | null> => {
+  return getAnalysisEntry(uid, source.handLogId);
+};
+
+export const saveAnalysisEntry = async (uid: string, entry: AnalysisEntry): Promise<void> => {
+  const normalizedEntry = normalizeAnalysisDraft({
+    ...entry,
+    id: entry.source.handLogId,
+    uid,
+  });
+  const entryId = entry.source.handLogId;
+
+  await setDoc(
+    getAnalysisEntryDocument(uid, entryId),
+    {
+      ...sanitizeFirestoreData({
+        ...normalizedEntry,
+      }),
+      updatedAt: serverTimestamp(),
+    },
+    { merge: true },
+  );
+};
+
+export const deleteAnalysisEntry = async (uid: string, entryId: string): Promise<void> => {
+  await deleteDoc(getAnalysisEntryDocument(uid, entryId));
+};

--- a/src/services/firestoreRules.test.ts
+++ b/src/services/firestoreRules.test.ts
@@ -20,3 +20,22 @@ describe('firestore.rules userSettings access control', () => {
     expect(rules).toContain('request.auth.uid == userId');
   });
 });
+
+describe('firestore.rules userAnalyses access control', () => {
+  it('defines a userAnalyses entry subcollection match', () => {
+    expect(rules).toContain('match /userAnalyses/{uid}');
+    expect(rules).toContain('match /entries/{entryId}');
+  });
+
+  it('restricts userAnalyses reads and writes to the authenticated owner', () => {
+    expect(rules).toContain(
+      'allow read, delete: if request.auth != null && request.auth.uid == uid;',
+    );
+    expect(rules).toContain('allow create: if request.auth != null');
+    expect(rules).toContain('request.auth.uid == uid');
+    expect(rules).toContain('request.resource.data.uid == uid');
+    expect(rules).toContain('request.resource.data.id == entryId');
+    expect(rules).toContain('request.resource.data.source.handLogId == entryId');
+    expect(rules).toContain('request.auth.uid == uid');
+  });
+});

--- a/src/services/firestoreRules.test.ts
+++ b/src/services/firestoreRules.test.ts
@@ -9,6 +9,13 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import rules from '../../firestore.rules?raw';
 
 const EMULATOR_PROJECT_ID = 'demo-mahjong-point-manager';
+const env = (
+  globalThis as {
+    process?: {
+      env?: Record<string, string | undefined>;
+    };
+  }
+).process?.env;
 
 const createAnalysisEntryData = (overrides: Record<string, unknown> = {}) => ({
   id: 'hand-1',
@@ -56,7 +63,7 @@ const getEntryPath = (uid = 'user-1', entryId = 'hand-1') => {
   return `userAnalyses/${uid}/entries/${entryId}`;
 };
 
-describe.runIf(Boolean(process.env.FIRESTORE_EMULATOR_HOST || process.env.FIREBASE_EMULATOR_HUB))(
+describe.runIf(Boolean(env?.FIRESTORE_EMULATOR_HOST || env?.FIREBASE_EMULATOR_HUB))(
   'firestore.rules userAnalyses emulator access control',
   () => {
     let testEnv: RulesTestEnvironment;

--- a/src/services/firestoreRules.test.ts
+++ b/src/services/firestoreRules.test.ts
@@ -1,5 +1,154 @@
-import { describe, expect, it } from 'vitest';
+import {
+  assertFails,
+  assertSucceeds,
+  initializeTestEnvironment,
+  type RulesTestEnvironment,
+} from '@firebase/rules-unit-testing';
+import { deleteDoc, doc, getDoc, setDoc, setLogLevel, updateDoc } from 'firebase/firestore';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import rules from '../../firestore.rules?raw';
+
+const EMULATOR_PROJECT_ID = 'demo-mahjong-point-manager';
+
+const createAnalysisEntryData = (overrides: Record<string, unknown> = {}) => ({
+  id: 'hand-1',
+  uid: 'user-1',
+  source: {
+    kind: 'room',
+    roomId: 'room-1',
+    handLogId: 'hand-1',
+  },
+  context: {
+    round: { wind: 'East', number: 1, honba: 0 },
+    seatWind: 'East',
+    roundWind: 'East',
+    eventType: 'win',
+    isDealer: true,
+  },
+  hand: {
+    concealed: ['1m', '2m', '3m'],
+    melds: [],
+    wait: ['ryanmen'],
+  },
+  dora: {
+    doraIndicators: [],
+    uraIndicators: [],
+    kanDoraIndicators: [],
+    kanUraIndicators: [],
+    redFiveCount: 0,
+  },
+  yaku: {
+    list: ['riichi'],
+    yakuman: [],
+    ippatsu: false,
+    riichi: 'normal',
+    special: null,
+    han: 3,
+    fu: 40,
+  },
+  notes: 'test',
+  createdAt: 1710000000000,
+  updatedAt: 1710000001000,
+  ...overrides,
+});
+
+const getEntryPath = (uid = 'user-1', entryId = 'hand-1') => {
+  return `userAnalyses/${uid}/entries/${entryId}`;
+};
+
+describe.runIf(Boolean(process.env.FIRESTORE_EMULATOR_HOST || process.env.FIREBASE_EMULATOR_HUB))(
+  'firestore.rules userAnalyses emulator access control',
+  () => {
+    let testEnv: RulesTestEnvironment;
+
+    beforeAll(async () => {
+      setLogLevel('silent');
+
+      testEnv = await initializeTestEnvironment({
+        projectId: EMULATOR_PROJECT_ID,
+        firestore: { rules },
+      });
+    });
+
+    afterEach(async () => {
+      await testEnv.clearFirestore();
+    });
+
+    afterAll(async () => {
+      await testEnv.cleanup();
+      setLogLevel('error');
+    });
+
+    it('allows the owner to create, read, update, and delete their own analysis entry', async () => {
+      const ownerDb = testEnv.authenticatedContext('user-1').firestore();
+      const entryRef = doc(ownerDb, getEntryPath());
+
+      await assertSucceeds(setDoc(entryRef, createAnalysisEntryData()));
+      await assertSucceeds(getDoc(entryRef));
+      await assertSucceeds(updateDoc(entryRef, { notes: 'updated note' }));
+      await assertSucceeds(deleteDoc(entryRef));
+    });
+
+    it('denies read and delete for other users and unauthenticated clients', async () => {
+      await testEnv.withSecurityRulesDisabled(async (context) => {
+        await setDoc(doc(context.firestore(), getEntryPath()), createAnalysisEntryData());
+      });
+
+      const otherUserRef = doc(testEnv.authenticatedContext('user-2').firestore(), getEntryPath());
+      const unauthRef = doc(testEnv.unauthenticatedContext().firestore(), getEntryPath());
+
+      await assertFails(getDoc(otherUserRef));
+      await assertFails(deleteDoc(otherUserRef));
+      await assertFails(getDoc(unauthRef));
+      await assertFails(deleteDoc(unauthRef));
+    });
+
+    it('denies create when uid, id, or source.handLogId do not match the path', async () => {
+      const ownerDb = testEnv.authenticatedContext('user-1').firestore();
+      const entryRef = doc(ownerDb, getEntryPath());
+
+      await assertFails(setDoc(entryRef, createAnalysisEntryData({ uid: 'user-2' })));
+      await assertFails(setDoc(entryRef, createAnalysisEntryData({ id: 'other-entry' })));
+      await assertFails(
+        setDoc(
+          entryRef,
+          createAnalysisEntryData({
+            source: {
+              kind: 'room',
+              roomId: 'room-1',
+              handLogId: 'other-entry',
+            },
+          }),
+        ),
+      );
+    });
+
+    it('denies update when the owner tries to change uid, id, or source.handLogId', async () => {
+      await testEnv.withSecurityRulesDisabled(async (context) => {
+        await setDoc(doc(context.firestore(), getEntryPath()), createAnalysisEntryData());
+      });
+
+      const ownerRef = doc(testEnv.authenticatedContext('user-1').firestore(), getEntryPath());
+
+      await assertFails(updateDoc(ownerRef, { uid: 'user-2' }));
+      await assertFails(updateDoc(ownerRef, { id: 'other-entry' }));
+      await assertFails(updateDoc(ownerRef, { 'source.handLogId': 'other-entry' }));
+    });
+
+    it('denies create and update for authenticated non-owners', async () => {
+      const otherUserDb = testEnv.authenticatedContext('user-2').firestore();
+      const otherUserRef = doc(otherUserDb, getEntryPath());
+
+      await assertFails(setDoc(otherUserRef, createAnalysisEntryData()));
+
+      await testEnv.withSecurityRulesDisabled(async (context) => {
+        await setDoc(doc(context.firestore(), getEntryPath()), createAnalysisEntryData());
+      });
+
+      await assertFails(updateDoc(otherUserRef, { notes: 'tampered' }));
+    });
+  },
+);
 
 describe('firestore.rules participants name validation', () => {
   it('requires non-whitespace participant names', () => {
@@ -33,9 +182,11 @@ describe('firestore.rules userAnalyses access control', () => {
     );
     expect(rules).toContain('allow create: if request.auth != null');
     expect(rules).toContain('request.auth.uid == uid');
+    expect(rules).toContain('allow update: if request.auth != null');
+    expect(rules).toContain('request.auth.uid == uid');
+    expect(rules).toContain('resource.data.uid == uid');
     expect(rules).toContain('request.resource.data.uid == uid');
     expect(rules).toContain('request.resource.data.id == entryId');
     expect(rules).toContain('request.resource.data.source.handLogId == entryId');
-    expect(rules).toContain('request.auth.uid == uid');
   });
 });

--- a/src/types/analysis.ts
+++ b/src/types/analysis.ts
@@ -1,0 +1,173 @@
+export type Wind = 'East' | 'South' | 'West' | 'North';
+
+type SuitTileDigit = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
+type HonorTileDigit = 1 | 2 | 3 | 4 | 5 | 6 | 7;
+
+export type TileCode =
+  | `${SuitTileDigit}m`
+  | `${SuitTileDigit}p`
+  | `${SuitTileDigit}s`
+  | `${HonorTileDigit}z`
+  | '0m'
+  | '0p'
+  | '0s';
+
+export type RelativePosition = 'kamicha' | 'toimen' | 'shimocha';
+
+export type Meld =
+  | { kind: 'chi'; tiles: [TileCode, TileCode, TileCode]; from: 'kamicha' }
+  | { kind: 'pon'; tiles: [TileCode, TileCode, TileCode]; from: RelativePosition }
+  | { kind: 'minkan'; tiles: [TileCode, TileCode, TileCode, TileCode]; from: RelativePosition }
+  | { kind: 'ankan'; tiles: [TileCode, TileCode, TileCode, TileCode] };
+
+export type WaitShape =
+  | 'ryanmen'
+  | 'penchan'
+  | 'kanchan'
+  | 'shanpon'
+  | 'tanki'
+  | 'nobetan'
+  | 'sanmenchan'
+  | 'multi-other';
+
+export type AnalysisEventType = 'win' | 'deal-in' | 'tenpai-draw';
+
+export type SpecialEnd = 'haitei' | 'houtei' | 'rinshan' | 'chankan';
+
+export interface WaitShapeDefinition {
+  label: string;
+}
+
+export const WAIT_SHAPE_DEFS = {
+  ryanmen: { label: '両面' },
+  penchan: { label: '辺張' },
+  kanchan: { label: '嵌張' },
+  shanpon: { label: '双碰' },
+  tanki: { label: '単騎' },
+  nobetan: { label: '延べ単' },
+  sanmenchan: { label: '三面張' },
+  'multi-other': { label: '多面張その他' },
+} as const satisfies Record<WaitShape, WaitShapeDefinition>;
+
+export const WAIT_SHAPES = Object.keys(WAIT_SHAPE_DEFS) as WaitShape[];
+
+export type YakuGroup = '1han' | '2han' | '3han' | '6han';
+
+export interface YakuDefinition {
+  label: string;
+  han: number;
+  group: YakuGroup;
+}
+
+export const YAKU_DEFS = {
+  riichi: { label: '立直', han: 1, group: '1han' },
+  doubleRiichi: { label: 'ダブル立直', han: 2, group: '2han' },
+  menzenTsumo: { label: '門前清自摸和', han: 1, group: '1han' },
+  pinfu: { label: '平和', han: 1, group: '1han' },
+  tanyao: { label: 'タンヤオ', han: 1, group: '1han' },
+  yakuhaiRoundWind: { label: '役牌: 場風', han: 1, group: '1han' },
+  yakuhaiSeatWind: { label: '役牌: 自風', han: 1, group: '1han' },
+  yakuhaiHaku: { label: '役牌: 白', han: 1, group: '1han' },
+  yakuhaiHatsu: { label: '役牌: 發', han: 1, group: '1han' },
+  yakuhaiChun: { label: '役牌: 中', han: 1, group: '1han' },
+  iipeikou: { label: '一盃口', han: 1, group: '1han' },
+  sanshokuDoujun: { label: '三色同順', han: 2, group: '2han' },
+  ikkitsuukan: { label: '一気通貫', han: 2, group: '2han' },
+  chanta: { label: '混全帯么九', han: 2, group: '2han' },
+  chiitoitsu: { label: '七対子', han: 2, group: '2han' },
+  toitoi: { label: '対々和', han: 2, group: '2han' },
+  sanankou: { label: '三暗刻', han: 2, group: '2han' },
+  sanshokuDoukou: { label: '三色同刻', han: 2, group: '2han' },
+  sankantsu: { label: '三槓子', han: 2, group: '2han' },
+  shousangen: { label: '小三元', han: 2, group: '2han' },
+  honroutou: { label: '混老頭', han: 2, group: '2han' },
+  junchan: { label: '純全帯么九', han: 3, group: '3han' },
+  honitsu: { label: '混一色', han: 3, group: '3han' },
+  ryanpeikou: { label: '二盃口', han: 3, group: '3han' },
+  chinitsu: { label: '清一色', han: 6, group: '6han' },
+} as const satisfies Record<string, YakuDefinition>;
+
+export type YakuId = keyof typeof YAKU_DEFS;
+
+export const YAKU_IDS = Object.keys(YAKU_DEFS) as YakuId[];
+
+export interface YakumanDefinition {
+  label: string;
+  multiplier: number;
+}
+
+export const YAKUMAN_DEFS = {
+  kokushiMusou: { label: '国士無双', multiplier: 1 },
+  kokushiMusou13Wait: { label: '国士無双十三面待ち', multiplier: 2 },
+  suuankou: { label: '四暗刻', multiplier: 1 },
+  suuankouTanki: { label: '四暗刻単騎', multiplier: 2 },
+  daisangen: { label: '大三元', multiplier: 1 },
+  shousuushii: { label: '小四喜', multiplier: 1 },
+  daisuushii: { label: '大四喜', multiplier: 2 },
+  tsuuiisou: { label: '字一色', multiplier: 1 },
+  ryuuiisou: { label: '緑一色', multiplier: 1 },
+  chinroutou: { label: '清老頭', multiplier: 1 },
+  chuurenPoutou: { label: '九蓮宝燈', multiplier: 1 },
+  junseiChuurenPoutou: { label: '純正九蓮宝燈', multiplier: 2 },
+  suukantsu: { label: '四槓子', multiplier: 1 },
+  tenhou: { label: '天和', multiplier: 1 },
+  chiihou: { label: '地和', multiplier: 1 },
+} as const satisfies Record<string, YakumanDefinition>;
+
+export type YakumanId = keyof typeof YAKUMAN_DEFS;
+
+export const YAKUMAN_IDS = Object.keys(YAKUMAN_DEFS) as YakumanId[];
+
+export interface AnalysisEntry {
+  id: string;
+  uid: string;
+  source: AnalysisSource;
+  context: AnalysisContext;
+  hand: AnalysisHand;
+  dora: AnalysisDora;
+  yaku: AnalysisYaku;
+  notes: string;
+  createdAt: number | object;
+  updatedAt: number | object;
+}
+
+export interface AnalysisSource {
+  kind: 'room' | 'competition';
+  roomId?: string;
+  competitionId?: string;
+  gameResultId?: string;
+  handLogId: string;
+}
+
+export interface AnalysisContext {
+  round: { wind: Wind; number: number; honba: number };
+  seatWind: Wind;
+  roundWind: Wind;
+  eventType: AnalysisEventType;
+  isDealer: boolean;
+}
+
+export interface AnalysisHand {
+  concealed: TileCode[];
+  melds: Meld[];
+  winningTile?: TileCode;
+  wait: WaitShape[];
+}
+
+export interface AnalysisDora {
+  doraIndicators: TileCode[];
+  uraIndicators: TileCode[];
+  kanDoraIndicators: TileCode[];
+  kanUraIndicators: TileCode[];
+  redFiveCount: number;
+}
+
+export interface AnalysisYaku {
+  list: YakuId[];
+  yakuman: YakumanId[];
+  ippatsu: boolean;
+  riichi: 'none' | 'normal' | 'double';
+  special: SpecialEnd | null;
+  han?: number;
+  fu?: number;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -217,3 +217,5 @@ export interface UserSettingsDocument {
   createdAt?: number | object;
   updatedAt?: number | object;
 }
+
+export * from './analysis';

--- a/src/utils/analysis.test.ts
+++ b/src/utils/analysis.test.ts
@@ -177,6 +177,83 @@ describe('createAnalysisEntrySeed', () => {
     expect(entry.yaku.fu).toBeUndefined();
     expect(entry.yaku.riichi).toBe('normal');
   });
+
+  it('extracts fixed han scoring summaries from N翻 (固定) names', () => {
+    const entry = createAnalysisEntrySeed({
+      uid: 'user-1',
+      handLog: createWinHandLog({
+        result: {
+          type: 'Win',
+          winners: [
+            {
+              id: 'p2',
+              payment: {
+                ron: 2000,
+                basePoints: 500,
+                name: '2翻 (固定)',
+              },
+            },
+          ],
+          loserId: 'p4',
+          riichiPlayerIds: [],
+          scoreDeltas: {
+            p1: 0,
+            p2: 2000,
+            p3: 0,
+            p4: -2000,
+          },
+        },
+      }),
+      playerId: 'p2',
+      players,
+      source: roomSource,
+      now: 1710000015000,
+    });
+
+    expect(entry.yaku.han).toBe(2);
+    expect(entry.yaku.fu).toBeUndefined();
+  });
+
+  it('extracts han and fu for deal-in events from the winning payment summary', () => {
+    const entry = createAnalysisEntrySeed({
+      uid: 'user-1',
+      handLog: createWinHandLog(),
+      playerId: 'p4',
+      players,
+      source: roomSource,
+      now: 1710000018000,
+    });
+
+    expect(entry.context.eventType).toBe('deal-in');
+    expect(entry.yaku.han).toBe(3);
+    expect(entry.yaku.fu).toBe(40);
+  });
+
+  it('throws when the player does not exist', () => {
+    expect(() =>
+      createAnalysisEntrySeed({
+        uid: 'user-1',
+        handLog: createWinHandLog(),
+        playerId: 'missing-player',
+        players,
+        source: roomSource,
+        now: 1710000030000,
+      }),
+    ).toThrowError('Player not found: missing-player');
+  });
+
+  it('throws when the hand log is not analysable for the player', () => {
+    expect(() =>
+      createAnalysisEntrySeed({
+        uid: 'user-1',
+        handLog: createDrawHandLog(),
+        playerId: 'p2',
+        players,
+        source: roomSource,
+        now: 1710000035000,
+      }),
+    ).toThrowError('HandLog hand-2 is not analysable for player p2');
+  });
 });
 
 describe('normalizeAnalysisEntry', () => {
@@ -231,5 +308,86 @@ describe('normalizeAnalysisEntry', () => {
     expect(normalized.yaku.han).toBe(2);
     expect(normalized.yaku.fu).toBeUndefined();
     expect(normalized.notes).toBe('test note');
+  });
+
+  it('keeps only valid pon melds and rejects invalid from or tile combinations', () => {
+    const seed = createAnalysisEntrySeed({
+      uid: 'user-1',
+      handLog: createWinHandLog(),
+      playerId: 'p2',
+      players,
+      source: roomSource,
+      now: 1710000040000,
+    });
+
+    const normalized = normalizeAnalysisEntry({
+      ...seed,
+      hand: {
+        ...seed.hand,
+        melds: [
+          { kind: 'pon', tiles: ['0p', '5p', '5p'], from: 'toimen' },
+          { kind: 'pon', tiles: ['5p', '5p', '6p'], from: 'kamicha' },
+          { kind: 'pon', tiles: ['5p', '5p', '5p'], from: 'self' },
+          { kind: 'pon', tiles: ['5p', '5p', '10p'], from: 'shimocha' },
+        ] as unknown as typeof seed.hand.melds,
+      },
+    });
+
+    expect(normalized.hand.melds).toEqual([
+      { kind: 'pon', tiles: ['0p', '5p', '5p'], from: 'toimen' },
+    ]);
+  });
+
+  it('keeps only valid minkan melds and rejects invalid from or tile combinations', () => {
+    const seed = createAnalysisEntrySeed({
+      uid: 'user-1',
+      handLog: createWinHandLog(),
+      playerId: 'p2',
+      players,
+      source: roomSource,
+      now: 1710000045000,
+    });
+
+    const normalized = normalizeAnalysisEntry({
+      ...seed,
+      hand: {
+        ...seed.hand,
+        melds: [
+          { kind: 'minkan', tiles: ['7s', '7s', '7s', '7s'], from: 'shimocha' },
+          { kind: 'minkan', tiles: ['7s', '7s', '7s', '8s'], from: 'kamicha' },
+          { kind: 'minkan', tiles: ['7s', '7s', '7s', '7s'], from: 'self' },
+          { kind: 'minkan', tiles: ['7s', '7s', '7s', '9x'], from: 'toimen' },
+        ] as unknown as typeof seed.hand.melds,
+      },
+    });
+
+    expect(normalized.hand.melds).toEqual([
+      { kind: 'minkan', tiles: ['7s', '7s', '7s', '7s'], from: 'shimocha' },
+    ]);
+  });
+
+  it('keeps only valid ankan melds and rejects invalid tile combinations', () => {
+    const seed = createAnalysisEntrySeed({
+      uid: 'user-1',
+      handLog: createWinHandLog(),
+      playerId: 'p2',
+      players,
+      source: roomSource,
+      now: 1710000050000,
+    });
+
+    const normalized = normalizeAnalysisEntry({
+      ...seed,
+      hand: {
+        ...seed.hand,
+        melds: [
+          { kind: 'ankan', tiles: ['1z', '1z', '1z', '1z'] },
+          { kind: 'ankan', tiles: ['1z', '1z', '1z', '2z'] },
+          { kind: 'ankan', tiles: ['1z', '1z', '1z', '8z'] },
+        ] as unknown as typeof seed.hand.melds,
+      },
+    });
+
+    expect(normalized.hand.melds).toEqual([{ kind: 'ankan', tiles: ['1z', '1z', '1z', '1z'] }]);
   });
 });

--- a/src/utils/analysis.test.ts
+++ b/src/utils/analysis.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from 'vitest';
+import type { HandLog, Player } from '../types';
+import type { AnalysisSource } from '../types/analysis';
+import { createAnalysisEntrySeed, getAnalysisEventType, normalizeAnalysisEntry } from './analysis';
+
+const players: Player[] = [
+  { id: 'p1', name: 'Alice', score: 25000, isRiichi: false, wind: 'East', chip: 0 },
+  { id: 'p2', name: 'Bob', score: 25000, isRiichi: false, wind: 'South', chip: 0 },
+  { id: 'p3', name: 'Carol', score: 25000, isRiichi: false, wind: 'West', chip: 0 },
+  { id: 'p4', name: 'Dave', score: 25000, isRiichi: false, wind: 'North', chip: 0 },
+];
+
+const roomSource: AnalysisSource = {
+  kind: 'room',
+  roomId: 'room-1',
+  handLogId: 'hand-1',
+};
+
+const createWinHandLog = (overrides?: Partial<HandLog>): HandLog => ({
+  id: 'hand-1',
+  timestamp: 1710000000000,
+  round: {
+    wind: 'East',
+    number: 2,
+    honba: 1,
+    riichiSticks: 1,
+  },
+  result: {
+    type: 'Win',
+    winners: [
+      {
+        id: 'p2',
+        payment: {
+          ron: 7700,
+          basePoints: 1920,
+          name: '3翻40符',
+        },
+      },
+    ],
+    loserId: 'p4',
+    riichiPlayerIds: ['p2'],
+    scoreDeltas: {
+      p1: 0,
+      p2: 7700,
+      p3: 0,
+      p4: -7700,
+    },
+  },
+  ...overrides,
+});
+
+const createDrawHandLog = (overrides?: Partial<HandLog>): HandLog => ({
+  id: 'hand-2',
+  timestamp: 1710000005000,
+  round: {
+    wind: 'South',
+    number: 3,
+    honba: 0,
+    riichiSticks: 0,
+  },
+  result: {
+    type: 'Draw',
+    tenpaiPlayerIds: ['p1', 'p3'],
+    riichiPlayerIds: ['p1'],
+    scoreDeltas: {
+      p1: 1500,
+      p2: -1500,
+      p3: 1500,
+      p4: -1500,
+    },
+  },
+  ...overrides,
+});
+
+describe('getAnalysisEventType', () => {
+  it('returns win when the player is among winners', () => {
+    expect(getAnalysisEventType(createWinHandLog(), 'p2')).toBe('win');
+  });
+
+  it('returns deal-in when the player is the loser', () => {
+    expect(getAnalysisEventType(createWinHandLog(), 'p4')).toBe('deal-in');
+  });
+
+  it('returns tenpai-draw when the player was tenpai on draw', () => {
+    expect(getAnalysisEventType(createDrawHandLog(), 'p1')).toBe('tenpai-draw');
+  });
+
+  it('returns null when the player has no analysable event', () => {
+    expect(getAnalysisEventType(createDrawHandLog(), 'p2')).toBeNull();
+  });
+});
+
+describe('createAnalysisEntrySeed', () => {
+  it('creates a winning seed with round, seat, and han/fu defaults', () => {
+    const entry = createAnalysisEntrySeed({
+      uid: 'user-1',
+      handLog: createWinHandLog(),
+      playerId: 'p2',
+      players,
+      source: roomSource,
+      now: 1710000010000,
+    });
+
+    expect(entry).toEqual({
+      id: 'hand-1',
+      uid: 'user-1',
+      source: roomSource,
+      context: {
+        round: {
+          wind: 'East',
+          number: 2,
+          honba: 1,
+        },
+        seatWind: 'South',
+        roundWind: 'East',
+        eventType: 'win',
+        isDealer: false,
+      },
+      hand: {
+        concealed: [],
+        melds: [],
+        wait: [],
+      },
+      dora: {
+        doraIndicators: [],
+        uraIndicators: [],
+        kanDoraIndicators: [],
+        kanUraIndicators: [],
+        redFiveCount: 0,
+      },
+      yaku: {
+        list: [],
+        yakuman: [],
+        ippatsu: false,
+        riichi: 'normal',
+        special: null,
+        han: 3,
+        fu: 40,
+      },
+      notes: '',
+      createdAt: 1710000010000,
+      updatedAt: 1710000010000,
+    });
+  });
+
+  it('creates a tenpai-draw seed without winning tile or han/fu', () => {
+    const handLog = createDrawHandLog();
+    const source: AnalysisSource = {
+      kind: 'competition',
+      competitionId: 'competition-1',
+      gameResultId: 'game-1',
+      handLogId: handLog.id,
+    };
+
+    const entry = createAnalysisEntrySeed({
+      uid: 'user-1',
+      handLog,
+      playerId: 'p1',
+      players,
+      source,
+      now: 1710000020000,
+    });
+
+    expect(entry.context).toEqual({
+      round: {
+        wind: 'South',
+        number: 3,
+        honba: 0,
+      },
+      seatWind: 'East',
+      roundWind: 'South',
+      eventType: 'tenpai-draw',
+      isDealer: true,
+    });
+    expect(entry.hand.winningTile).toBeUndefined();
+    expect(entry.yaku.han).toBeUndefined();
+    expect(entry.yaku.fu).toBeUndefined();
+    expect(entry.yaku.riichi).toBe('normal');
+  });
+});
+
+describe('normalizeAnalysisEntry', () => {
+  it('deduplicates ordered list fields and removes winningTile for draw entries', () => {
+    const normalized = normalizeAnalysisEntry({
+      ...createAnalysisEntrySeed({
+        uid: 'user-1',
+        handLog: createDrawHandLog(),
+        playerId: 'p1',
+        players,
+        source: {
+          kind: 'room',
+          roomId: 'room-1',
+          handLogId: 'hand-2',
+        },
+        now: 1710000020000,
+      }),
+      hand: {
+        concealed: ['1m', '1m'],
+        melds: [],
+        winningTile: '5m',
+        wait: ['kanchan', 'kanchan', 'ryanmen'],
+      },
+      dora: {
+        doraIndicators: ['1p', '1p'],
+        uraIndicators: [],
+        kanDoraIndicators: [],
+        kanUraIndicators: [],
+        redFiveCount: -3,
+      },
+      yaku: {
+        list: ['tanyao', 'tanyao'],
+        yakuman: ['tenhou', 'tenhou'],
+        ippatsu: false,
+        riichi: 'normal',
+        special: null,
+        han: 2.8,
+        fu: -20,
+      },
+      notes: '  test note  ',
+    });
+
+    expect(normalized.hand).toEqual({
+      concealed: ['1m', '1m'],
+      melds: [],
+      wait: ['kanchan', 'ryanmen'],
+    });
+    expect(normalized.dora.redFiveCount).toBe(0);
+    expect(normalized.dora.doraIndicators).toEqual(['1p', '1p']);
+    expect(normalized.yaku.list).toEqual(['tanyao']);
+    expect(normalized.yaku.yakuman).toEqual(['tenhou']);
+    expect(normalized.yaku.han).toBe(2);
+    expect(normalized.yaku.fu).toBeUndefined();
+    expect(normalized.notes).toBe('test note');
+  });
+});

--- a/src/utils/analysis.ts
+++ b/src/utils/analysis.ts
@@ -1,0 +1,310 @@
+import type { HandLog, Player } from '../types';
+import type {
+  AnalysisEntry,
+  AnalysisEventType,
+  AnalysisSource,
+  Meld,
+  RelativePosition,
+  TileCode,
+  WaitShape,
+  YakumanId,
+  YakuId,
+} from '../types/analysis';
+import { WAIT_SHAPE_DEFS, YAKUMAN_DEFS, YAKU_DEFS } from '../types/analysis';
+import { normalizeTileCode } from './tiles';
+
+const TILE_CODE_PATTERN = /^(?:[1-9][mps]|[1-7]z|0[mps])$/;
+const RELATIVE_POSITIONS: RelativePosition[] = ['kamicha', 'toimen', 'shimocha'];
+
+const parseNonNegativeInteger = (value: unknown): number => {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return 0;
+  }
+
+  return Math.max(0, Math.trunc(value));
+};
+
+const parsePositiveInteger = (value: unknown): number | undefined => {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return undefined;
+  }
+
+  const normalized = Math.trunc(value);
+  return normalized > 0 ? normalized : undefined;
+};
+
+const isTileCode = (value: unknown): value is TileCode => {
+  return typeof value === 'string' && TILE_CODE_PATTERN.test(value);
+};
+
+const isRelativePosition = (value: unknown): value is RelativePosition => {
+  return typeof value === 'string' && RELATIVE_POSITIONS.includes(value as RelativePosition);
+};
+
+const isWaitShape = (value: unknown): value is WaitShape => {
+  return typeof value === 'string' && value in WAIT_SHAPE_DEFS;
+};
+
+const isYakuId = (value: unknown): value is YakuId => {
+  return typeof value === 'string' && value in YAKU_DEFS;
+};
+
+const isYakumanId = (value: unknown): value is YakumanId => {
+  return typeof value === 'string' && value in YAKUMAN_DEFS;
+};
+
+const unique = <T>(values: T[]): T[] => {
+  return [...new Set(values)];
+};
+
+const normalizeTileCodes = (tiles: TileCode[] | undefined): TileCode[] => {
+  return (tiles ?? []).filter(isTileCode);
+};
+
+const areSameTileKinds = (tiles: TileCode[]): boolean => {
+  if (tiles.length === 0) {
+    return false;
+  }
+
+  const [firstTile, ...restTiles] = tiles.map(normalizeTileCode);
+  return restTiles.every((tile) => tile === firstTile);
+};
+
+const isValidChi = (tiles: [TileCode, TileCode, TileCode]): boolean => {
+  const normalizedTiles = tiles.map(normalizeTileCode);
+  if (normalizedTiles.some((tile) => tile.endsWith('z'))) {
+    return false;
+  }
+
+  const suit = normalizedTiles[0][1];
+  if (!normalizedTiles.every((tile) => tile[1] === suit)) {
+    return false;
+  }
+
+  const ranks = normalizedTiles
+    .map((tile) => Number.parseInt(tile[0], 10))
+    .sort((left, right) => left - right);
+
+  return ranks[1] === ranks[0] + 1 && ranks[2] === ranks[1] + 1;
+};
+
+const normalizeMeld = (meld: Meld): Meld | null => {
+  switch (meld.kind) {
+    case 'chi':
+      return meld.tiles.length === 3 &&
+        meld.tiles.every(isTileCode) &&
+        meld.from === 'kamicha' &&
+        isValidChi(meld.tiles)
+        ? { ...meld, tiles: [...meld.tiles] as [TileCode, TileCode, TileCode] }
+        : null;
+    case 'pon':
+      return meld.tiles.length === 3 &&
+        meld.tiles.every(isTileCode) &&
+        isRelativePosition(meld.from) &&
+        areSameTileKinds(meld.tiles)
+        ? { ...meld, tiles: [...meld.tiles] as [TileCode, TileCode, TileCode] }
+        : null;
+    case 'minkan':
+      return meld.tiles.length === 4 &&
+        meld.tiles.every(isTileCode) &&
+        isRelativePosition(meld.from) &&
+        areSameTileKinds(meld.tiles)
+        ? { ...meld, tiles: [...meld.tiles] as [TileCode, TileCode, TileCode, TileCode] }
+        : null;
+    case 'ankan':
+      return meld.tiles.length === 4 && meld.tiles.every(isTileCode) && areSameTileKinds(meld.tiles)
+        ? { ...meld, tiles: [...meld.tiles] as [TileCode, TileCode, TileCode, TileCode] }
+        : null;
+    default:
+      return null;
+  }
+};
+
+const getRiichiState = (handLog: HandLog, playerId: string): AnalysisEntry['yaku']['riichi'] => {
+  return handLog.result.riichiPlayerIds?.includes(playerId) ? 'normal' : 'none';
+};
+
+const extractScoringSummary = (
+  handLog: HandLog,
+  playerId: string,
+  eventType: AnalysisEventType,
+): Pick<AnalysisEntry['yaku'], 'han' | 'fu'> => {
+  if (handLog.result.type !== 'Win') {
+    return {};
+  }
+
+  const payment =
+    eventType === 'win'
+      ? handLog.result.winners?.find((winner) => winner.id === playerId)?.payment
+      : handLog.result.winners?.length === 1
+        ? handLog.result.winners[0]?.payment
+        : undefined;
+
+  if (!payment?.name) {
+    return {};
+  }
+
+  const explicitHanFu = payment.name.match(/^(\d+)翻(\d+)符$/);
+  if (explicitHanFu) {
+    return {
+      han: Number.parseInt(explicitHanFu[1], 10),
+      fu: Number.parseInt(explicitHanFu[2], 10),
+    };
+  }
+
+  const explicitHan = payment.name.match(/^(\d+)翻(?:\s*\(固定\))$/);
+  if (explicitHan) {
+    return {
+      han: Number.parseInt(explicitHan[1], 10),
+    };
+  }
+
+  return {};
+};
+
+export const getAnalysisEventType = (
+  handLog: HandLog,
+  playerId: string,
+): AnalysisEventType | null => {
+  if (handLog.result.type === 'Win') {
+    if (handLog.result.winners?.some((winner) => winner.id === playerId)) {
+      return 'win';
+    }
+
+    if (handLog.result.loserId === playerId) {
+      return 'deal-in';
+    }
+
+    return null;
+  }
+
+  return handLog.result.tenpaiPlayerIds?.includes(playerId) ? 'tenpai-draw' : null;
+};
+
+export interface CreateAnalysisEntrySeedParams {
+  uid: string;
+  handLog: HandLog;
+  playerId: string;
+  players: Pick<Player, 'id' | 'wind'>[];
+  source: AnalysisSource;
+  now?: number;
+  entryId?: string;
+}
+
+export const createAnalysisEntrySeed = ({
+  uid,
+  handLog,
+  playerId,
+  players,
+  source,
+  now = Date.now(),
+  entryId,
+}: CreateAnalysisEntrySeedParams): AnalysisEntry => {
+  const player = players.find((candidate) => candidate.id === playerId);
+
+  if (!player) {
+    throw new Error(`Player not found: ${playerId}`);
+  }
+
+  const eventType = getAnalysisEventType(handLog, playerId);
+  if (!eventType) {
+    throw new Error(`HandLog ${handLog.id} is not analysable for player ${playerId}`);
+  }
+
+  const normalizedSource: AnalysisSource = {
+    ...source,
+    handLogId: handLog.id,
+  };
+
+  return normalizeAnalysisEntry({
+    id: entryId ?? normalizedSource.handLogId,
+    uid,
+    source: normalizedSource,
+    context: {
+      round: {
+        wind: handLog.round.wind,
+        number: handLog.round.number,
+        honba: handLog.round.honba,
+      },
+      seatWind: player.wind,
+      roundWind: handLog.round.wind,
+      eventType,
+      isDealer: player.wind === 'East',
+    },
+    hand: {
+      concealed: [],
+      melds: [],
+      wait: [],
+    },
+    dora: {
+      doraIndicators: [],
+      uraIndicators: [],
+      kanDoraIndicators: [],
+      kanUraIndicators: [],
+      redFiveCount: 0,
+    },
+    yaku: {
+      list: [],
+      yakuman: [],
+      ippatsu: false,
+      riichi: getRiichiState(handLog, playerId),
+      special: null,
+      ...extractScoringSummary(handLog, playerId, eventType),
+    },
+    notes: '',
+    createdAt: now,
+    updatedAt: now,
+  });
+};
+
+export const normalizeAnalysisEntry = (entry: AnalysisEntry): AnalysisEntry => {
+  const normalizedWait = unique((entry.hand.wait ?? []).filter(isWaitShape));
+  const normalizedYakuList = unique((entry.yaku.list ?? []).filter(isYakuId));
+  const normalizedYakumanList = unique((entry.yaku.yakuman ?? []).filter(isYakumanId));
+  const normalizedWinningTile =
+    entry.context.eventType === 'tenpai-draw' || !isTileCode(entry.hand.winningTile)
+      ? undefined
+      : entry.hand.winningTile;
+
+  return {
+    ...entry,
+    source: {
+      ...entry.source,
+      handLogId: entry.source.handLogId,
+    },
+    context: {
+      ...entry.context,
+      round: {
+        wind: entry.context.round.wind,
+        number: parseNonNegativeInteger(entry.context.round.number),
+        honba: parseNonNegativeInteger(entry.context.round.honba),
+      },
+      isDealer: entry.context.seatWind === 'East' ? true : entry.context.isDealer,
+    },
+    hand: {
+      concealed: normalizeTileCodes(entry.hand.concealed),
+      melds: (entry.hand.melds ?? [])
+        .map(normalizeMeld)
+        .filter((meld): meld is Meld => meld !== null),
+      ...(normalizedWinningTile ? { winningTile: normalizedWinningTile } : {}),
+      wait: normalizedWait,
+    },
+    dora: {
+      doraIndicators: normalizeTileCodes(entry.dora.doraIndicators),
+      uraIndicators: normalizeTileCodes(entry.dora.uraIndicators),
+      kanDoraIndicators: normalizeTileCodes(entry.dora.kanDoraIndicators),
+      kanUraIndicators: normalizeTileCodes(entry.dora.kanUraIndicators),
+      redFiveCount: parseNonNegativeInteger(entry.dora.redFiveCount),
+    },
+    yaku: {
+      ...entry.yaku,
+      list: normalizedYakuList,
+      yakuman: normalizedYakumanList,
+      han: parsePositiveInteger(entry.yaku.han),
+      fu: parsePositiveInteger(entry.yaku.fu),
+    },
+    notes: entry.notes.trim().slice(0, 2000),
+    createdAt: parseNonNegativeInteger(entry.createdAt),
+    updatedAt: parseNonNegativeInteger(entry.updatedAt),
+  };
+};

--- a/src/utils/analysisEvents.test.ts
+++ b/src/utils/analysisEvents.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  CompetitionGameResult,
+  CompetitionParticipant,
+  GameResult,
+  HandLog,
+  RoomState,
+} from '../types';
+import {
+  buildCompetitionAnalysisEvents,
+  buildRoomAnalysisEvents,
+  getTimestampValue,
+} from './analysisEvents';
+
+const createWinLog = (overrides: Partial<HandLog> = {}): HandLog => ({
+  id: 'hand-win',
+  timestamp: 1710000000000,
+  round: {
+    wind: 'East',
+    number: 1,
+    honba: 0,
+    riichiSticks: 0,
+  },
+  result: {
+    type: 'Win',
+    winners: [
+      {
+        id: 'user-1',
+        payment: {
+          ron: 7700,
+          basePoints: 1920,
+          name: '3翻40符',
+        },
+      },
+    ],
+    loserId: 'user-2',
+    scoreDeltas: {
+      'user-1': 7700,
+      'user-2': -7700,
+      'guest-1': 0,
+      'guest-2': 0,
+    },
+  },
+  ...overrides,
+});
+
+const createDrawLog = (overrides: Partial<HandLog> = {}): HandLog => ({
+  id: 'hand-draw',
+  timestamp: 1710000001000,
+  round: {
+    wind: 'East',
+    number: 2,
+    honba: 1,
+    riichiSticks: 1,
+  },
+  result: {
+    type: 'Draw',
+    tenpaiPlayerIds: ['user-1'],
+    riichiPlayerIds: ['user-1'],
+    scoreDeltas: {
+      'user-1': 1500,
+      'user-2': -1500,
+      'guest-1': 0,
+      'guest-2': 0,
+    },
+  },
+  ...overrides,
+});
+
+describe('analysisEvents', () => {
+  it('builds room events from game results and current logs with matched player snapshots', () => {
+    const room: RoomState = {
+      id: 'room-1',
+      hostId: 'user-1',
+      status: 'playing',
+      createdAt: 1710000000000,
+      round: {
+        wind: 'East',
+        number: 2,
+        honba: 1,
+        riichiSticks: 1,
+      },
+      players: [
+        { id: 'user-1', name: 'Alice', score: 25000, isRiichi: false, wind: 'South', chip: 0 },
+        { id: 'user-2', name: 'Bob', score: 25000, isRiichi: false, wind: 'West', chip: 0 },
+        { id: 'guest-1', name: 'Carol', score: 25000, isRiichi: false, wind: 'North', chip: 0 },
+        { id: 'guest-2', name: 'Dave', score: 25000, isRiichi: false, wind: 'East', chip: 0 },
+      ],
+      playerIds: ['user-1', 'user-2', 'guest-1', 'guest-2'],
+      settings: {
+        mode: '4ma',
+        length: 'Hanchan',
+        startPoint: 25000,
+        returnPoint: 30000,
+        uma: [10, 30],
+        hasHonba: true,
+        honbaPoints: 300,
+        tenpaiRenchan: true,
+        useTobi: true,
+        useChip: false,
+        useOka: true,
+        useFuCalculation: true,
+        noFuFixedPoints: {
+          1: { child: 1000, dealer: 1500 },
+          2: { child: 2000, dealer: 3000 },
+          3: { child: 4000, dealer: 6000 },
+        },
+        westExtension: false,
+        rate: 0,
+      },
+      history: [
+        {
+          id: 'room-1',
+          hostId: 'user-1',
+          status: 'playing',
+          round: { wind: 'East', number: 1, honba: 0, riichiSticks: 0 },
+          players: [
+            { id: 'user-1', name: 'Alice', score: 25000, isRiichi: false, wind: 'East', chip: 0 },
+            { id: 'user-2', name: 'Bob', score: 25000, isRiichi: false, wind: 'South', chip: 0 },
+            { id: 'guest-1', name: 'Carol', score: 25000, isRiichi: false, wind: 'West', chip: 0 },
+            { id: 'guest-2', name: 'Dave', score: 25000, isRiichi: false, wind: 'North', chip: 0 },
+          ],
+          playerIds: ['user-1', 'user-2', 'guest-1', 'guest-2'],
+          settings: {} as RoomState['settings'],
+        },
+        {
+          id: 'room-1',
+          hostId: 'user-1',
+          status: 'playing',
+          round: { wind: 'East', number: 2, honba: 1, riichiSticks: 1 },
+          players: [
+            { id: 'user-1', name: 'Alice', score: 25700, isRiichi: false, wind: 'South', chip: 0 },
+            { id: 'user-2', name: 'Bob', score: 17300, isRiichi: false, wind: 'West', chip: 0 },
+            { id: 'guest-1', name: 'Carol', score: 25000, isRiichi: false, wind: 'North', chip: 0 },
+            { id: 'guest-2', name: 'Dave', score: 32000, isRiichi: false, wind: 'East', chip: 0 },
+          ],
+          playerIds: ['user-1', 'user-2', 'guest-1', 'guest-2'],
+          settings: {} as RoomState['settings'],
+        },
+      ],
+      gameResults: [
+        {
+          id: 'game-1',
+          timestamp: 1710000000500,
+          ruleSnapshot: {} as GameResult['ruleSnapshot'],
+          scores: [],
+          logs: [createWinLog()],
+        },
+      ],
+      currentLogs: [createDrawLog()],
+    };
+
+    const events = buildRoomAnalysisEvents(room, 'user-1');
+
+    expect(events).toHaveLength(2);
+    expect(events[0]).toEqual(
+      expect.objectContaining({
+        source: expect.objectContaining({ roomId: 'room-1', handLogId: 'hand-draw' }),
+        eventType: 'tenpai-draw',
+        roundLabel: '東2局 1本場',
+        locationLabel: '進行中の対局',
+        scoreDeltaLabel: '+1,500',
+      }),
+    );
+    expect(events[1]).toEqual(
+      expect.objectContaining({
+        eventType: 'win',
+        roundLabel: '東1局 0本場',
+        locationLabel: '第1戦',
+      }),
+    );
+    expect(events[1].players.find((player) => player.id === 'user-1')?.wind).toBe('East');
+  });
+
+  it('builds competition events using participant ownership and table labels', () => {
+    const participants: CompetitionParticipant[] = [
+      {
+        id: 'participant-1',
+        userId: 'user-1',
+        name: 'Alice',
+        isGuest: false,
+        status: 'idle',
+        role: 'player',
+        joinedAt: 1710000000000,
+      },
+      {
+        id: 'participant-2',
+        userId: 'user-2',
+        name: 'Bob',
+        isGuest: false,
+        status: 'idle',
+        role: 'player',
+        joinedAt: 1710000000000,
+      },
+      {
+        id: 'participant-3',
+        name: 'Carol',
+        isGuest: true,
+        status: 'idle',
+        role: 'player',
+        joinedAt: 1710000000000,
+      },
+    ];
+    const gameResults: CompetitionGameResult[] = [
+      {
+        id: 'competition-result-1',
+        tableId: 'table-1',
+        tableName: 'A卓',
+        gameIndex: 2,
+        participantIds: ['participant-1', 'participant-2', 'participant-3'],
+        timestamp: 1710000002000,
+        result: {
+          id: 'game-2',
+          timestamp: 1710000002000,
+          ruleSnapshot: {} as GameResult['ruleSnapshot'],
+          scores: [],
+          logs: [
+            createWinLog({
+              id: 'competition-hand-1',
+              result: {
+                type: 'Win',
+                winners: [
+                  {
+                    id: 'user-2',
+                    payment: {
+                      ron: 5200,
+                      basePoints: 1300,
+                      name: '2翻40符',
+                    },
+                  },
+                ],
+                loserId: 'user-1',
+                scoreDeltas: {
+                  'user-1': -5200,
+                  'user-2': 5200,
+                  'participant-3': 0,
+                },
+              },
+            }),
+          ],
+        },
+      },
+    ];
+
+    const events = buildCompetitionAnalysisEvents(
+      'competition-1',
+      gameResults,
+      participants,
+      'user-1',
+    );
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual(
+      expect.objectContaining({
+        eventType: 'deal-in',
+        locationLabel: 'A卓 / 第2戦',
+        source: expect.objectContaining({
+          kind: 'competition',
+          competitionId: 'competition-1',
+          gameResultId: 'game-2',
+          handLogId: 'competition-hand-1',
+        }),
+        scoreDeltaLabel: '-5,200',
+      }),
+    );
+  });
+
+  it('normalizes number and Firestore-style timestamps to milliseconds', () => {
+    expect(getTimestampValue(1710000000000)).toBe(1710000000000);
+    expect(getTimestampValue({ seconds: 1710000000 })).toBe(1710000000000);
+    expect(getTimestampValue(undefined)).toBe(0);
+  });
+});

--- a/src/utils/analysisEvents.ts
+++ b/src/utils/analysisEvents.ts
@@ -1,0 +1,247 @@
+import type {
+  CompetitionGameResult,
+  CompetitionParticipant,
+  HandLog,
+  Player,
+  RoomState,
+} from '../types';
+import type { AnalysisEventType, AnalysisSource, Wind } from '../types/analysis';
+import { getAnalysisEventType } from './analysis';
+
+const EVENT_LABELS: Record<AnalysisEventType, string> = {
+  win: '和了',
+  'deal-in': '放銃',
+  'tenpai-draw': 'テンパイ流局',
+};
+
+const WIND_LABELS: Record<Wind, string> = {
+  East: '東',
+  South: '南',
+  West: '西',
+  North: '北',
+};
+
+const WIND_ORDER: Wind[] = ['East', 'South', 'West', 'North'];
+
+export interface AnalysisEventPlayer {
+  id: string;
+  name: string;
+  wind: Wind;
+}
+
+export interface AnalysisEventSummary {
+  id: string;
+  source: AnalysisSource;
+  handLog: HandLog;
+  players: AnalysisEventPlayer[];
+  eventType: AnalysisEventType;
+  eventLabel: string;
+  roundLabel: string;
+  locationLabel: string;
+  summary: string;
+  scoreDeltaLabel: string;
+  timestamp: number;
+}
+
+const createPlayerMap = (players: AnalysisEventPlayer[]) => {
+  return new Map(players.map((player) => [player.id, player]));
+};
+
+const clonePlayers = (players: Pick<Player, 'id' | 'name' | 'wind'>[]): AnalysisEventPlayer[] => {
+  return players.map((player) => ({
+    id: player.id,
+    name: player.name,
+    wind: player.wind,
+  }));
+};
+
+const formatSignedNumber = (value: number): string => {
+  const formatted = Math.abs(value).toLocaleString('ja-JP');
+  if (value > 0) {
+    return `+${formatted}`;
+  }
+
+  if (value < 0) {
+    return `-${formatted}`;
+  }
+
+  return '0';
+};
+
+const formatWinnerNames = (
+  handLog: HandLog,
+  playerMap: Map<string, AnalysisEventPlayer>,
+): string => {
+  return (
+    handLog.result.winners
+      ?.map((winner) => playerMap.get(winner.id)?.name ?? winner.id)
+      .join('・') ?? '不明'
+  );
+};
+
+const formatEventSummary = (
+  handLog: HandLog,
+  eventType: AnalysisEventType,
+  playerMap: Map<string, AnalysisEventPlayer>,
+): string => {
+  if (eventType === 'win') {
+    if (handLog.result.loserId) {
+      const loserName = playerMap.get(handLog.result.loserId)?.name ?? handLog.result.loserId;
+      return `${loserName}から和了`;
+    }
+
+    return 'ツモ和了';
+  }
+
+  if (eventType === 'deal-in') {
+    return `${formatWinnerNames(handLog, playerMap)}に放銃`;
+  }
+
+  const tenpaiNames =
+    handLog.result.tenpaiPlayerIds
+      ?.map((tenpaiPlayerId) => playerMap.get(tenpaiPlayerId)?.name ?? tenpaiPlayerId)
+      .join('・') ?? '自分';
+
+  return `${tenpaiNames} テンパイ`;
+};
+
+const buildEventSummary = (
+  handLog: HandLog,
+  players: AnalysisEventPlayer[],
+  playerId: string,
+  source: AnalysisSource,
+  locationLabel: string,
+): AnalysisEventSummary | null => {
+  const eventType = getAnalysisEventType(handLog, playerId);
+  if (!eventType) {
+    return null;
+  }
+
+  const playerMap = createPlayerMap(players);
+
+  return {
+    id: [source.kind, source.handLogId, source.gameResultId ?? '', source.roomId ?? ''].join(':'),
+    source,
+    handLog,
+    players,
+    eventType,
+    eventLabel: EVENT_LABELS[eventType],
+    roundLabel: `${WIND_LABELS[handLog.round.wind]}${handLog.round.number}局 ${handLog.round.honba}本場`,
+    locationLabel,
+    summary: formatEventSummary(handLog, eventType, playerMap),
+    scoreDeltaLabel: formatSignedNumber(handLog.result.scoreDeltas[playerId] ?? 0),
+    timestamp: handLog.timestamp,
+  };
+};
+
+const buildRoomPlayerSnapshots = (
+  room: RoomState,
+  totalLogCount: number,
+): AnalysisEventPlayer[][] => {
+  const historySnapshots = room.history ?? [];
+
+  return Array.from({ length: totalLogCount }, (_, index) => {
+    const snapshot = historySnapshots[index];
+    return clonePlayers(snapshot?.players ?? room.players);
+  });
+};
+
+export const getTimestampValue = (value: number | object | undefined): number => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (value && typeof value === 'object' && 'seconds' in value) {
+    return (value as { seconds: number }).seconds * 1000;
+  }
+
+  return 0;
+};
+
+export const buildRoomAnalysisEvents = (
+  room: RoomState,
+  playerId: string,
+): AnalysisEventSummary[] => {
+  const finishedLogs = (room.gameResults ?? []).flatMap((gameResult, index) => {
+    return (gameResult.logs ?? []).map((handLog) => ({
+      handLog,
+      source: {
+        kind: 'room' as const,
+        roomId: room.id,
+        handLogId: handLog.id,
+      },
+      locationLabel: `第${index + 1}戦`,
+    }));
+  });
+
+  const currentLogs = (room.currentLogs ?? []).map((handLog) => ({
+    handLog,
+    source: {
+      kind: 'room' as const,
+      roomId: room.id,
+      handLogId: handLog.id,
+    },
+    locationLabel: '進行中の対局',
+  }));
+
+  const allLogs = [...finishedLogs, ...currentLogs];
+  const playerSnapshots = buildRoomPlayerSnapshots(room, allLogs.length);
+
+  return allLogs
+    .map((entry, index) => {
+      return buildEventSummary(
+        entry.handLog,
+        playerSnapshots[index] ?? clonePlayers(room.players),
+        playerId,
+        entry.source,
+        entry.locationLabel,
+      );
+    })
+    .filter((entry): entry is AnalysisEventSummary => entry !== null)
+    .sort((left, right) => right.timestamp - left.timestamp);
+};
+
+const buildCompetitionPlayers = (
+  participantIds: string[],
+  participants: CompetitionParticipant[],
+): AnalysisEventPlayer[] => {
+  const participantMap = new Map(participants.map((participant) => [participant.id, participant]));
+
+  return participantIds.map((participantId, index) => {
+    const participant = participantMap.get(participantId);
+    return {
+      id: participant?.userId ?? participant?.id ?? participantId,
+      name: participant?.name ?? participantId,
+      wind: WIND_ORDER[index] ?? 'North',
+    };
+  });
+};
+
+export const buildCompetitionAnalysisEvents = (
+  competitionId: string,
+  gameResults: CompetitionGameResult[],
+  participants: CompetitionParticipant[],
+  playerId: string,
+): AnalysisEventSummary[] => {
+  return gameResults
+    .flatMap((gameResult) => {
+      const players = buildCompetitionPlayers(gameResult.participantIds, participants);
+
+      return (gameResult.result.logs ?? []).map((handLog) => {
+        return buildEventSummary(
+          handLog,
+          players,
+          playerId,
+          {
+            kind: 'competition',
+            competitionId,
+            gameResultId: gameResult.result.id,
+            handLogId: handLog.id,
+          },
+          `${gameResult.tableName} / 第${gameResult.gameIndex}戦`,
+        );
+      });
+    })
+    .filter((entry): entry is AnalysisEventSummary => entry !== null)
+    .sort((left, right) => right.timestamp - left.timestamp);
+};

--- a/src/utils/tiles.test.ts
+++ b/src/utils/tiles.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import {
+  TILE_CODES,
+  TILE_GROUPS,
+  createMeldDraft,
+  getTileMetadata,
+  isRedFive,
+  isTileCode,
+  normalizeTileCode,
+} from './tiles';
+
+describe('tiles', () => {
+  it('exposes tile codes in grouped picker order including red fives', () => {
+    expect(TILE_CODES).toHaveLength(37);
+    expect(TILE_CODES.slice(0, 10)).toEqual([
+      '1m',
+      '2m',
+      '3m',
+      '4m',
+      '5m',
+      '0m',
+      '6m',
+      '7m',
+      '8m',
+      '9m',
+    ]);
+    expect(TILE_CODES.slice(10, 20)).toEqual([
+      '1p',
+      '2p',
+      '3p',
+      '4p',
+      '5p',
+      '0p',
+      '6p',
+      '7p',
+      '8p',
+      '9p',
+    ]);
+    expect(TILE_CODES.slice(20, 30)).toEqual([
+      '1s',
+      '2s',
+      '3s',
+      '4s',
+      '5s',
+      '0s',
+      '6s',
+      '7s',
+      '8s',
+      '9s',
+    ]);
+    expect(TILE_CODES.slice(30)).toEqual(['1z', '2z', '3z', '4z', '5z', '6z', '7z']);
+  });
+
+  it('provides grouped definitions with Japanese labels and suit palettes', () => {
+    expect(TILE_GROUPS.map((group) => group.id)).toEqual(['manzu', 'pinzu', 'souzu', 'honor']);
+    expect(TILE_GROUPS.map((group) => group.label)).toEqual(['萬子', '筒子', '索子', '字牌']);
+    expect(TILE_GROUPS[0].palette.id).toBe('manzu');
+    expect(TILE_GROUPS[3].tiles).toEqual(['1z', '2z', '3z', '4z', '5z', '6z', '7z']);
+  });
+
+  it('normalizes red fives while preserving display metadata', () => {
+    const tile = getTileMetadata('0s');
+
+    expect(tile.code).toBe('0s');
+    expect(tile.normalizedCode).toBe('5s');
+    expect(tile.group).toBe('souzu');
+    expect(tile.label).toBe('赤5索');
+    expect(tile.shortLabel).toBe('5索');
+    expect(tile.isRed).toBe(true);
+    expect(tile.isHonor).toBe(false);
+    expect(tile.palette.id).toBe('souzu');
+    expect(tile.rank).toBe(5);
+  });
+
+  it('detects valid tile codes and red fives', () => {
+    expect(isTileCode('7z')).toBe(true);
+    expect(isTileCode('0m')).toBe(true);
+    expect(isTileCode('8z')).toBe(false);
+    expect(isTileCode('1x')).toBe(false);
+    expect(isRedFive('0p')).toBe(true);
+    expect(isRedFive('5p')).toBe(false);
+    expect(normalizeTileCode('0m')).toBe('5m');
+    expect(normalizeTileCode('7z')).toBe('7z');
+  });
+
+  it('creates sensible meld drafts from a base tile', () => {
+    expect(createMeldDraft('chi', '9p')).toEqual({
+      kind: 'chi',
+      from: 'kamicha',
+      tiles: ['7p', '8p', '9p'],
+    });
+    expect(createMeldDraft('pon', '0m')).toEqual({
+      kind: 'pon',
+      from: 'toimen',
+      tiles: ['0m', '5m', '5m'],
+    });
+    expect(createMeldDraft('minkan', '6z')).toEqual({
+      kind: 'minkan',
+      from: 'toimen',
+      tiles: ['6z', '6z', '6z', '6z'],
+    });
+    expect(createMeldDraft('ankan')).toEqual({
+      kind: 'ankan',
+      tiles: ['1m', '1m', '1m', '1m'],
+    });
+  });
+
+  it('rejects chi meld drafts from honor tiles', () => {
+    expect(() => createMeldDraft('chi', '6z')).toThrow(
+      'Chi meld cannot be created from an honor tile',
+    );
+  });
+});

--- a/src/utils/tiles.ts
+++ b/src/utils/tiles.ts
@@ -1,0 +1,271 @@
+import type { Meld, TileCode } from '../types/analysis';
+
+export type TileGroupId = 'manzu' | 'pinzu' | 'souzu' | 'honor';
+export type TileFaceSymbol = '萬' | '筒' | '索' | '東' | '南' | '西' | '北' | '白' | '發' | '中';
+
+export interface TilePalette {
+  id: TileGroupId;
+  label: string;
+  accentColor: string;
+  textColor: string;
+  shadowColor: string;
+}
+
+export interface TileGroupDefinition {
+  id: TileGroupId;
+  label: string;
+  tiles: TileCode[];
+  palette: TilePalette;
+}
+
+export interface TileMetadata {
+  code: TileCode;
+  normalizedCode: TileCode;
+  group: TileGroupId;
+  palette: TilePalette;
+  label: string;
+  shortLabel: string;
+  symbol: TileFaceSymbol;
+  rank: number;
+  rankLabel: string;
+  isHonor: boolean;
+  isRed: boolean;
+}
+
+const SUIT_TILE_RANKS = ['1', '2', '3', '4', '5', '0', '6', '7', '8', '9'] as const;
+const HONOR_TILE_RANKS = ['1', '2', '3', '4', '5', '6', '7'] as const;
+const TILE_CODE_PATTERN = /^(?:[1-9][mps]|[1-7]z|0[mps])$/;
+const RED_FIVE_MAP: Record<'0m' | '0p' | '0s', '5m' | '5p' | '5s'> = {
+  '0m': '5m',
+  '0p': '5p',
+  '0s': '5s',
+};
+
+const SUIT_SYMBOLS: Record<'m' | 'p' | 's', Extract<TileFaceSymbol, '萬' | '筒' | '索'>> = {
+  m: '萬',
+  p: '筒',
+  s: '索',
+};
+
+const GROUP_FROM_SUIT: Record<'m' | 'p' | 's' | 'z', TileGroupId> = {
+  m: 'manzu',
+  p: 'pinzu',
+  s: 'souzu',
+  z: 'honor',
+};
+
+const HONOR_LABELS: Record<
+  Extract<TileCode, `${number}z`>,
+  Extract<TileFaceSymbol, '東' | '南' | '西' | '北' | '白' | '發' | '中'>
+> = {
+  '1z': '東',
+  '2z': '南',
+  '3z': '西',
+  '4z': '北',
+  '5z': '白',
+  '6z': '發',
+  '7z': '中',
+};
+
+const createSuitTiles = (suit: 'm' | 'p' | 's'): TileCode[] => {
+  return SUIT_TILE_RANKS.map((rank) => `${rank}${suit}` as TileCode);
+};
+
+const MANZU_TILES = createSuitTiles('m');
+const PINZU_TILES = createSuitTiles('p');
+const SOUZU_TILES = createSuitTiles('s');
+const HONOR_TILES = HONOR_TILE_RANKS.map((rank) => `${rank}z` as TileCode);
+
+export const TILE_CODES: TileCode[] = [
+  ...MANZU_TILES,
+  ...PINZU_TILES,
+  ...SOUZU_TILES,
+  ...HONOR_TILES,
+];
+
+export const TILE_PALETTES: Record<TileGroupId, TilePalette> = {
+  manzu: {
+    id: 'manzu',
+    label: '萬子',
+    accentColor: 'var(--color-danger)',
+    textColor: 'var(--color-danger)',
+    shadowColor: 'var(--color-bg-main)',
+  },
+  pinzu: {
+    id: 'pinzu',
+    label: '筒子',
+    accentColor: 'var(--color-info)',
+    textColor: 'var(--color-info)',
+    shadowColor: 'var(--color-bg-main)',
+  },
+  souzu: {
+    id: 'souzu',
+    label: '索子',
+    accentColor: 'var(--color-success)',
+    textColor: 'var(--color-success)',
+    shadowColor: 'var(--color-bg-main)',
+  },
+  honor: {
+    id: 'honor',
+    label: '字牌',
+    accentColor: 'var(--color-text-secondary)',
+    textColor: 'var(--color-bg-main)',
+    shadowColor: 'var(--color-bg-main)',
+  },
+};
+
+export const TILE_GROUPS: TileGroupDefinition[] = [
+  {
+    id: 'manzu',
+    label: '萬子',
+    tiles: MANZU_TILES,
+    palette: TILE_PALETTES.manzu,
+  },
+  {
+    id: 'pinzu',
+    label: '筒子',
+    tiles: PINZU_TILES,
+    palette: TILE_PALETTES.pinzu,
+  },
+  {
+    id: 'souzu',
+    label: '索子',
+    tiles: SOUZU_TILES,
+    palette: TILE_PALETTES.souzu,
+  },
+  {
+    id: 'honor',
+    label: '字牌',
+    tiles: HONOR_TILES,
+    palette: TILE_PALETTES.honor,
+  },
+];
+
+export const isTileCode = (value: unknown): value is TileCode => {
+  return typeof value === 'string' && TILE_CODE_PATTERN.test(value);
+};
+
+export const isRedFive = (tileCode: TileCode): boolean => {
+  return tileCode === '0m' || tileCode === '0p' || tileCode === '0s';
+};
+
+export const normalizeTileCode = (tileCode: TileCode): TileCode => {
+  switch (tileCode) {
+    case '0m':
+    case '0p':
+    case '0s':
+      return RED_FIVE_MAP[tileCode];
+    default:
+      return tileCode;
+  }
+};
+
+export const getTileGroup = (tileCode: TileCode): TileGroupId => {
+  const normalizedCode = normalizeTileCode(tileCode);
+  const suit = normalizedCode[1] as 'm' | 'p' | 's' | 'z';
+  return GROUP_FROM_SUIT[suit];
+};
+
+const getTileRank = (tileCode: TileCode): number => {
+  const normalizedCode = normalizeTileCode(tileCode);
+  return Number.parseInt(normalizedCode[0], 10);
+};
+
+const getTileSymbol = (tileCode: TileCode): TileFaceSymbol => {
+  const normalizedCode = normalizeTileCode(tileCode);
+
+  if (normalizedCode.endsWith('z')) {
+    return HONOR_LABELS[normalizedCode as Extract<TileCode, `${number}z`>];
+  }
+
+  return SUIT_SYMBOLS[normalizedCode[1] as 'm' | 'p' | 's'];
+};
+
+export const getTileLabel = (tileCode: TileCode): string => {
+  if (tileCode.endsWith('z')) {
+    return HONOR_LABELS[tileCode as Extract<TileCode, `${number}z`>];
+  }
+
+  const normalizedCode = normalizeTileCode(tileCode);
+  const symbol = SUIT_SYMBOLS[normalizedCode[1] as 'm' | 'p' | 's'];
+  const rank = normalizedCode[0];
+
+  return `${isRedFive(tileCode) ? '赤' : ''}${rank}${symbol}`;
+};
+
+export const getTileMetadata = (tileCode: TileCode): TileMetadata => {
+  const normalizedCode = normalizeTileCode(tileCode);
+  const group = getTileGroup(tileCode);
+  const rank = getTileRank(tileCode);
+  const isHonor = normalizedCode.endsWith('z');
+
+  return {
+    code: tileCode,
+    normalizedCode,
+    group,
+    palette: TILE_PALETTES[group],
+    label: getTileLabel(tileCode),
+    shortLabel: isHonor ? getTileLabel(tileCode) : `${rank}${getTileSymbol(tileCode)}`,
+    symbol: getTileSymbol(tileCode),
+    rank,
+    rankLabel: String(rank),
+    isHonor,
+    isRed: isRedFive(tileCode),
+  };
+};
+
+const createRepeatedTiles = (tileCode: TileCode, count: 3 | 4): TileCode[] => {
+  const normalizedCode = normalizeTileCode(tileCode);
+
+  if (!isRedFive(tileCode)) {
+    return Array.from({ length: count }, () => normalizedCode);
+  }
+
+  return [tileCode, ...Array.from({ length: count - 1 }, () => normalizedCode)];
+};
+
+const createChiTiles = (tileCode: TileCode): [TileCode, TileCode, TileCode] => {
+  const normalizedCode = normalizeTileCode(tileCode);
+
+  if (normalizedCode.endsWith('z')) {
+    throw new Error('Chi meld cannot be created from an honor tile');
+  }
+
+  const suit = normalizedCode[1] as 'm' | 'p' | 's';
+  const rank = getTileRank(tileCode);
+  const start = Math.min(Math.max(rank - 1, 1), 7);
+
+  return [
+    `${start}${suit}` as TileCode,
+    `${start + 1}${suit}` as TileCode,
+    `${start + 2}${suit}` as TileCode,
+  ];
+};
+
+export const createMeldDraft = (kind: Meld['kind'], tileCode: TileCode = '1m'): Meld => {
+  switch (kind) {
+    case 'chi':
+      return {
+        kind: 'chi',
+        from: 'kamicha',
+        tiles: createChiTiles(tileCode),
+      };
+    case 'pon':
+      return {
+        kind: 'pon',
+        from: 'toimen',
+        tiles: createRepeatedTiles(tileCode, 3) as [TileCode, TileCode, TileCode],
+      };
+    case 'minkan':
+      return {
+        kind: 'minkan',
+        from: 'toimen',
+        tiles: createRepeatedTiles(tileCode, 4) as [TileCode, TileCode, TileCode, TileCode],
+      };
+    case 'ankan':
+      return {
+        kind: 'ankan',
+        tiles: createRepeatedTiles(tileCode, 4) as [TileCode, TileCode, TileCode, TileCode],
+      };
+  }
+};

--- a/src/utils/yaku.test.ts
+++ b/src/utils/yaku.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import {
+  YAKU_GROUP_SECTIONS,
+  YAKUMAN_GROUP_SECTIONS,
+  getYakumanDefinition,
+  getYakumanIdsByGroup,
+  getYakuDefinition,
+  getYakuIdsByGroup,
+} from './yaku';
+
+describe('yaku', () => {
+  it('groups standard yaku by han in stable display order', () => {
+    expect(YAKU_GROUP_SECTIONS.map((section) => section.id)).toEqual([
+      '1han',
+      '2han',
+      '3han',
+      '6han',
+    ]);
+    expect(YAKU_GROUP_SECTIONS.map((section) => section.label)).toEqual([
+      '1翻',
+      '2翻',
+      '3翻',
+      '6翻',
+    ]);
+    expect(getYakuIdsByGroup('1han')).toContain('riichi');
+    expect(getYakuIdsByGroup('1han')).toContain('yakuhaiChun');
+    expect(getYakuIdsByGroup('6han')).toEqual(['chinitsu']);
+  });
+
+  it('groups yakuman by multiplier for selector UIs', () => {
+    expect(YAKUMAN_GROUP_SECTIONS.map((section) => section.id)).toEqual(['single', 'double']);
+    expect(YAKUMAN_GROUP_SECTIONS.map((section) => section.label)).toEqual(['役満', 'ダブル役満']);
+    expect(getYakumanIdsByGroup('single')).toContain('daisangen');
+    expect(getYakumanIdsByGroup('double')).toEqual([
+      'kokushiMusou13Wait',
+      'suuankouTanki',
+      'daisuushii',
+      'junseiChuurenPoutou',
+    ]);
+  });
+
+  it('returns raw definition metadata for individual yaku ids', () => {
+    expect(getYakuDefinition('doubleRiichi')).toEqual({
+      label: 'ダブル立直',
+      han: 2,
+      group: '2han',
+    });
+    expect(getYakumanDefinition('tenhou')).toEqual({
+      label: '天和',
+      multiplier: 1,
+    });
+  });
+});

--- a/src/utils/yaku.ts
+++ b/src/utils/yaku.ts
@@ -1,0 +1,105 @@
+import {
+  YAKUMAN_DEFS,
+  YAKU_DEFS,
+  type YakumanDefinition,
+  type YakumanId,
+  type YakuDefinition,
+  type YakuId,
+} from '../types/analysis';
+
+export type YakuGroupId = (typeof YAKU_DEFS)[YakuId]['group'];
+export type YakumanGroupId = 'single' | 'double';
+
+export interface YakuSelectorOption extends YakuDefinition {
+  id: YakuId;
+}
+
+export interface YakumanSelectorOption extends YakumanDefinition {
+  id: YakumanId;
+}
+
+export interface YakuGroupSection {
+  id: YakuGroupId;
+  label: string;
+  items: YakuSelectorOption[];
+}
+
+export interface YakumanGroupSection {
+  id: YakumanGroupId;
+  label: string;
+  items: YakumanSelectorOption[];
+}
+
+export const YAKU_GROUP_ORDER = [
+  '1han',
+  '2han',
+  '3han',
+  '6han',
+] as const satisfies readonly YakuGroupId[];
+export const YAKUMAN_GROUP_ORDER = [
+  'single',
+  'double',
+] as const satisfies readonly YakumanGroupId[];
+
+export const YAKU_GROUP_LABELS: Record<YakuGroupId, string> = {
+  '1han': '1翻',
+  '2han': '2翻',
+  '3han': '3翻',
+  '6han': '6翻',
+};
+
+export const YAKUMAN_GROUP_LABELS: Record<YakumanGroupId, string> = {
+  single: '役満',
+  double: 'ダブル役満',
+};
+
+const YAKU_OPTIONS: YakuSelectorOption[] = (
+  Object.entries(YAKU_DEFS) as [YakuId, YakuDefinition][]
+).map(([id, definition]) => ({
+  id,
+  ...definition,
+}));
+
+const YAKUMAN_OPTIONS: YakumanSelectorOption[] = (
+  Object.entries(YAKUMAN_DEFS) as [YakumanId, YakumanDefinition][]
+).map(([id, definition]) => ({
+  id,
+  ...definition,
+}));
+
+export const YAKU_GROUP_SECTIONS: YakuGroupSection[] = YAKU_GROUP_ORDER.map((groupId) => ({
+  id: groupId,
+  label: YAKU_GROUP_LABELS[groupId],
+  items: YAKU_OPTIONS.filter((option) => option.group === groupId),
+}));
+
+export const YAKUMAN_GROUP_SECTIONS: YakumanGroupSection[] = YAKUMAN_GROUP_ORDER.map((groupId) => ({
+  id: groupId,
+  label: YAKUMAN_GROUP_LABELS[groupId],
+  items: YAKUMAN_OPTIONS.filter((option) => {
+    return groupId === 'single' ? option.multiplier === 1 : option.multiplier > 1;
+  }),
+}));
+
+export const getYakuDefinition = (id: YakuId): YakuDefinition => {
+  return YAKU_DEFS[id];
+};
+
+export const getYakumanDefinition = (id: YakumanId): YakumanDefinition => {
+  return YAKUMAN_DEFS[id];
+};
+
+export const getYakuIdsByGroup = (groupId: YakuGroupId): YakuId[] => {
+  return (
+    YAKU_GROUP_SECTIONS.find((section) => section.id === groupId)?.items.map((item) => item.id) ??
+    []
+  );
+};
+
+export const getYakumanIdsByGroup = (groupId: YakumanGroupId): YakumanId[] => {
+  return (
+    YAKUMAN_GROUP_SECTIONS.find((section) => section.id === groupId)?.items.map(
+      (item) => item.id,
+    ) ?? []
+  );
+};


### PR DESCRIPTION
## 概要

自分の麻雀を詳細に分析・振り返るための基盤機能とUIを実装しました。
主な機能として、対局中の和了・放銃・テンパイ流局時に詳細な手牌や役、メモを保存できる「分析メモ」機能を追加し、それらを一覧・検索できるページを実装しています。

## 変更内容

### service / hook

- `src/services/analysisService.ts`: Firestore (`userAnalyses`) を利用した分析データの CRUD とリアルタイム同期を実装。
- `src/hooks/useAnalysisEntry.ts`: 単一の分析データを、ソース（手牌ログID）またはエントリIDで管理するフック。ドラフト（編集中の未保存状態）の管理機能込み。
- `src/hooks/useAnalysisEntries.ts`: 保存済みの分析データ一覧を同期するフック。

### component / ui

- `src/components/ui/TileImage.tsx`: 麻雀牌を表示するための汎用コンポーネント。赤牌や選択状態に対応。
- `src/components/features/AnalysisDetailModal.tsx`: 手牌、鳴き、待ち形、役、ドラ、メモを詳細に入力・表示するモーダル。
- `src/components/features/AnalysisEventModalLauncher.tsx`: スナックバーや履歴からモーダルを呼び出す際のステールチェック（読み込み中の前データ表示防止）を行うラッパー。
- `src/components/features/analysis/*`: 手牌入力、鳴きエディタ、役・待ち形選択のサブコンポーネント。

### page

- `src/pages/AnalysisListPage.tsx`: 保存した分析ノートを期間やイベント種別で絞り込んで閲覧・編集できる一覧ページ。

### utils / test

- `src/utils/tiles.ts`, `src/utils/yaku.ts`: 牌や役の定義・メタデータ管理。
- 各種 Vitest によるサービス、フック、変換ロジック、UIのテスト。

## テスト計画

- [x] npm run lint
- [x] npm run build
- [x] npm run test（370 tests passed）
- [x] 受入テスト（ルームでの和了後のスナックバーからの「開く」ボタン、履歴アクション、分析一覧ページでのフィルタリングを確認済み）

Closes #126 #127 #128