### PR TITLE
分析メモの MPSZ 手牌入力でツモ/ロン末尾記号が消える問題を修正

### DIFF
--- a/src/components/features/AnalysisDetailModal.test.tsx
+++ b/src/components/features/AnalysisDetailModal.test.tsx
@@ -138,7 +138,144 @@ describe('AnalysisDetailModal', () => {
 
     const savedEntry = handleSave.mock.calls[0][0] as AnalysisEntry;
     expect(savedEntry.hand.concealed).toContain('1m');
+    expect(savedEntry.hand.winningTile).toBe('4m');
     expect(savedEntry.notes).toBe('良いリーチ判断だった');
+  });
+
+  it('preserves tsumo marker information when saving MPSZ notation', async () => {
+    const handleSave = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <AnalysisDetailModal
+        isOpen
+        mode="create"
+        entry={createAnalysisEntry()}
+        onClose={() => undefined}
+        onSave={handleSave}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'MPSZ形式で手牌を入力' }), {
+      target: { value: 'm1234_' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '保存' }));
+
+    await waitFor(() => {
+      expect(handleSave).toHaveBeenCalledTimes(1);
+    });
+
+    const savedHand = handleSave.mock.calls[0][0].hand as AnalysisEntry['hand'] & {
+      winningTileSource?: string;
+    };
+
+    expect(savedHand.winningTile).toBe('4m');
+    expect(savedHand.winningTileSource).toBe('tsumo');
+  });
+
+  it('preserves ron marker information when saving MPSZ notation', async () => {
+    const handleSave = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <AnalysisDetailModal
+        isOpen
+        mode="create"
+        entry={createAnalysisEntry()}
+        onClose={() => undefined}
+        onSave={handleSave}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'MPSZ形式で手牌を入力' }), {
+      target: { value: 'm1234-' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '保存' }));
+
+    await waitFor(() => {
+      expect(handleSave).toHaveBeenCalledTimes(1);
+    });
+
+    const savedHand = handleSave.mock.calls[0][0].hand as AnalysisEntry['hand'] & {
+      winningTileSource?: string;
+    };
+
+    expect(savedHand.winningTile).toBe('4m');
+    expect(savedHand.winningTileSource).toBe('shimocha');
+  });
+
+  it('rebuilds the MPSZ input with the stored winning marker', () => {
+    render(
+      <AnalysisDetailModal
+        isOpen
+        mode="edit"
+        entry={
+          {
+            ...createAnalysisEntry(),
+            hand: {
+              concealed: ['1m', '2m', '3m'],
+              melds: [],
+              winningTile: '4m',
+              wait: [],
+              winningTileSource: 'tsumo',
+            },
+          } as AnalysisEntry
+        }
+        onClose={() => undefined}
+        onSave={() => Promise.resolve()}
+      />,
+    );
+
+    const input = screen.getByRole('textbox', { name: 'MPSZ形式で手牌を入力' });
+    expect((input as HTMLInputElement).value).toBe('m1234_');
+  });
+
+  it('falls back to showing the winning tile in MPSZ input when old data has no marker source', () => {
+    render(
+      <AnalysisDetailModal
+        isOpen
+        mode="edit"
+        entry={createAnalysisEntry(
+          {},
+          {
+            hand: {
+              concealed: ['1m', '2m', '3m'],
+              melds: [],
+              winningTile: '4m',
+              wait: [],
+            },
+          },
+        )}
+        onClose={() => undefined}
+        onSave={() => Promise.resolve()}
+      />,
+    );
+
+    const input = screen.getByRole('textbox', { name: 'MPSZ形式で手牌を入力' });
+    expect((input as HTMLInputElement).value).toBe('m1234');
+  });
+
+  it('does not duplicate the winning tile in MPSZ input for legacy data that already includes it in concealed tiles', () => {
+    render(
+      <AnalysisDetailModal
+        isOpen
+        mode="edit"
+        entry={createAnalysisEntry(
+          {},
+          {
+            hand: {
+              concealed: ['1m', '2m', '3m', '4m'],
+              melds: [],
+              winningTile: '4m',
+              wait: [],
+            },
+          },
+        )}
+        onClose={() => undefined}
+        onSave={() => Promise.resolve()}
+      />,
+    );
+
+    const input = screen.getByRole('textbox', { name: 'MPSZ形式で手牌を入力' });
+    expect((input as HTMLInputElement).value).toBe('m1234');
   });
 
   it('saves dora changes via MPSZ notation', async () => {

--- a/src/components/features/AnalysisDetailModal.tsx
+++ b/src/components/features/AnalysisDetailModal.tsx
@@ -68,6 +68,7 @@ const cloneEntry = (entry: AnalysisEntry): AnalysisEntry => ({
     concealed: [...entry.hand.concealed],
     melds: entry.hand.melds.map(cloneMeld),
     ...(entry.hand.winningTile ? { winningTile: entry.hand.winningTile } : {}),
+    ...(entry.hand.winningTileSource ? { winningTileSource: entry.hand.winningTileSource } : {}),
     ...(entry.hand.wait ? { wait: [...entry.hand.wait] } : {}),
   },
   dora: {
@@ -90,7 +91,14 @@ const getEntryIdentity = (entry: AnalysisEntry) => {
 
 const getTileCount = (entry: AnalysisEntry) => {
   const meldTileCount = entry.hand.melds.reduce((total, meld) => total + meld.tiles.length, 0);
-  return entry.hand.concealed.length + meldTileCount;
+  const winningTileCount =
+    entry.context.eventType === 'tenpai-draw' ||
+    !entry.hand.winningTile ||
+    entry.hand.concealed.includes(entry.hand.winningTile)
+      ? 0
+      : 1;
+
+  return entry.hand.concealed.length + meldTileCount + winningTileCount;
 };
 
 const getWarnings = (entry: AnalysisEntry): string[] => {
@@ -104,14 +112,6 @@ const getWarnings = (entry: AnalysisEntry): string[] => {
 
   if (entry.context.eventType !== 'tenpai-draw' && !entry.hand.winningTile) {
     warnings.push('和了牌が未入力です');
-  }
-
-  if (
-    entry.context.eventType !== 'tenpai-draw' &&
-    entry.hand.winningTile &&
-    !entry.hand.concealed.includes(entry.hand.winningTile)
-  ) {
-    warnings.push('和了牌は手牌内の牌から選択してください');
   }
 
   if (tileCount > 0 && tileCount !== expectedTileCount) {
@@ -175,10 +175,15 @@ const AnalysisDetailModalContent = ({
       hand: {
         ...draft.hand,
         ...(draft.context.eventType === 'tenpai-draw'
-          ? { winningTile: undefined }
-          : draft.hand.winningTile && draft.hand.concealed.includes(draft.hand.winningTile)
-            ? { winningTile: draft.hand.winningTile }
-            : {}),
+          ? { winningTile: undefined, winningTileSource: undefined }
+          : draft.hand.winningTile
+            ? {
+                winningTile: draft.hand.winningTile,
+                ...(draft.hand.winningTileSource
+                  ? { winningTileSource: draft.hand.winningTileSource }
+                  : { winningTileSource: undefined }),
+              }
+            : { winningTile: undefined, winningTileSource: undefined }),
       },
       notes: draft.notes.trim(),
     });
@@ -274,6 +279,7 @@ const AnalysisDetailModalContent = ({
           concealed={draft.hand.concealed}
           melds={draft.hand.melds}
           winningTile={draft.hand.winningTile}
+          winningTileSource={draft.hand.winningTileSource}
           eventType={draft.context.eventType}
           readOnly={readOnly || isBusy}
           onConcealedChange={(concealed) => {
@@ -300,6 +306,15 @@ const AnalysisDetailModalContent = ({
               hand: {
                 ...current.hand,
                 ...(winningTile ? { winningTile } : { winningTile: undefined }),
+              },
+            }));
+          }}
+          onWinningTileSourceChange={(winningTileSource) => {
+            updateDraft((current) => ({
+              ...current,
+              hand: {
+                ...current.hand,
+                ...(winningTileSource ? { winningTileSource } : { winningTileSource: undefined }),
               },
             }));
           }}

--- a/src/components/features/analysis/HandInputSection.test.tsx
+++ b/src/components/features/analysis/HandInputSection.test.tsx
@@ -3,7 +3,7 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { useState } from 'react';
 import { afterEach, describe, expect, it } from 'vitest';
-import type { AnalysisEventType, Meld, TileCode } from '../../../types';
+import type { AnalysisEventType, Meld, TileCode, WinningTileSource } from '../../../types';
 import { HandInputSection } from './HandInputSection';
 
 afterEach(() => {
@@ -14,6 +14,7 @@ interface HandInputSectionHarnessProps {
   initialConcealed?: TileCode[];
   initialMelds?: Meld[];
   initialWinningTile?: TileCode;
+  initialWinningTileSource?: WinningTileSource;
   eventType?: AnalysisEventType;
   readOnly?: boolean;
 }
@@ -22,12 +23,16 @@ const HandInputSectionHarness = ({
   initialConcealed = [],
   initialMelds = [],
   initialWinningTile,
+  initialWinningTileSource,
   eventType = 'win',
   readOnly = false,
 }: HandInputSectionHarnessProps) => {
   const [concealed, setConcealed] = useState<TileCode[]>(initialConcealed);
   const [melds, setMelds] = useState<Meld[]>(initialMelds);
   const [winningTile, setWinningTile] = useState<TileCode | undefined>(initialWinningTile);
+  const [winningTileSource, setWinningTileSource] = useState<WinningTileSource | undefined>(
+    initialWinningTileSource,
+  );
 
   return (
     <>
@@ -35,11 +40,13 @@ const HandInputSectionHarness = ({
         concealed={concealed}
         melds={melds}
         winningTile={winningTile}
+        winningTileSource={winningTileSource}
         eventType={eventType}
         readOnly={readOnly}
         onConcealedChange={setConcealed}
         onMeldsChange={setMelds}
         onWinningTileChange={setWinningTile}
+        onWinningTileSourceChange={setWinningTileSource}
       />
       <output aria-label="concealed-state">{concealed.join(',') || 'none'}</output>
       <output aria-label="melds-state">{melds.length > 0 ? JSON.stringify(melds) : 'none'}</output>

--- a/src/components/features/analysis/HandInputSection.tsx
+++ b/src/components/features/analysis/HandInputSection.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import type { AnalysisEventType, Meld, TileCode } from '../../../types';
+import type { AnalysisEventType, Meld, TileCode, WinningTileSource } from '../../../types';
 import { HandNotationInput } from './HandNotationInput';
 import styles from './HandInputSection.module.css';
 
@@ -7,21 +7,26 @@ interface HandInputSectionProps {
   concealed: TileCode[];
   melds: Meld[];
   winningTile?: TileCode;
+  winningTileSource?: WinningTileSource;
   eventType: AnalysisEventType;
   readOnly: boolean;
   onConcealedChange: (tiles: TileCode[]) => void;
   onMeldsChange: (melds: Meld[]) => void;
   onWinningTileChange: (tile: TileCode | undefined) => void;
+  onWinningTileSourceChange: (source: WinningTileSource | undefined) => void;
 }
 
 export const HandInputSection = ({
   concealed,
   melds,
   eventType,
+  winningTile,
+  winningTileSource,
   readOnly,
   onConcealedChange,
   onMeldsChange,
   onWinningTileChange,
+  onWinningTileSourceChange,
 }: HandInputSectionProps) => {
   const handleParsed = useCallback(
     (result: {
@@ -35,15 +40,19 @@ export const HandInputSection = ({
 
       if (eventType === 'tenpai-draw') {
         onWinningTileChange(undefined);
+        onWinningTileSourceChange(undefined);
       } else if (result.tsumo) {
         onWinningTileChange(result.tsumo);
+        onWinningTileSourceChange('tsumo');
       } else if (result.ron) {
         onWinningTileChange(result.ron.tile);
+        onWinningTileSourceChange(result.ron.from);
       } else {
         onWinningTileChange(undefined);
+        onWinningTileSourceChange(undefined);
       }
     },
-    [eventType, onConcealedChange, onMeldsChange, onWinningTileChange],
+    [eventType, onConcealedChange, onMeldsChange, onWinningTileChange, onWinningTileSourceChange],
   );
 
   return (
@@ -56,6 +65,8 @@ export const HandInputSection = ({
       <HandNotationInput
         concealed={concealed}
         melds={melds}
+        winningTile={winningTile}
+        winningTileSource={winningTileSource}
         readOnly={readOnly}
         onParsed={handleParsed}
       />

--- a/src/components/features/analysis/HandNotationInput.tsx
+++ b/src/components/features/analysis/HandNotationInput.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react';
-import type { Meld, TileCode } from '../../../types';
+import type { Meld, ParsedHand, TileCode, WinningTileSource } from '../../../types';
 import { getTileLabel, getTileSvgPath } from '../../../utils/tiles';
 import {
   type ParseResult,
@@ -17,6 +17,8 @@ const FROM_LABELS: Record<string, string> = {
 interface HandNotationInputProps {
   concealed: TileCode[];
   melds: Meld[];
+  winningTile?: TileCode;
+  winningTileSource?: WinningTileSource;
   readOnly: boolean;
   onParsed: (result: {
     concealed: TileCode[];
@@ -25,6 +27,35 @@ interface HandNotationInputProps {
     ron?: { tile: TileCode; from: 'kamicha' | 'toimen' | 'shimocha' };
   }) => void;
 }
+
+const buildParsedHand = ({
+  concealed,
+  melds,
+  winningTile,
+  winningTileSource,
+}: Pick<
+  HandNotationInputProps,
+  'concealed' | 'melds' | 'winningTile' | 'winningTileSource'
+>): ParsedHand | null => {
+  if (concealed.length === 0 && melds.length === 0) {
+    return null;
+  }
+
+  const parsedHand: ParsedHand = {
+    concealed: [...concealed],
+    melds: [...melds],
+  };
+
+  if (winningTile && winningTileSource === 'tsumo') {
+    parsedHand.tsumo = winningTile;
+  } else if (winningTile && winningTileSource && winningTileSource !== 'tsumo') {
+    parsedHand.ron = { tile: winningTile, from: winningTileSource };
+  } else if (winningTile && !parsedHand.concealed.includes(winningTile)) {
+    parsedHand.concealed = [...parsedHand.concealed, winningTile];
+  }
+
+  return parsedHand;
+};
 
 const TileSvg = ({ code }: { code: TileCode }) => (
   <img
@@ -49,17 +80,21 @@ const MeldGroupPreview = ({ meld }: { meld: Meld }) => (
 export const HandNotationInput = ({
   concealed,
   melds,
+  winningTile,
+  winningTileSource,
   readOnly,
   onParsed,
 }: HandNotationInputProps) => {
+  const initialHand = buildParsedHand({ concealed, melds, winningTile, winningTileSource });
+
   const [notation, setNotation] = useState(() => {
-    if (concealed.length === 0 && melds.length === 0) return '';
-    return formatHandNotation({ concealed, melds });
+    if (!initialHand) return '';
+    return formatHandNotation(initialHand);
   });
   const [parseError, setParseError] = useState<string | null>(null);
   const [parsed, setParsed] = useState<ParseResult | null>(() => {
-    if (concealed.length === 0 && melds.length === 0) return null;
-    return parseHandNotation(formatHandNotation({ concealed, melds }));
+    if (!initialHand) return null;
+    return { success: true, hand: initialHand };
   });
 
   const handleChange = useCallback(

--- a/src/services/analysisService.test.ts
+++ b/src/services/analysisService.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
     path: pathSegments.join('/'),
   })),
   mockDeleteDoc: vi.fn(),
+  mockDeleteField: vi.fn(() => 'DELETE_FIELD'),
   mockDoc: vi.fn((_db: any, ...pathSegments: string[]) => ({
     id: pathSegments[pathSegments.length - 1],
     path: pathSegments.join('/'),
@@ -28,6 +29,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('firebase/firestore', () => ({
   collection: mocks.mockCollection,
+  deleteField: mocks.mockDeleteField,
   deleteDoc: mocks.mockDeleteDoc,
   doc: mocks.mockDoc,
   getDoc: mocks.mockGetDoc,
@@ -104,8 +106,44 @@ describe('analysisService', () => {
     await expect(getAnalysisEntry('user-1', 'entry-1')).resolves.toBeNull();
   });
 
+  it('normalizes invalid winningTileSource values when reading an analysis entry', async () => {
+    mocks.mockGetDoc.mockResolvedValue({
+      id: 'hand-1',
+      exists: () => true,
+      data: () =>
+        createAnalysisEntry({
+          hand: {
+            concealed: ['1m', '2m', '3m'],
+            melds: [],
+            winningTile: '4m',
+            winningTileSource: 'invalid-source',
+            wait: [],
+          },
+        }),
+    });
+
+    const result = await getAnalysisEntry('user-1', 'hand-1');
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        hand: expect.objectContaining({
+          winningTile: '4m',
+        }),
+      }),
+    );
+    expect(result?.hand).not.toHaveProperty('winningTileSource');
+  });
+
   it('saves an analysis entry with merge semantics and a server updatedAt timestamp', async () => {
-    const entry = createAnalysisEntry();
+    const entry = createAnalysisEntry({
+      hand: {
+        concealed: ['1m', '2m', '3m'],
+        melds: [],
+        winningTile: '4m',
+        winningTileSource: 'tsumo',
+        wait: [],
+      },
+    });
 
     await saveAnalysisEntry('user-1', entry as any);
 
@@ -122,7 +160,34 @@ describe('analysisService', () => {
         ...entry,
         id: 'hand-1',
         uid: 'user-1',
+        hand: expect.objectContaining({
+          winningTile: '4m',
+          winningTileSource: 'tsumo',
+        }),
         updatedAt: 'SERVER_TIMESTAMP',
+      }),
+      { merge: true },
+    );
+  });
+
+  it('deletes stale winning tile fields when the normalized entry does not keep them', async () => {
+    const entry = createAnalysisEntry({
+      hand: {
+        concealed: ['1m', '2m', '3m'],
+        melds: [],
+        wait: [],
+      },
+    });
+
+    await saveAnalysisEntry('user-1', entry as any);
+
+    expect(mocks.mockSetDoc).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        hand: expect.objectContaining({
+          winningTile: 'DELETE_FIELD',
+          winningTileSource: 'DELETE_FIELD',
+        }),
       }),
       { merge: true },
     );

--- a/src/services/analysisService.ts
+++ b/src/services/analysisService.ts
@@ -1,5 +1,6 @@
 import {
   collection,
+  deleteField,
   deleteDoc,
   doc,
   getDoc,
@@ -31,11 +32,11 @@ const normalizeAnalysisEntry = (
   entryId: string,
   data: AnalysisEntry,
 ): AnalysisEntry => {
-  return {
+  return normalizeAnalysisDraft({
     ...data,
     id: data.id || entryId,
     uid: data.uid || uid,
-  };
+  });
 };
 
 export const subscribeAnalysisEntries = (
@@ -90,14 +91,20 @@ export const saveAnalysisEntry = async (uid: string, entry: AnalysisEntry): Prom
     id: entry.source.handLogId,
     uid,
   });
+  const sanitizedEntry = sanitizeFirestoreData({
+    ...normalizedEntry,
+  }) as AnalysisEntry;
   const entryId = entry.source.handLogId;
 
   await setDoc(
     getAnalysisEntryDocument(uid, entryId),
     {
-      ...sanitizeFirestoreData({
-        ...normalizedEntry,
-      }),
+      ...sanitizedEntry,
+      hand: {
+        ...sanitizedEntry.hand,
+        ...(normalizedEntry.hand.winningTile ? {} : { winningTile: deleteField() }),
+        ...(normalizedEntry.hand.winningTileSource ? {} : { winningTileSource: deleteField() }),
+      },
       updatedAt: serverTimestamp(),
     },
     { merge: true },

--- a/src/types/analysis.ts
+++ b/src/types/analysis.ts
@@ -13,6 +13,7 @@ export type TileCode =
   | '0s';
 
 export type RelativePosition = 'kamicha' | 'toimen' | 'shimocha';
+export type WinningTileSource = 'tsumo' | RelativePosition;
 
 export type Meld =
   | { kind: 'chi'; tiles: [TileCode, TileCode, TileCode]; from: 'kamicha' }
@@ -152,6 +153,7 @@ export interface AnalysisHand {
   concealed: TileCode[];
   melds: Meld[];
   winningTile?: TileCode;
+  winningTileSource?: WinningTileSource;
   wait?: WaitShape[];
 }
 

--- a/src/utils/analysis.ts
+++ b/src/utils/analysis.ts
@@ -7,6 +7,7 @@ import type {
   RelativePosition,
   TileCode,
   WaitShape,
+  WinningTileSource,
   YakumanId,
   YakuId,
 } from '../types/analysis';
@@ -39,6 +40,10 @@ const isTileCode = (value: unknown): value is TileCode => {
 
 const isRelativePosition = (value: unknown): value is RelativePosition => {
   return typeof value === 'string' && RELATIVE_POSITIONS.includes(value as RelativePosition);
+};
+
+const isWinningTileSource = (value: unknown): value is WinningTileSource => {
+  return value === 'tsumo' || isRelativePosition(value);
 };
 
 const isWaitShape = (value: unknown): value is WaitShape => {
@@ -272,6 +277,10 @@ export const normalizeAnalysisEntry = (entry: AnalysisEntry): AnalysisEntry => {
     entry.context.eventType === 'tenpai-draw' || !isTileCode(entry.hand.winningTile)
       ? undefined
       : entry.hand.winningTile;
+  const normalizedWinningTileSource =
+    normalizedWinningTile && isWinningTileSource(entry.hand.winningTileSource)
+      ? entry.hand.winningTileSource
+      : undefined;
 
   return {
     ...entry,
@@ -294,6 +303,7 @@ export const normalizeAnalysisEntry = (entry: AnalysisEntry): AnalysisEntry => {
         .map(normalizeMeld)
         .filter((meld): meld is Meld => meld !== null),
       ...(normalizedWinningTile ? { winningTile: normalizedWinningTile } : {}),
+      ...(normalizedWinningTileSource ? { winningTileSource: normalizedWinningTileSource } : {}),
       wait: normalizedWait,
     },
     dora: {


### PR DESCRIPTION
## 概要

- AnalysisEntry.hand に winningTileSource を追加し、MPSZ のツモ/ロン末尾記号を Firestore 保存後も保持できるようにしました。
- 旧データの後方互換を維持しつつ、保存時の stale な winningTile 系フィールド削除と、読み取り時の normalize による不正値除去を追加しました。

## 変更内容

### modal / input

- `src/components/features/AnalysisDetailModal.tsx`: MPSZ 入力の初期値を winningTile と winningTileSource から再構築し、source がない旧データでは winningTile を牌姿にフォールバック表示するようにしました。
- `src/components/features/analysis/HandInputSection.tsx`: 手牌入力セクションで保存済みの和了牌ソースを扱えるようにし、再編集時の round-trip を維持しました。
- `src/components/features/analysis/HandNotationInput.tsx`: 旧データ読み込み時に winningTile を二重計上せず、牌数警告が過剰に出ないよう調整しました。

### service / type / utils

- `src/types/analysis.ts`: AnalysisHand に winningTileSource を追加しました。
- `src/utils/analysis.ts`: winningTileSource の normalize と、MPSZ 表記への再構築処理を追加しました。
- `src/services/analysisService.ts`: merge 保存時に stale な winningTile と winningTileSource を deleteField で削除し、読み取り時にも normalize を通すようにしました。

### test

- `src/components/features/AnalysisDetailModal.test.tsx`: `_` と `-` を含む保存後再編集、およびプレビュー保持のケースを追加しました。
- `src/components/features/analysis/HandInputSection.test.tsx`: MPSZ suffix を含む入力の回帰テストを更新しました。
- `src/services/analysisService.test.ts`: winningTileSource の保存、削除、invalid 値の normalize を検証するテストを追加しました。

## テスト計画

- [ ] npm run lint
  - 既存不良で失敗: src/components/features/AnalysisEventModalLauncher.test.tsx の未使用変数
  - 既存不良で失敗: src/components/features/ScoreBoard.tsx の react-hooks/set-state-in-effect
  - 既存不良で失敗: src/hooks/useAnalysisEntry.ts の react-hooks/set-state-in-effect
  - 既存不良で失敗: src/hooks/useUserSettings.ts の react-hooks/set-state-in-effect
  - 既存不良で失敗: src/pages/UserSettingsPage.tsx の react-hooks/set-state-in-effect
- [x] npm run build
- [x] npm run test -- --run（52 files / 464 passed / 5 skipped）
- [x] 受入テスト
  - m1234_ を保存して再オープン後も `_` が残る
  - m1234- を保存して再オープン後も `-` が残る
  - プレビューでもツモ / ロン表示が保持される

Closes #135
