### PR TITLE
分析メモで牌姿から待ち牌を自動判定できるようにする

### DIFF
--- a/src/components/features/AnalysisDetailModal.test.tsx
+++ b/src/components/features/AnalysisDetailModal.test.tsx
@@ -45,7 +45,6 @@ const createAnalysisEntry = (
     concealed: ['2m', '3m'],
     melds: [],
     winningTile: '4m',
-    wait: [],
     ...nestedOverrides?.hand,
   },
   dora: {
@@ -125,7 +124,7 @@ describe('AnalysisDetailModal', () => {
     );
 
     fireEvent.change(screen.getByRole('textbox', { name: 'MPSZ形式で手牌を入力' }), {
-      target: { value: 'm1234_' },
+      target: { value: 'm123456s123z22p231_' },
     });
     fireEvent.change(screen.getByLabelText('メモ'), {
       target: { value: '良いリーチ判断だった' },
@@ -138,7 +137,15 @@ describe('AnalysisDetailModal', () => {
 
     const savedEntry = handleSave.mock.calls[0][0] as AnalysisEntry;
     expect(savedEntry.hand.concealed).toContain('1m');
-    expect(savedEntry.hand.winningTile).toBe('4m');
+    expect(savedEntry.hand.winningTile).toBe('1p');
+    expect(savedEntry.hand.waits).toEqual({
+      kind: 'auto',
+      categories: ['ryanmen'],
+      tiles: [
+        { tile: '1p', categories: ['ryanmen'] },
+        { tile: '4p', categories: ['ryanmen'] },
+      ],
+    });
     expect(savedEntry.notes).toBe('良いリーチ判断だった');
   });
 
@@ -214,7 +221,6 @@ describe('AnalysisDetailModal', () => {
               concealed: ['1m', '2m', '3m'],
               melds: [],
               winningTile: '4m',
-              wait: [],
               winningTileSource: 'tsumo',
             },
           } as AnalysisEntry
@@ -240,7 +246,6 @@ describe('AnalysisDetailModal', () => {
               concealed: ['1m', '2m', '3m'],
               melds: [],
               winningTile: '4m',
-              wait: [],
             },
           },
         )}
@@ -265,7 +270,6 @@ describe('AnalysisDetailModal', () => {
               concealed: ['1m', '2m', '3m', '4m'],
               melds: [],
               winningTile: '4m',
-              wait: [],
             },
           },
         )}
@@ -334,7 +338,6 @@ describe('AnalysisDetailModal', () => {
               concealed: [],
               melds: [],
               winningTile: undefined,
-              wait: [],
             },
           },
         )}
@@ -433,6 +436,287 @@ describe('AnalysisDetailModal', () => {
 
     const savedEntry = handleSave.mock.calls[0][0] as AnalysisEntry;
     expect(savedEntry.hand.winningTile).toBe('5m');
+  });
+
+  it('shows detected waits in view mode', () => {
+    render(
+      <AnalysisDetailModal
+        isOpen
+        mode="view"
+        entry={createAnalysisEntry(
+          {},
+          {
+            context: { eventType: 'win' },
+            hand: {
+              concealed: [
+                '1m',
+                '2m',
+                '3m',
+                '4m',
+                '5m',
+                '6m',
+                '1s',
+                '2s',
+                '3s',
+                '2z',
+                '2z',
+                '2p',
+                '3p',
+              ],
+              melds: [],
+              winningTile: '1p',
+              winningTileSource: 'tsumo',
+            },
+          },
+        )}
+        onClose={() => undefined}
+      />,
+    );
+
+    expect(screen.getByText('待ち')).toBeTruthy();
+    expect(screen.getByText('1筒')).toBeTruthy();
+    expect(screen.getByText('4筒')).toBeTruthy();
+  });
+
+  it('shows stored waits in view mode before any re-analysis', () => {
+    render(
+      <AnalysisDetailModal
+        isOpen
+        mode="view"
+        entry={createAnalysisEntry(
+          {},
+          {
+            hand: {
+              concealed: ['1m', '2m', '3m'],
+              melds: [],
+              winningTile: '4m',
+              waits: {
+                kind: 'legacy',
+                categories: ['shabo'],
+                tiles: [{ tile: '1p', categories: ['shabo'] }],
+              },
+            },
+          },
+        )}
+        onClose={() => undefined}
+      />,
+    );
+
+    expect(screen.getByText('1筒')).toBeTruthy();
+    expect(screen.getByText('シャボ')).toBeTruthy();
+    expect(screen.getByText('保存済み')).toBeTruthy();
+  });
+
+  it('shows category-only legacy waits in view mode', () => {
+    render(
+      <AnalysisDetailModal
+        isOpen
+        mode="view"
+        entry={createAnalysisEntry(
+          {},
+          {
+            hand: {
+              concealed: ['1m', '2m', '3m'],
+              melds: [],
+              winningTile: '4m',
+              waits: {
+                kind: 'legacy',
+                categories: ['shabo'],
+                tiles: [],
+              },
+            },
+          },
+        )}
+        onClose={() => undefined}
+      />,
+    );
+
+    expect(screen.getByText('待ち牌情報なし')).toBeTruthy();
+    expect(screen.getByText('シャボ')).toBeTruthy();
+  });
+
+  it('preserves stored waits when saving without hand edits', async () => {
+    const handleSave = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <AnalysisDetailModal
+        isOpen
+        mode="edit"
+        entry={createAnalysisEntry(
+          {},
+          {
+            hand: {
+              concealed: ['1m', '2m', '3m'],
+              melds: [],
+              winningTile: '4m',
+              waits: {
+                kind: 'legacy',
+                categories: ['shabo'],
+                tiles: [{ tile: '1p', categories: ['shabo'] }],
+              },
+            },
+          },
+        )}
+        onClose={() => undefined}
+        onSave={handleSave}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('メモ'), {
+      target: { value: '待ちは維持する' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '保存' }));
+
+    await waitFor(() => {
+      expect(handleSave).toHaveBeenCalledTimes(1);
+    });
+
+    const savedEntry = handleSave.mock.calls[0][0] as AnalysisEntry;
+    expect(savedEntry.hand.waits).toEqual({
+      kind: 'legacy',
+      categories: ['shabo'],
+      tiles: [{ tile: '1p', categories: ['shabo'] }],
+    });
+  });
+
+  it('preserves stored waits when the hand is edited and restored', async () => {
+    const handleSave = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <AnalysisDetailModal
+        isOpen
+        mode="edit"
+        entry={createAnalysisEntry(
+          {},
+          {
+            hand: {
+              concealed: ['1m', '2m', '3m'],
+              melds: [],
+              winningTile: '4m',
+              winningTileSource: 'tsumo',
+              waits: {
+                kind: 'legacy',
+                categories: ['shabo'],
+                tiles: [{ tile: '1p', categories: ['shabo'] }],
+              },
+            },
+          },
+        )}
+        onClose={() => undefined}
+        onSave={handleSave}
+      />,
+    );
+
+    const input = screen.getByRole('textbox', { name: 'MPSZ形式で手牌を入力' });
+    fireEvent.change(input, { target: { value: 'm12345_' } });
+    fireEvent.change(input, { target: { value: 'm1234_' } });
+    fireEvent.click(screen.getByRole('button', { name: '保存' }));
+
+    await waitFor(() => {
+      expect(handleSave).toHaveBeenCalledTimes(1);
+    });
+
+    const savedEntry = handleSave.mock.calls[0][0] as AnalysisEntry;
+    expect(savedEntry.hand.waits).toEqual({
+      kind: 'legacy',
+      categories: ['shabo'],
+      tiles: [{ tile: '1p', categories: ['shabo'] }],
+    });
+  });
+
+  it('preserves stored waits when equivalent notation order is restored', async () => {
+    const handleSave = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <AnalysisDetailModal
+        isOpen
+        mode="edit"
+        entry={createAnalysisEntry(
+          {},
+          {
+            hand: {
+              concealed: ['1m', '2m', '3m'],
+              melds: [],
+              winningTile: '4m',
+              winningTileSource: 'tsumo',
+              waits: {
+                kind: 'legacy',
+                categories: ['shabo'],
+                tiles: [{ tile: '1p', categories: ['shabo'] }],
+              },
+            },
+          },
+        )}
+        onClose={() => undefined}
+        onSave={handleSave}
+      />,
+    );
+
+    const input = screen.getByRole('textbox', { name: 'MPSZ形式で手牌を入力' });
+    fireEvent.change(input, { target: { value: 'm12345_' } });
+    fireEvent.change(input, { target: { value: 'm3214_' } });
+
+    expect(screen.getByText('保存済み')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: '保存' }));
+
+    await waitFor(() => {
+      expect(handleSave).toHaveBeenCalledTimes(1);
+    });
+
+    const savedEntry = handleSave.mock.calls[0][0] as AnalysisEntry;
+    expect(savedEntry.hand.waits).toEqual({
+      kind: 'legacy',
+      categories: ['shabo'],
+      tiles: [{ tile: '1p', categories: ['shabo'] }],
+    });
+  });
+
+  it('preserves stored waits when only the winning source marker changes', async () => {
+    const handleSave = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <AnalysisDetailModal
+        isOpen
+        mode="edit"
+        entry={createAnalysisEntry(
+          {},
+          {
+            hand: {
+              concealed: ['1m', '2m', '3m'],
+              melds: [],
+              winningTile: '4m',
+              winningTileSource: 'tsumo',
+              waits: {
+                kind: 'legacy',
+                categories: ['shabo'],
+                tiles: [{ tile: '1p', categories: ['shabo'] }],
+              },
+            },
+          },
+        )}
+        onClose={() => undefined}
+        onSave={handleSave}
+      />,
+    );
+
+    const input = screen.getByRole('textbox', { name: 'MPSZ形式で手牌を入力' });
+    fireEvent.change(input, { target: { value: 'm1234-' } });
+
+    expect(screen.getByText('保存済み')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: '保存' }));
+
+    await waitFor(() => {
+      expect(handleSave).toHaveBeenCalledTimes(1);
+    });
+
+    const savedEntry = handleSave.mock.calls[0][0] as AnalysisEntry;
+    expect(savedEntry.hand.waits).toEqual({
+      kind: 'legacy',
+      categories: ['shabo'],
+      tiles: [{ tile: '1p', categories: ['shabo'] }],
+    });
   });
 
   it('is read only in view mode', () => {

--- a/src/components/features/AnalysisDetailModal.tsx
+++ b/src/components/features/AnalysisDetailModal.tsx
@@ -4,6 +4,8 @@ import { Button } from '../ui/Button';
 import { Modal } from '../ui/Modal';
 import { DoraNotationInput } from './analysis/DoraNotationInput';
 import { HandInputSection } from './analysis/HandInputSection';
+import { detectHandWaits } from '../../utils/waits';
+import { normalizeTileCode } from '../../utils/tiles';
 import styles from './AnalysisDetailModal.module.css';
 
 export type AnalysisDetailMode = 'create' | 'edit' | 'view';
@@ -69,7 +71,18 @@ const cloneEntry = (entry: AnalysisEntry): AnalysisEntry => ({
     melds: entry.hand.melds.map(cloneMeld),
     ...(entry.hand.winningTile ? { winningTile: entry.hand.winningTile } : {}),
     ...(entry.hand.winningTileSource ? { winningTileSource: entry.hand.winningTileSource } : {}),
-    ...(entry.hand.wait ? { wait: [...entry.hand.wait] } : {}),
+    ...(entry.hand.waits
+      ? {
+          waits: {
+            ...entry.hand.waits,
+            tiles: entry.hand.waits.tiles.map((waitTile) => ({
+              tile: waitTile.tile,
+              categories: [...waitTile.categories],
+            })),
+            categories: [...entry.hand.waits.categories],
+          },
+        }
+      : {}),
   },
   dora: {
     doraIndicators: [...entry.dora.doraIndicators],
@@ -119,6 +132,81 @@ const getWarnings = (entry: AnalysisEntry): string[] => {
   }
 
   return warnings;
+};
+
+const buildDetectedWaits = (entry: AnalysisEntry): AnalysisEntry['hand']['waits'] => {
+  return detectHandWaits({
+    eventType: entry.context.eventType,
+    hand: {
+      concealed: entry.hand.concealed,
+      melds: entry.hand.melds,
+      ...(entry.hand.winningTile ? { winningTile: entry.hand.winningTile } : {}),
+    },
+  });
+};
+
+const buildWaitInputSignature = (entry: AnalysisEntry) => {
+  const concealed = [...entry.hand.concealed].map(normalizeTileCode).sort();
+  const melds = entry.hand.melds
+    .map((meld) => {
+      const from = 'from' in meld ? (meld.from ?? '') : '';
+      const tiles = [...meld.tiles].map(normalizeTileCode).sort().join(',');
+
+      return `${meld.kind}:${from}:${tiles}`;
+    })
+    .sort();
+
+  return JSON.stringify({
+    eventType: entry.context.eventType,
+    concealed,
+    melds,
+    winningTile: entry.hand.winningTile ? normalizeTileCode(entry.hand.winningTile) : undefined,
+  });
+};
+
+const shouldRecomputeWaits = (previousEntry: AnalysisEntry, nextEntry: AnalysisEntry) => {
+  return buildWaitInputSignature(previousEntry) !== buildWaitInputSignature(nextEntry);
+};
+
+const areWaitsEqual = (
+  left: AnalysisEntry['hand']['waits'],
+  right: AnalysisEntry['hand']['waits'],
+) => {
+  if (left === right) {
+    return true;
+  }
+
+  if (!left || !right) {
+    return left === right;
+  }
+
+  if (left.kind !== right.kind || left.categories.length !== right.categories.length) {
+    return false;
+  }
+
+  if (left.tiles.length !== right.tiles.length) {
+    return false;
+  }
+
+  if (left.categories.some((category, index) => category !== right.categories[index])) {
+    return false;
+  }
+
+  return left.tiles.every((tile, index) => {
+    const otherTile = right.tiles[index];
+
+    if (
+      !otherTile ||
+      tile.tile !== otherTile.tile ||
+      tile.categories.length !== otherTile.categories.length
+    ) {
+      return false;
+    }
+
+    return tile.categories.every(
+      (category, categoryIndex) => category === otherTile.categories[categoryIndex],
+    );
+  });
 };
 
 const SPECIAL_OPTIONS = [
@@ -187,6 +275,14 @@ const AnalysisDetailModalContent = ({
       },
       notes: draft.notes.trim(),
     });
+    const detectedWaits = shouldRecomputeWaits(entry, nextEntry)
+      ? buildDetectedWaits(nextEntry)
+      : entry.hand.waits;
+
+    nextEntry.hand = {
+      ...nextEntry.hand,
+      waits: detectedWaits,
+    };
 
     setIsSubmitting(true);
     try {
@@ -280,6 +376,14 @@ const AnalysisDetailModalContent = ({
           melds={draft.hand.melds}
           winningTile={draft.hand.winningTile}
           winningTileSource={draft.hand.winningTileSource}
+          waits={draft.hand.waits}
+          storedSnapshot={{
+            concealed: entry.hand.concealed,
+            melds: entry.hand.melds,
+            winningTile: entry.hand.winningTile,
+            winningTileSource: entry.hand.winningTileSource,
+            waits: entry.hand.waits,
+          }}
           eventType={draft.context.eventType}
           readOnly={readOnly || isBusy}
           onConcealedChange={(concealed) => {
@@ -317,6 +421,21 @@ const AnalysisDetailModalContent = ({
                 ...(winningTileSource ? { winningTileSource } : { winningTileSource: undefined }),
               },
             }));
+          }}
+          onWaitsChange={(waits) => {
+            updateDraft((current) => {
+              if (areWaitsEqual(current.hand.waits, waits)) {
+                return current;
+              }
+
+              return {
+                ...current,
+                hand: {
+                  ...current.hand,
+                  waits,
+                },
+              };
+            });
           }}
         />
 

--- a/src/components/features/AnalysisEventModalLauncher.test.tsx
+++ b/src/components/features/AnalysisEventModalLauncher.test.tsx
@@ -151,7 +151,7 @@ const createEntry = (): AnalysisEntry => ({
   updatedAt: 1710000001000,
 });
 
-const mockSaveAnalysisEntry = vi.fn(async (_entry: AnalysisEntry) => undefined);
+const mockSaveAnalysisEntry = vi.fn(async () => undefined);
 const mockDeleteAnalysisEntry = vi.fn(async () => undefined);
 
 const mockHookResult = ({

--- a/src/components/features/ScoreBoard.tsx
+++ b/src/components/features/ScoreBoard.tsx
@@ -209,16 +209,17 @@ const PlayerRow = ({
         // Prevents animation bugs where startScore becomes huge (e.g. -5e31)
         if (!Number.isFinite(totalDelta) || Math.abs(totalDelta) > 500000) {
           console.warn('ScoreBoard: Detected astronomical delta, skipping animation.', totalDelta);
-          setDisplayScore(player.score);
           prevEventIdRef.current = lastEvent.id;
           prevScoreRef.current = player.score;
+          requestAnimationFrame(() => {
+            setDisplayScore(player.score);
+          });
           return;
         }
 
         const startScore = player.score - totalDelta; // Reconstruct start
 
         // Setup
-        setIsAnimating(true);
         prevEventIdRef.current = lastEvent.id;
         prevScoreRef.current = player.score;
 
@@ -226,48 +227,50 @@ const PlayerRow = ({
         const PAUSE = 400;
         const STICK_DURATION = 800;
         const FADE_OUT_DELAY = 1500; // Duration to keep the final delta visible
+        const frameIds: number[] = [];
 
         // Initial State (Phase 1)
         // If hand is 0, we might want to skip or just show 0?
         // Usually hand != 0. If 0 (e.g. only riichi stick?), jump to sticks?
         // Let's assume sequential.
-        setDisplayScore(startScore);
-        if (myDelta.hand !== 0) setDelta({ value: myDelta.hand, type: 'hand' });
-        else if (myDelta.sticks !== 0) setDelta({ value: myDelta.sticks, type: 'stick' });
+        frameIds.push(
+          requestAnimationFrame(() => {
+            setIsAnimating(true);
+            setDisplayScore(startScore);
+            if (myDelta.hand !== 0) setDelta({ value: myDelta.hand, type: 'hand' });
+            else if (myDelta.sticks !== 0) setDelta({ value: myDelta.sticks, type: 'stick' });
 
-        // Animation Loop
-        const startTime = performance.now();
+            // Animation Loop
+            const startTime = performance.now();
 
-        const animate = (now: number) => {
-          const elapsed = now - startTime;
+            const animate = (now: number) => {
+              const elapsed = now - startTime;
 
-          if (elapsed < HAND_DURATION) {
-            // Phase 1: Hand
-            const progress = elapsed / HAND_DURATION;
-            const ease = 1 - Math.pow(1 - progress, 3);
-            const current = Math.floor(startScore + myDelta.hand * ease);
-            setDisplayScore(current);
-            requestAnimationFrame(animate);
-          } else if (elapsed < HAND_DURATION + PAUSE) {
-            // Pause
-            setDisplayScore(startScore + myDelta.hand);
-            requestAnimationFrame(animate);
-          } else if (elapsed < HAND_DURATION + PAUSE + STICK_DURATION) {
-            // Phase 2: Sticks
-            const stickElapsed = elapsed - (HAND_DURATION + PAUSE);
-            const progress = stickElapsed / STICK_DURATION;
-            const ease = 1 - Math.pow(1 - progress, 3);
-            const current = Math.floor(startScore + myDelta.hand + myDelta.sticks * ease);
-            setDisplayScore(current);
-            requestAnimationFrame(animate);
-          } else {
-            // End
-            setDisplayScore(player.score);
-            setIsAnimating(false);
-          }
-        };
+              if (elapsed < HAND_DURATION) {
+                const progress = elapsed / HAND_DURATION;
+                const ease = 1 - Math.pow(1 - progress, 3);
+                const current = Math.floor(startScore + myDelta.hand * ease);
+                setDisplayScore(current);
+                frameIds.push(requestAnimationFrame(animate));
+              } else if (elapsed < HAND_DURATION + PAUSE) {
+                setDisplayScore(startScore + myDelta.hand);
+                frameIds.push(requestAnimationFrame(animate));
+              } else if (elapsed < HAND_DURATION + PAUSE + STICK_DURATION) {
+                const stickElapsed = elapsed - (HAND_DURATION + PAUSE);
+                const progress = stickElapsed / STICK_DURATION;
+                const ease = 1 - Math.pow(1 - progress, 3);
+                const current = Math.floor(startScore + myDelta.hand + myDelta.sticks * ease);
+                setDisplayScore(current);
+                frameIds.push(requestAnimationFrame(animate));
+              } else {
+                setDisplayScore(player.score);
+                setIsAnimating(false);
+              }
+            };
 
-        requestAnimationFrame(animate);
+            frameIds.push(requestAnimationFrame(animate));
+          }),
+        );
 
         // Delta Switching Logic (Timed)
         const timers: ReturnType<typeof setTimeout>[] = [];
@@ -290,13 +293,18 @@ const PlayerRow = ({
           }, totalDuration),
         );
 
-        return () => timers.forEach(clearTimeout);
+        return () => {
+          timers.forEach(clearTimeout);
+          frameIds.forEach((frameId) => cancelAnimationFrame(frameId));
+        };
       } else {
         // Event exists but didn't affect me? (possible if delta 0)
         // Just snap.
-        setDisplayScore(player.score);
         prevEventIdRef.current = lastEvent.id;
         prevScoreRef.current = player.score;
+        requestAnimationFrame(() => {
+          setDisplayScore(player.score);
+        });
       }
     } else if (prevScoreRef.current !== player.score) {
       // Fallback: Score changed without a LastEvent (e.g. Undo, Riichi click, or initial load sync)
@@ -310,29 +318,44 @@ const PlayerRow = ({
       // Fallback animation (Single stage) for non-win updates
       const diff = player.score - prevScoreRef.current;
       if (diff !== 0) {
-        setDelta({ value: diff, type: 'simple' });
         const duration = 1000;
         const start = prevScoreRef.current;
-        const startTime = performance.now();
+        const frameIds: number[] = [];
 
-        const animateSimple = (now: number) => {
-          const elapsed = now - startTime;
-          const progress = Math.min(elapsed / duration, 1);
-          const ease = 1 - Math.pow(1 - progress, 3);
-          const current = Math.floor(start + diff * ease);
-          setDisplayScore(current);
-          if (progress < 1) requestAnimationFrame(animateSimple);
-          else {
-            setDelta(null);
-            setDisplayScore(player.score);
-            prevScoreRef.current = player.score;
-          }
+        frameIds.push(
+          requestAnimationFrame(() => {
+            setDelta({ value: diff, type: 'simple' });
+            const startTime = performance.now();
+
+            const animateSimple = (now: number) => {
+              const elapsed = now - startTime;
+              const progress = Math.min(elapsed / duration, 1);
+              const ease = 1 - Math.pow(1 - progress, 3);
+              const current = Math.floor(start + diff * ease);
+              setDisplayScore(current);
+              if (progress < 1) frameIds.push(requestAnimationFrame(animateSimple));
+              else {
+                setDelta(null);
+                setDisplayScore(player.score);
+                prevScoreRef.current = player.score;
+              }
+            };
+
+            frameIds.push(requestAnimationFrame(animateSimple));
+          }),
+        );
+
+        return () => {
+          frameIds.forEach((frameId) => cancelAnimationFrame(frameId));
         };
-        requestAnimationFrame(animateSimple);
       }
     } else {
       // Init or stable
-      if (!isAnimating) setDisplayScore(player.score);
+      if (!isAnimating) {
+        requestAnimationFrame(() => {
+          setDisplayScore(player.score);
+        });
+      }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [player.score, lastEvent?.id]);

--- a/src/components/features/analysis/HandInputSection.module.css
+++ b/src/components/features/analysis/HandInputSection.module.css
@@ -54,3 +54,8 @@
   padding-top: var(--spacing-s);
   border-top: 1px solid rgba(255, 255, 255, 0.08);
 }
+
+.waitsPreview {
+  display: grid;
+  gap: var(--spacing-s);
+}

--- a/src/components/features/analysis/HandInputSection.test.tsx
+++ b/src/components/features/analysis/HandInputSection.test.tsx
@@ -3,7 +3,13 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { useState } from 'react';
 import { afterEach, describe, expect, it } from 'vitest';
-import type { AnalysisEventType, Meld, TileCode, WinningTileSource } from '../../../types';
+import type {
+  AnalysisEventType,
+  AnalysisWaits,
+  Meld,
+  TileCode,
+  WinningTileSource,
+} from '../../../types';
 import { HandInputSection } from './HandInputSection';
 
 afterEach(() => {
@@ -33,6 +39,7 @@ const HandInputSectionHarness = ({
   const [winningTileSource, setWinningTileSource] = useState<WinningTileSource | undefined>(
     initialWinningTileSource,
   );
+  const [waits, setWaits] = useState<AnalysisWaits | undefined>(undefined);
 
   return (
     <>
@@ -47,10 +54,12 @@ const HandInputSectionHarness = ({
         onMeldsChange={setMelds}
         onWinningTileChange={setWinningTile}
         onWinningTileSourceChange={setWinningTileSource}
+        onWaitsChange={setWaits}
       />
       <output aria-label="concealed-state">{concealed.join(',') || 'none'}</output>
       <output aria-label="melds-state">{melds.length > 0 ? JSON.stringify(melds) : 'none'}</output>
       <output aria-label="winning-tile-state">{winningTile ?? 'none'}</output>
+      <output aria-label="waits-state">{waits ? JSON.stringify(waits) : 'none'}</output>
     </>
   );
 };
@@ -139,5 +148,33 @@ describe('HandInputSection', () => {
 
     const alert = screen.getByRole('alert');
     expect(alert.textContent).not.toBe('');
+  });
+
+  it('updates detected waits when the notation becomes tenpai', () => {
+    render(<HandInputSectionHarness eventType="win" />);
+
+    const input = screen.getByRole('textbox', { name: 'MPSZ形式で手牌を入力' });
+    fireEvent.change(input, { target: { value: 'm123456s123z22p231_' } });
+
+    expect(screen.getByText('待ち')).toBeTruthy();
+    expect(screen.getByText('1筒')).toBeTruthy();
+    expect(screen.getByText('4筒')).toBeTruthy();
+    expect(screen.getAllByText('両面')).toHaveLength(2);
+
+    const waits = JSON.parse(screen.getByLabelText('waits-state').textContent ?? '{}');
+    expect(waits.kind).toBe('auto');
+    expect(waits.tiles).toEqual([
+      { tile: '1p', categories: ['ryanmen'] },
+      { tile: '4p', categories: ['ryanmen'] },
+    ]);
+  });
+
+  it('shows a quiet unresolved message when the input cannot be analysed', () => {
+    render(<HandInputSectionHarness eventType="win" />);
+
+    const input = screen.getByRole('textbox', { name: 'MPSZ形式で手牌を入力' });
+    fireEvent.change(input, { target: { value: 'm123456s123z22p23' } });
+
+    expect(screen.getByText('待ちを自動判定できませんでした')).toBeTruthy();
   });
 });

--- a/src/components/features/analysis/HandInputSection.tsx
+++ b/src/components/features/analysis/HandInputSection.tsx
@@ -1,5 +1,11 @@
 import { useCallback } from 'react';
-import type { AnalysisEventType, Meld, TileCode, WinningTileSource } from '../../../types';
+import type {
+  AnalysisEventType,
+  AnalysisWaits,
+  Meld,
+  TileCode,
+  WinningTileSource,
+} from '../../../types';
 import { HandNotationInput } from './HandNotationInput';
 import styles from './HandInputSection.module.css';
 
@@ -8,12 +14,21 @@ interface HandInputSectionProps {
   melds: Meld[];
   winningTile?: TileCode;
   winningTileSource?: WinningTileSource;
+  waits?: AnalysisWaits;
+  storedSnapshot?: {
+    concealed: TileCode[];
+    melds: Meld[];
+    winningTile?: TileCode;
+    winningTileSource?: WinningTileSource;
+    waits?: AnalysisWaits;
+  };
   eventType: AnalysisEventType;
   readOnly: boolean;
   onConcealedChange: (tiles: TileCode[]) => void;
   onMeldsChange: (melds: Meld[]) => void;
   onWinningTileChange: (tile: TileCode | undefined) => void;
   onWinningTileSourceChange: (source: WinningTileSource | undefined) => void;
+  onWaitsChange: (waits: AnalysisWaits | undefined) => void;
 }
 
 export const HandInputSection = ({
@@ -22,11 +37,14 @@ export const HandInputSection = ({
   eventType,
   winningTile,
   winningTileSource,
+  waits,
+  storedSnapshot,
   readOnly,
   onConcealedChange,
   onMeldsChange,
   onWinningTileChange,
   onWinningTileSourceChange,
+  onWaitsChange,
 }: HandInputSectionProps) => {
   const handleParsed = useCallback(
     (result: {
@@ -67,8 +85,12 @@ export const HandInputSection = ({
         melds={melds}
         winningTile={winningTile}
         winningTileSource={winningTileSource}
+        waits={waits}
+        storedSnapshot={storedSnapshot}
+        eventType={eventType}
         readOnly={readOnly}
         onParsed={handleParsed}
+        onWaitsChange={onWaitsChange}
       />
     </section>
   );

--- a/src/components/features/analysis/HandNotationInput.module.css
+++ b/src/components/features/analysis/HandNotationInput.module.css
@@ -120,3 +120,72 @@
   font-size: var(--font-size-xs);
   line-height: 1.4;
 }
+
+.waitSection {
+  display: grid;
+  gap: var(--spacing-s);
+  padding: var(--spacing-s);
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--border-radius-m);
+}
+
+.waitHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-s);
+}
+
+.waitMeta {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-xs);
+}
+
+.waitList {
+  display: grid;
+  gap: var(--spacing-s);
+}
+
+.waitItem {
+  display: grid;
+  gap: var(--spacing-xs);
+}
+
+.waitTileRow {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-s);
+}
+
+.waitTileLabel {
+  color: var(--color-text-primary);
+  font-size: var(--font-size-s);
+}
+
+.waitBadgeRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-xs);
+}
+
+.waitBadge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px var(--spacing-xs);
+  border-radius: var(--border-radius-s);
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-xs);
+}
+
+.waitFallback {
+  display: grid;
+  gap: var(--spacing-xs);
+}
+
+.waitFallbackText,
+.waitHint {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-xs);
+}

--- a/src/components/features/analysis/HandNotationInput.tsx
+++ b/src/components/features/analysis/HandNotationInput.tsx
@@ -1,11 +1,21 @@
-import { useCallback, useState } from 'react';
-import type { Meld, ParsedHand, TileCode, WinningTileSource } from '../../../types';
+import { useMemo, useState } from 'react';
+import type {
+  AnalysisEventType,
+  AnalysisWaits,
+  Meld,
+  ParsedHand,
+  TileCode,
+  WinningTileSource,
+} from '../../../types';
+import { WAIT_CATEGORY_DEFS } from '../../../types/analysis';
 import { getTileLabel, getTileSvgPath } from '../../../utils/tiles';
 import {
   type ParseResult,
   formatHandNotation,
   parseHandNotation,
 } from '../../../utils/handNotation';
+import { detectHandWaits } from '../../../utils/waits';
+import { normalizeTileCode } from '../../../utils/tiles';
 import styles from './HandNotationInput.module.css';
 
 const FROM_LABELS: Record<string, string> = {
@@ -19,6 +29,15 @@ interface HandNotationInputProps {
   melds: Meld[];
   winningTile?: TileCode;
   winningTileSource?: WinningTileSource;
+  waits?: AnalysisWaits;
+  storedSnapshot?: {
+    concealed: TileCode[];
+    melds: Meld[];
+    winningTile?: TileCode;
+    winningTileSource?: WinningTileSource;
+    waits?: AnalysisWaits;
+  };
+  eventType: AnalysisEventType;
   readOnly: boolean;
   onParsed: (result: {
     concealed: TileCode[];
@@ -26,6 +45,7 @@ interface HandNotationInputProps {
     tsumo?: TileCode;
     ron?: { tile: TileCode; from: 'kamicha' | 'toimen' | 'shimocha' };
   }) => void;
+  onWaitsChange?: (waits: AnalysisWaits | undefined) => void;
 }
 
 const buildParsedHand = ({
@@ -77,54 +97,136 @@ const MeldGroupPreview = ({ meld }: { meld: Meld }) => (
   </span>
 );
 
+const buildWaitDetectionResult = (
+  parsedHand: ParsedHand,
+  eventType: AnalysisEventType,
+): AnalysisWaits | undefined => {
+  return detectHandWaits({
+    eventType,
+    hand: {
+      concealed: parsedHand.concealed,
+      melds: parsedHand.melds,
+      ...(parsedHand.tsumo
+        ? { winningTile: parsedHand.tsumo }
+        : parsedHand.ron
+          ? { winningTile: parsedHand.ron.tile }
+          : {}),
+    },
+  });
+};
+
+const buildParsedHandSignature = (parsedHand: ParsedHand | null) => {
+  if (!parsedHand) {
+    return null;
+  }
+
+  return JSON.stringify({
+    concealed: [...parsedHand.concealed].map(normalizeTileCode).sort(),
+    melds: parsedHand.melds
+      .map((meld) => {
+        const from = 'from' in meld ? (meld.from ?? '') : '';
+        const tiles = [...meld.tiles].map(normalizeTileCode).sort().join(',');
+
+        return `${meld.kind}:${from}:${tiles}`;
+      })
+      .sort(),
+    winningTile: parsedHand.tsumo
+      ? normalizeTileCode(parsedHand.tsumo)
+      : parsedHand.ron
+        ? normalizeTileCode(parsedHand.ron.tile)
+        : undefined,
+  });
+};
+
 export const HandNotationInput = ({
   concealed,
   melds,
   winningTile,
   winningTileSource,
+  waits,
+  storedSnapshot,
+  eventType,
   readOnly,
   onParsed,
+  onWaitsChange,
 }: HandNotationInputProps) => {
   const initialHand = buildParsedHand({ concealed, melds, winningTile, winningTileSource });
+  const storedHand = buildParsedHand({
+    concealed: storedSnapshot?.concealed ?? concealed,
+    melds: storedSnapshot?.melds ?? melds,
+    winningTile: storedSnapshot?.winningTile,
+    winningTileSource: storedSnapshot?.winningTileSource,
+  });
 
   const [notation, setNotation] = useState(() => {
     if (!initialHand) return '';
     return formatHandNotation(initialHand);
   });
   const [parseError, setParseError] = useState<string | null>(null);
+  const [hasUserEditedNotation, setHasUserEditedNotation] = useState(false);
   const [parsed, setParsed] = useState<ParseResult | null>(() => {
     if (!initialHand) return null;
     return { success: true, hand: initialHand };
   });
+  const detectedWaits = useMemo(() => {
+    if (!parsed || !parsed.success) {
+      return undefined;
+    }
 
-  const handleChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      const value = e.target.value;
-      setNotation(value);
+    return buildWaitDetectionResult(parsed.hand, eventType);
+  }, [eventType, parsed]);
 
-      if (value.trim() === '') {
-        setParseError(null);
-        setParsed(null);
-        onParsed({ concealed: [], melds: [] });
-        return;
-      }
+  const storedHandSignature = useMemo(() => buildParsedHandSignature(storedHand), [storedHand]);
+  const parsedHandSignature = useMemo(() => {
+    if (!parsed || !parsed.success) {
+      return null;
+    }
 
-      const result = parseHandNotation(value);
-      setParsed(result);
-      if (result.success) {
-        setParseError(null);
-        onParsed({
-          concealed: result.hand.concealed,
-          melds: result.hand.melds,
-          tsumo: result.hand.tsumo,
-          ron: result.hand.ron,
-        });
-      } else {
-        setParseError(result.error.message);
-      }
-    },
-    [onParsed],
-  );
+    return buildParsedHandSignature(parsed.hand);
+  }, [parsed]);
+  const matchesInitialHand =
+    storedHandSignature !== null &&
+    parsedHandSignature !== null &&
+    storedHandSignature === parsedHandSignature;
+
+  const displayedWaits =
+    hasUserEditedNotation && !matchesInitialHand
+      ? detectedWaits
+      : (storedSnapshot?.waits ?? waits ?? detectedWaits);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setNotation(value);
+    setHasUserEditedNotation(true);
+
+    if (value.trim() === '') {
+      setParseError(null);
+      setParsed(null);
+      onParsed({ concealed: [], melds: [] });
+      onWaitsChange?.(undefined);
+      return;
+    }
+
+    const result = parseHandNotation(value);
+    setParsed(result);
+    if (result.success) {
+      setParseError(null);
+      const nextWaits =
+        storedSnapshot?.waits && buildParsedHandSignature(result.hand) === storedHandSignature
+          ? storedSnapshot.waits
+          : buildWaitDetectionResult(result.hand, eventType);
+      onWaitsChange?.(nextWaits);
+      onParsed({
+        concealed: result.hand.concealed,
+        melds: result.hand.melds,
+        tsumo: result.hand.tsumo,
+        ron: result.hand.ron,
+      });
+    } else {
+      setParseError(result.error.message);
+      onWaitsChange?.(undefined);
+    }
+  };
 
   const inputClassName = [styles.notationInput, parseError ? styles.notationInputError : '']
     .filter(Boolean)
@@ -194,6 +296,59 @@ export const HandNotationInput = ({
           </div>
         )}
       </div>
+
+      {parsed &&
+      parsed.success &&
+      displayedWaits &&
+      (displayedWaits.tiles.length > 0 || displayedWaits.categories.length > 0) ? (
+        <div className={styles.waitSection}>
+          <div className={styles.waitHeader}>
+            <span className={styles.previewLabel}>待ち</span>
+            <span className={styles.waitMeta}>
+              {displayedWaits.kind === 'auto'
+                ? '自動判定'
+                : displayedWaits.kind === 'legacy'
+                  ? '保存済み'
+                  : '未解決'}
+            </span>
+          </div>
+          {displayedWaits.tiles.length > 0 ? (
+            <div className={styles.waitList}>
+              {displayedWaits.tiles.map((waitTile) => (
+                <div key={waitTile.tile} className={styles.waitItem}>
+                  <div className={styles.waitTileRow}>
+                    <TileSvg code={waitTile.tile} />
+                    <span className={styles.waitTileLabel}>{getTileLabel(waitTile.tile)}</span>
+                  </div>
+                  <div className={styles.waitBadgeRow}>
+                    {waitTile.categories.map((category) => (
+                      <span key={`${waitTile.tile}-${category}`} className={styles.waitBadge}>
+                        {WAIT_CATEGORY_DEFS[category].label}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className={styles.waitFallback}>
+              <span className={styles.waitFallbackText}>待ち牌情報なし</span>
+              <div className={styles.waitBadgeRow}>
+                {displayedWaits.categories.map((category) => (
+                  <span key={`legacy-${category}`} className={styles.waitBadge}>
+                    {WAIT_CATEGORY_DEFS[category].label}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      ) : null}
+
+      {notation.trim() !== '' &&
+      (!parsed || !parsed.success || displayedWaits?.kind === 'unresolved') ? (
+        <p className={styles.waitHint}>待ちを自動判定できませんでした</p>
+      ) : null}
 
       <p className={styles.helpText}>
         MPSZ形式: m=萬子, p=筒子, s=索子, z=字牌(1東2南3西4北5白6發7中)。

--- a/src/hooks/useAnalysisEntry.test.ts
+++ b/src/hooks/useAnalysisEntry.test.ts
@@ -328,4 +328,46 @@ describe('useAnalysisEntry', () => {
     expect(result.current.draftAnalysisEntry).toBeNull();
     expect(result.current.hasDraftChanges).toBe(false);
   });
+
+  it('reloads before exposing cached entry when the same uid signs in again', async () => {
+    const firstEntry = createAnalysisEntry('entry-1');
+    const refreshedEntry = createAnalysisEntry('entry-1');
+    refreshedEntry.notes = 'reloaded';
+
+    let secondResolve: ((entry: typeof refreshedEntry | null) => void) | undefined;
+    mocks.mockGetAnalysisEntry.mockResolvedValueOnce(firstEntry).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          secondResolve = resolve;
+        }),
+    );
+
+    const { result } = renderHook(() => useAnalysisEntry({ entryId: 'entry-1' }));
+
+    await waitFor(() => {
+      expect(result.current.analysisEntry).toEqual(firstEntry);
+    });
+
+    act(() => {
+      authStateCallback?.(null);
+    });
+
+    await waitFor(() => {
+      expect(result.current.uid).toBeNull();
+    });
+
+    act(() => {
+      authStateCallback?.({ uid: 'user-1' });
+    });
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.analysisEntry).toBeNull();
+    expect(result.current.draftAnalysisEntry).toBeNull();
+
+    secondResolve?.(refreshedEntry);
+
+    await waitFor(() => {
+      expect(result.current.analysisEntry).toEqual(refreshedEntry);
+    });
+  });
 });

--- a/src/hooks/useAnalysisEntry.ts
+++ b/src/hooks/useAnalysisEntry.ts
@@ -83,71 +83,63 @@ export const useAnalysisEntry = ({
   source,
 }: UseAnalysisEntryOptions): UseAnalysisEntryResult => {
   const sourceKey = getSourceKey(source);
+  const targetKey = entryId ?? sourceKey;
   const stableSource = useMemo(() => getSourceFromKey(sourceKey), [sourceKey]);
   const [uid, setUid] = useState<string | null>(auth.currentUser?.uid ?? null);
+  const [authReady, setAuthReady] = useState(false);
+  const [authGeneration, setAuthGeneration] = useState(0);
   const [analysisEntry, setAnalysisEntry] = useState<AnalysisEntry | null>(null);
   const [draftAnalysisEntry, setDraftAnalysisEntry] = useState<AnalysisEntry | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [loadedTargetKey, setLoadedTargetKey] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
 
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, (user) => {
-      setAnalysisEntry(null);
-      setDraftAnalysisEntry(null);
       setUid(user?.uid ?? null);
-
-      if (!user) {
-        setLoading(false);
-        return;
-      }
-
-      setLoading(true);
+      setAuthGeneration((current) => current + 1);
+      setAuthReady(true);
     });
 
     return () => unsubscribe();
   }, []);
 
-  useEffect(() => {
-    if (!uid) {
-      setAnalysisEntry(null);
-      setDraftAnalysisEntry(null);
-      setLoading(false);
-      return;
-    }
+  const activeTargetKey =
+    authReady && uid && targetKey ? `${authGeneration}:${uid}:${targetKey}` : null;
+  const loading = !authReady
+    ? Boolean(targetKey)
+    : activeTargetKey !== null && loadedTargetKey !== activeTargetKey;
+  const resolvedAnalysisEntry = activeTargetKey === null || loading ? null : analysisEntry;
+  const resolvedDraftAnalysisEntry =
+    activeTargetKey === null || loading ? null : (draftAnalysisEntry ?? resolvedAnalysisEntry);
 
-    if (!entryId && !stableSource) {
-      setAnalysisEntry(null);
-      setDraftAnalysisEntry(null);
-      setLoading(false);
+  useEffect(() => {
+    if (!uid || !activeTargetKey) {
       return;
     }
 
     let isCancelled = false;
-    setAnalysisEntry(null);
-    setDraftAnalysisEntry(null);
-    setLoading(true);
 
     void loadAnalysisEntry(uid, entryId, stableSource)
       .then((entry) => {
         if (!isCancelled) {
           setAnalysisEntry(entry);
           setDraftAnalysisEntry(null);
-          setLoading(false);
+          setLoadedTargetKey(activeTargetKey);
         }
       })
       .catch(() => {
         if (!isCancelled) {
           setAnalysisEntry(null);
           setDraftAnalysisEntry(null);
-          setLoading(false);
+          setLoadedTargetKey(activeTargetKey);
         }
       });
 
     return () => {
       isCancelled = true;
     };
-  }, [entryId, stableSource, uid]);
+  }, [activeTargetKey, entryId, stableSource, uid]);
 
   const saveAnalysisEntry = async (entry: AnalysisEntry) => {
     if (!uid) {
@@ -163,6 +155,7 @@ export const useAnalysisEntry = ({
         uid,
       });
       setDraftAnalysisEntry(null);
+      setLoadedTargetKey(activeTargetKey);
     } finally {
       setSaving(false);
     }
@@ -184,6 +177,7 @@ export const useAnalysisEntry = ({
       await removeAnalysisEntry(uid, targetEntryId);
       setAnalysisEntry(null);
       setDraftAnalysisEntry(null);
+      setLoadedTargetKey(activeTargetKey);
     } finally {
       setDeleting(false);
     }
@@ -191,12 +185,12 @@ export const useAnalysisEntry = ({
 
   return {
     uid,
-    analysisEntry,
+    analysisEntry: resolvedAnalysisEntry,
     loading,
     saving,
     deleting,
-    draftAnalysisEntry: draftAnalysisEntry ?? analysisEntry,
-    hasDraftChanges: draftAnalysisEntry !== null,
+    draftAnalysisEntry: resolvedDraftAnalysisEntry,
+    hasDraftChanges: resolvedDraftAnalysisEntry !== null && draftAnalysisEntry !== null,
     setDraftAnalysisEntry,
     resetDraftAnalysisEntry: () => setDraftAnalysisEntry(null),
     saveAnalysisEntry,

--- a/src/hooks/useUserSettings.test.ts
+++ b/src/hooks/useUserSettings.test.ts
@@ -79,12 +79,15 @@ vi.mock('../services/userSettingsService', () => ({
 }));
 
 describe('useUserSettings', () => {
+  let authStateCallback: ((user: { uid: string } | null) => void) | null = null;
+
   beforeEach(() => {
     localStorage.clear();
     mockSaveUserSettings.mockReset();
     mockSubscribeToUserSettings.mockReset();
     mockOnAuthStateChanged.mockReset();
     mockOnAuthStateChanged.mockImplementation((_auth, callback) => {
+      authStateCallback = callback;
       callback({ uid: 'user-1' });
       return vi.fn();
     });
@@ -154,5 +157,55 @@ describe('useUserSettings', () => {
 
     expect(mockSaveUserSettings).toHaveBeenCalledWith('user-1', nextSettings);
     expect(localStorage.getItem('mahjong_player_name')).toBe('更新後表示名');
+  });
+
+  it('reloads settings before showing data when the same uid signs in again', async () => {
+    const firstSettings = createUserSettings({
+      displayName: '初回設定',
+    });
+    const refreshedSettings = createUserSettings({
+      displayName: '再ログイン後設定',
+    });
+
+    let latestListener: ((settings: UserSettings | null) => void) | null = null;
+    mockSubscribeToUserSettings.mockImplementation((_uid, callback) => {
+      latestListener = callback;
+      callback(firstSettings);
+      return vi.fn();
+    });
+
+    const { result } = renderHook(() => useUserSettings());
+
+    await waitFor(() => {
+      expect(result.current.userSettings.displayName).toBe('初回設定');
+    });
+
+    act(() => {
+      authStateCallback?.(null);
+    });
+
+    await waitFor(() => {
+      expect(result.current.uid).toBeNull();
+    });
+
+    mockSubscribeToUserSettings.mockImplementationOnce((_uid, callback) => {
+      latestListener = callback;
+      return vi.fn();
+    });
+
+    act(() => {
+      authStateCallback?.({ uid: 'user-1' });
+    });
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.userSettings.displayName).toBe('初回設定');
+
+    act(() => {
+      latestListener?.(refreshedSettings);
+    });
+
+    await waitFor(() => {
+      expect(result.current.userSettings.displayName).toBe('再ログイン後設定');
+    });
   });
 });

--- a/src/hooks/useUserSettings.ts
+++ b/src/hooks/useUserSettings.ts
@@ -14,6 +14,7 @@ import {
 
 interface UseUserSettingsResult {
   uid: string | null;
+  sessionKey: string | null;
   userSettings: UserSettings;
   loading: boolean;
   saving: boolean;
@@ -22,34 +23,42 @@ interface UseUserSettingsResult {
 }
 
 export const useUserSettings = (): UseUserSettingsResult => {
+  const defaultSettings = createDefaultUserSettings();
   const [uid, setUid] = useState<string | null>(auth.currentUser?.uid ?? null);
-  const [userSettings, setUserSettings] = useState<UserSettings>(() => createDefaultUserSettings());
-  const [loading, setLoading] = useState(true);
+  const [authReady, setAuthReady] = useState(false);
+  const [authGeneration, setAuthGeneration] = useState(0);
+  const [userSettings, setUserSettings] = useState<UserSettings>(() => defaultSettings);
+  const [loadedSettingsKey, setLoadedSettingsKey] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
 
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, (user) => {
       setUid(user?.uid ?? null);
+      setAuthGeneration((current) => current + 1);
+      setAuthReady(true);
     });
 
     return () => unsubscribe();
   }, []);
 
+  const activeSettingsKey = authReady && uid ? `${authGeneration}:${uid}` : null;
+
   useEffect(() => {
-    if (!uid) {
-      setUserSettings(createDefaultUserSettings());
-      setLoading(false);
+    if (!uid || !activeSettingsKey) {
       return;
     }
 
-    setLoading(true);
     const unsubscribe = subscribeToUserSettings(uid, (nextSettings) => {
       setUserSettings(normalizeUserSettings(nextSettings));
-      setLoading(false);
+      setLoadedSettingsKey(activeSettingsKey);
     });
 
     return () => unsubscribe();
-  }, [uid]);
+  }, [activeSettingsKey, uid]);
+
+  const loading =
+    !authReady || (activeSettingsKey !== null && loadedSettingsKey !== activeSettingsKey);
+  const resolvedUserSettings = uid === null ? defaultSettings : userSettings;
 
   const saveUserSettings = async (settings: UserSettings) => {
     if (!uid) {
@@ -63,6 +72,7 @@ export const useUserSettings = (): UseUserSettingsResult => {
       await persistUserSettings(uid, normalizedSettings);
       writeStoredPlayerName(normalizedSettings.displayName);
       setUserSettings(normalizedSettings);
+      setLoadedSettingsKey(activeSettingsKey);
     } finally {
       setSaving(false);
     }
@@ -70,7 +80,8 @@ export const useUserSettings = (): UseUserSettingsResult => {
 
   return {
     uid,
-    userSettings,
+    sessionKey: activeSettingsKey,
+    userSettings: resolvedUserSettings,
     loading,
     saving,
     setUserSettings,

--- a/src/pages/CompetitionNewPage.tsx
+++ b/src/pages/CompetitionNewPage.tsx
@@ -13,7 +13,7 @@ import { writeStoredPlayerName } from '../utils/userSettings';
 export const CompetitionNewPage = () => {
   const navigate = useNavigate();
   const { showSnackbar } = useSnackbar();
-  const { userSettings } = useUserSettings();
+  const { userSettings, loading: userSettingsLoading } = useUserSettings();
   const [loading, setLoading] = useState(false);
   const initialOrganizerDisplayName = userSettings.displayName || '主催者名';
 
@@ -100,7 +100,7 @@ export const CompetitionNewPage = () => {
         onSubmit={handleSubmit}
         organizerDisplayName={initialOrganizerDisplayName}
         initialSettings={userSettings.defaultCompetitionSettings}
-        loading={loading}
+        loading={loading || userSettingsLoading}
       />
     </div>
   );

--- a/src/pages/TopPage.tsx
+++ b/src/pages/TopPage.tsx
@@ -16,7 +16,7 @@ import styles from './TopPage.module.css';
 export const TopPage = () => {
   const navigate = useNavigate();
   const { showSnackbar } = useSnackbar();
-  const { userSettings } = useUserSettings();
+  const { userSettings, loading: userSettingsLoading } = useUserSettings();
   const [roomIdInput, setRoomIdInput] = useState('');
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isAuthModalOpen, setIsAuthModalOpen] = useState(false);
@@ -141,7 +141,7 @@ export const TopPage = () => {
       <div className={styles.mainActions}>
         <Button
           onClick={() => setIsModalOpen(true)}
-          disabled={loading}
+          disabled={loading || userSettingsLoading}
           className={styles.mainActionButton}
         >
           部屋作成
@@ -201,7 +201,7 @@ export const TopPage = () => {
           isOpen={isModalOpen}
           onClose={() => setIsModalOpen(false)}
           onCreate={handleCreateRoom}
-          loading={loading}
+          loading={loading || userSettingsLoading}
           initialHostName={userSettings.displayName}
           initialSettings={userSettings.defaultRoomSettings}
         />

--- a/src/pages/UserSettingsPage.tsx
+++ b/src/pages/UserSettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { CompetitionRuleSettings } from '../components/features/CompetitionRuleSettings';
 import { RoomRuleSettings } from '../components/features/RoomRuleSettings';
@@ -7,19 +7,18 @@ import { Input } from '../components/ui/Input';
 import { useSnackbar } from '../contexts/SnackbarContext';
 import { useUserSettings } from '../hooks/useUserSettings';
 import type { UserSettings } from '../types';
-import { AVATAR_PRESET_OPTIONS, createDefaultUserSettings } from '../utils/userSettings';
+import { AVATAR_PRESET_OPTIONS } from '../utils/userSettings';
 import styles from './UserSettingsPage.module.css';
 
 export const UserSettingsPage = () => {
   const { showSnackbar } = useSnackbar();
-  const { userSettings, loading, saving, saveUserSettings } = useUserSettings();
-  const [draftSettings, setDraftSettings] = useState<UserSettings>(() =>
-    createDefaultUserSettings(),
-  );
-
-  useEffect(() => {
-    setDraftSettings(userSettings);
-  }, [userSettings]);
+  const { userSettings, loading, saving, saveUserSettings, sessionKey } = useUserSettings();
+  const [draftOverride, setDraftOverride] = useState<{
+    sessionKey: string | null;
+    value: UserSettings;
+  } | null>(null);
+  const draftSettings =
+    draftOverride && draftOverride.sessionKey === sessionKey ? draftOverride.value : userSettings;
 
   const handleSave = async () => {
     const normalizedDisplayName = draftSettings.displayName.trim();
@@ -33,6 +32,7 @@ export const UserSettingsPage = () => {
         ...draftSettings,
         displayName: normalizedDisplayName,
       });
+      setDraftOverride(null);
       showSnackbar('設定を保存しました');
     } catch {
       showSnackbar('設定の保存に失敗しました', { position: 'top' });
@@ -60,9 +60,12 @@ export const UserSettingsPage = () => {
             aria-label="表示名"
             value={draftSettings.displayName}
             onChange={(event) =>
-              setDraftSettings((current) => ({
-                ...current,
-                displayName: event.target.value,
+              setDraftOverride((current) => ({
+                sessionKey,
+                value: {
+                  ...(current && current.sessionKey === sessionKey ? current.value : draftSettings),
+                  displayName: event.target.value,
+                },
               }))
             }
             placeholder="表示名を入力"
@@ -80,9 +83,14 @@ export const UserSettingsPage = () => {
                 type="button"
                 variant={draftSettings.avatarPresetId === avatarOption.id ? 'primary' : 'secondary'}
                 onClick={() =>
-                  setDraftSettings((current) => ({
-                    ...current,
-                    avatarPresetId: avatarOption.id,
+                  setDraftOverride((current) => ({
+                    sessionKey,
+                    value: {
+                      ...(current && current.sessionKey === sessionKey
+                        ? current.value
+                        : draftSettings),
+                      avatarPresetId: avatarOption.id,
+                    },
                   }))
                 }
                 disabled={loading || saving}
@@ -102,9 +110,12 @@ export const UserSettingsPage = () => {
         <RoomRuleSettings
           settings={draftSettings.defaultRoomSettings}
           onChange={(nextSettings) =>
-            setDraftSettings((current) => ({
-              ...current,
-              defaultRoomSettings: nextSettings,
+            setDraftOverride((current) => ({
+              sessionKey,
+              value: {
+                ...(current && current.sessionKey === sessionKey ? current.value : draftSettings),
+                defaultRoomSettings: nextSettings,
+              },
             }))
           }
           disabled={loading || saving}
@@ -116,9 +127,12 @@ export const UserSettingsPage = () => {
         <CompetitionRuleSettings
           settings={draftSettings.defaultCompetitionSettings}
           onChange={(nextSettings) =>
-            setDraftSettings((current) => ({
-              ...current,
-              defaultCompetitionSettings: nextSettings,
+            setDraftOverride((current) => ({
+              sessionKey,
+              value: {
+                ...(current && current.sessionKey === sessionKey ? current.value : draftSettings),
+                defaultCompetitionSettings: nextSettings,
+              },
             }))
           }
           disabled={loading || saving}

--- a/src/services/analysisService.test.ts
+++ b/src/services/analysisService.test.ts
@@ -67,7 +67,6 @@ const createAnalysisEntry = (overrides: Record<string, unknown> = {}) => ({
   hand: {
     concealed: [],
     melds: [],
-    wait: [],
   },
   dora: {
     doraIndicators: [],
@@ -117,7 +116,16 @@ describe('analysisService', () => {
             melds: [],
             winningTile: '4m',
             winningTileSource: 'invalid-source',
-            wait: [],
+            waits: {
+              kind: 'auto',
+              categories: ['ryanmen'],
+              tiles: [
+                {
+                  tile: '4m',
+                  categories: ['ryanmen'],
+                },
+              ],
+            },
           },
         }),
     });
@@ -141,7 +149,11 @@ describe('analysisService', () => {
         melds: [],
         winningTile: '4m',
         winningTileSource: 'tsumo',
-        wait: [],
+        waits: {
+          kind: 'auto',
+          categories: ['ryanmen'],
+          tiles: [{ tile: '4m', categories: ['ryanmen'] }],
+        },
       },
     });
 
@@ -163,6 +175,12 @@ describe('analysisService', () => {
         hand: expect.objectContaining({
           winningTile: '4m',
           winningTileSource: 'tsumo',
+          waits: {
+            kind: 'auto',
+            categories: ['ryanmen'],
+            tiles: [{ tile: '4m', categories: ['ryanmen'] }],
+          },
+          wait: 'DELETE_FIELD',
         }),
         updatedAt: 'SERVER_TIMESTAMP',
       }),
@@ -175,7 +193,6 @@ describe('analysisService', () => {
       hand: {
         concealed: ['1m', '2m', '3m'],
         melds: [],
-        wait: [],
       },
     });
 
@@ -187,6 +204,12 @@ describe('analysisService', () => {
         hand: expect.objectContaining({
           winningTile: 'DELETE_FIELD',
           winningTileSource: 'DELETE_FIELD',
+          waits: {
+            kind: 'unresolved',
+            tiles: [],
+            categories: [],
+          },
+          wait: 'DELETE_FIELD',
         }),
       }),
       { merge: true },

--- a/src/services/analysisService.ts
+++ b/src/services/analysisService.ts
@@ -104,6 +104,8 @@ export const saveAnalysisEntry = async (uid: string, entry: AnalysisEntry): Prom
         ...sanitizedEntry.hand,
         ...(normalizedEntry.hand.winningTile ? {} : { winningTile: deleteField() }),
         ...(normalizedEntry.hand.winningTileSource ? {} : { winningTileSource: deleteField() }),
+        ...(normalizedEntry.hand.waits ? {} : { waits: deleteField() }),
+        wait: deleteField(),
       },
       updatedAt: serverTimestamp(),
     },

--- a/src/types/analysis.ts
+++ b/src/types/analysis.ts
@@ -32,11 +32,25 @@ export type WaitShape =
   | 'sanmenchan'
   | 'multi-other';
 
+export type WaitCategory =
+  | 'ryanmen'
+  | 'sanmen'
+  | 'penchan'
+  | 'kanchan'
+  | 'shabo'
+  | 'tanki'
+  | 'nobetan'
+  | 'irregular';
+
 export type AnalysisEventType = 'win' | 'deal-in' | 'tenpai-draw';
 
 export type SpecialEnd = 'haitei' | 'houtei' | 'rinshan' | 'chankan';
 
 export interface WaitShapeDefinition {
+  label: string;
+}
+
+export interface WaitCategoryDefinition {
   label: string;
 }
 
@@ -51,7 +65,30 @@ export const WAIT_SHAPE_DEFS = {
   'multi-other': { label: '多面張その他' },
 } as const satisfies Record<WaitShape, WaitShapeDefinition>;
 
+export const WAIT_CATEGORY_DEFS = {
+  ryanmen: { label: '両面' },
+  sanmen: { label: '三面' },
+  penchan: { label: '辺張' },
+  kanchan: { label: '嵌張' },
+  shabo: { label: 'シャボ' },
+  tanki: { label: '単騎' },
+  nobetan: { label: '延べ単騎' },
+  irregular: { label: '変則' },
+} as const satisfies Record<WaitCategory, WaitCategoryDefinition>;
+
 export const WAIT_SHAPES = Object.keys(WAIT_SHAPE_DEFS) as WaitShape[];
+export const WAIT_CATEGORIES = Object.keys(WAIT_CATEGORY_DEFS) as WaitCategory[];
+
+export const LEGACY_WAIT_CATEGORY_ALIASES = {
+  ryanmen: 'ryanmen',
+  penchan: 'penchan',
+  kanchan: 'kanchan',
+  shanpon: 'shabo',
+  tanki: 'tanki',
+  nobetan: 'nobetan',
+  sanmenchan: 'sanmen',
+  'multi-other': 'irregular',
+} as const satisfies Record<WaitShape, WaitCategory>;
 
 export type YakuGroup = '1han' | '2han' | '3han' | '6han';
 
@@ -155,6 +192,18 @@ export interface AnalysisHand {
   winningTile?: TileCode;
   winningTileSource?: WinningTileSource;
   wait?: WaitShape[];
+  waits?: AnalysisWaits;
+}
+
+export interface AnalysisWaitTile {
+  tile: TileCode;
+  categories: WaitCategory[];
+}
+
+export interface AnalysisWaits {
+  kind: 'auto' | 'legacy' | 'unresolved';
+  tiles: AnalysisWaitTile[];
+  categories: WaitCategory[];
 }
 
 export interface AnalysisDora {

--- a/src/utils/analysis.test.ts
+++ b/src/utils/analysis.test.ts
@@ -119,7 +119,6 @@ describe('createAnalysisEntrySeed', () => {
       hand: {
         concealed: [],
         melds: [],
-        wait: [],
       },
       dora: {
         doraIndicators: [],
@@ -275,7 +274,11 @@ describe('normalizeAnalysisEntry', () => {
         concealed: ['1m', '1m'],
         melds: [],
         winningTile: '5m',
-        wait: ['kanchan', 'kanchan', 'ryanmen'],
+        waits: {
+          kind: 'auto',
+          categories: ['kanchan', 'ryanmen'],
+          tiles: [{ tile: '3m', categories: ['kanchan', 'ryanmen', 'ryanmen'] as never[] }],
+        },
       },
       dora: {
         doraIndicators: ['1p', '1p'],
@@ -299,7 +302,11 @@ describe('normalizeAnalysisEntry', () => {
     expect(normalized.hand).toEqual({
       concealed: ['1m', '1m'],
       melds: [],
-      wait: ['kanchan', 'ryanmen'],
+      waits: {
+        kind: 'auto',
+        categories: ['kanchan', 'ryanmen'],
+        tiles: [{ tile: '3m', categories: ['kanchan', 'ryanmen'] }],
+      },
     });
     expect(normalized.dora.redFiveCount).toBe(0);
     expect(normalized.dora.doraIndicators).toEqual(['1p', '1p']);
@@ -391,7 +398,7 @@ describe('normalizeAnalysisEntry', () => {
     expect(normalized.hand.melds).toEqual([{ kind: 'ankan', tiles: ['1z', '1z', '1z', '1z'] }]);
   });
 
-  it('defaults undefined wait to empty array', () => {
+  it('maps legacy wait categories into the new waits format', () => {
     const seed = createAnalysisEntrySeed({
       uid: 'user-1',
       handLog: createWinHandLog(),
@@ -405,11 +412,47 @@ describe('normalizeAnalysisEntry', () => {
       ...seed,
       hand: {
         ...seed.hand,
-        wait: undefined,
+        wait: ['shanpon', 'sanmenchan', 'multi-other'],
       } as unknown as typeof seed.hand,
     });
 
-    expect(normalized.hand.wait).toEqual([]);
+    expect(normalized.hand.waits).toEqual({
+      kind: 'legacy',
+      tiles: [],
+      categories: ['shabo', 'sanmen', 'irregular'],
+    });
+  });
+
+  it('derives waits automatically from the stored hand when no wait data exists', () => {
+    const seed = createAnalysisEntrySeed({
+      uid: 'user-1',
+      handLog: createDrawHandLog(),
+      playerId: 'p1',
+      players,
+      source: {
+        kind: 'room',
+        roomId: 'room-1',
+        handLogId: 'hand-2',
+      },
+      now: 1710000055500,
+    });
+
+    const normalized = normalizeAnalysisEntry({
+      ...seed,
+      hand: {
+        concealed: ['1m', '2m', '3m', '4m', '5m', '6m', '1s', '2s', '3s', '2z', '2z', '2p', '3p'],
+        melds: [],
+      },
+    });
+
+    expect(normalized.hand.waits).toEqual({
+      kind: 'auto',
+      categories: ['ryanmen'],
+      tiles: [
+        { tile: '1p', categories: ['ryanmen'] },
+        { tile: '4p', categories: ['ryanmen'] },
+      ],
+    });
   });
 
   it('defaults undefined redFiveCount to 0', () => {

--- a/src/utils/analysis.ts
+++ b/src/utils/analysis.ts
@@ -2,16 +2,26 @@ import type { HandLog, Player } from '../types';
 import type {
   AnalysisEntry,
   AnalysisEventType,
+  AnalysisWaitTile,
+  AnalysisWaits,
   AnalysisSource,
   Meld,
   RelativePosition,
   TileCode,
+  WaitCategory,
   WaitShape,
   WinningTileSource,
   YakumanId,
   YakuId,
 } from '../types/analysis';
-import { WAIT_SHAPE_DEFS, YAKUMAN_DEFS, YAKU_DEFS } from '../types/analysis';
+import {
+  LEGACY_WAIT_CATEGORY_ALIASES,
+  WAIT_CATEGORIES,
+  WAIT_SHAPE_DEFS,
+  YAKUMAN_DEFS,
+  YAKU_DEFS,
+} from '../types/analysis';
+import { detectHandWaits } from './waits';
 import { normalizeTileCode } from './tiles';
 
 const TILE_CODE_PATTERN = /^(?:[1-9][mps]|[1-7]z|0[mps])$/;
@@ -50,6 +60,10 @@ const isWaitShape = (value: unknown): value is WaitShape => {
   return typeof value === 'string' && value in WAIT_SHAPE_DEFS;
 };
 
+const isWaitCategory = (value: unknown): value is WaitCategory => {
+  return typeof value === 'string' && WAIT_CATEGORIES.includes(value as WaitCategory);
+};
+
 const isYakuId = (value: unknown): value is YakuId => {
   return typeof value === 'string' && value in YAKU_DEFS;
 };
@@ -64,6 +78,64 @@ const unique = <T>(values: T[]): T[] => {
 
 const normalizeTileCodes = (tiles: TileCode[] | undefined): TileCode[] => {
   return (tiles ?? []).filter(isTileCode);
+};
+
+const normalizeWaitCategories = (categories: unknown[] | undefined): WaitCategory[] => {
+  return unique((categories ?? []).filter(isWaitCategory));
+};
+
+const normalizeWaitTiles = (tiles: AnalysisWaitTile[] | undefined): AnalysisWaitTile[] => {
+  return (tiles ?? [])
+    .map((tileEntry) => {
+      if (!tileEntry || !isTileCode(tileEntry.tile)) {
+        return null;
+      }
+
+      const categories = normalizeWaitCategories(tileEntry.categories);
+      if (categories.length === 0) {
+        return null;
+      }
+
+      return {
+        tile: normalizeTileCode(tileEntry.tile),
+        categories,
+      };
+    })
+    .filter((tileEntry): tileEntry is AnalysisWaitTile => tileEntry !== null);
+};
+
+const normalizeStoredWaits = (waits: AnalysisWaits | undefined): AnalysisWaits | undefined => {
+  if (!waits) {
+    return undefined;
+  }
+
+  if (waits.kind === 'unresolved') {
+    return { kind: 'unresolved', tiles: [], categories: [] };
+  }
+
+  const tiles = normalizeWaitTiles(waits.tiles);
+  const categories = unique([
+    ...normalizeWaitCategories(waits.categories),
+    ...tiles.flatMap((tile) => tile.categories),
+  ]);
+
+  if (tiles.length === 0 && categories.length === 0) {
+    return undefined;
+  }
+
+  return {
+    kind: waits.kind,
+    tiles,
+    categories,
+  };
+};
+
+const normalizeLegacyWaits = (wait: WaitShape[] | undefined): WaitCategory[] => {
+  return unique(
+    (wait ?? []).filter(isWaitShape).map((shape) => {
+      return LEGACY_WAIT_CATEGORY_ALIASES[shape];
+    }),
+  );
 };
 
 const areSameTileKinds = (tiles: TileCode[]): boolean => {
@@ -246,7 +318,6 @@ export const createAnalysisEntrySeed = ({
     hand: {
       concealed: [],
       melds: [],
-      wait: [],
     },
     dora: {
       doraIndicators: [],
@@ -270,7 +341,6 @@ export const createAnalysisEntrySeed = ({
 };
 
 export const normalizeAnalysisEntry = (entry: AnalysisEntry): AnalysisEntry => {
-  const normalizedWait = unique((entry.hand.wait ?? []).filter(isWaitShape));
   const normalizedYakuList = unique((entry.yaku.list ?? []).filter(isYakuId));
   const normalizedYakumanList = unique((entry.yaku.yakuman ?? []).filter(isYakumanId));
   const normalizedWinningTile =
@@ -281,6 +351,28 @@ export const normalizeAnalysisEntry = (entry: AnalysisEntry): AnalysisEntry => {
     normalizedWinningTile && isWinningTileSource(entry.hand.winningTileSource)
       ? entry.hand.winningTileSource
       : undefined;
+  const normalizedConcealed = normalizeTileCodes(entry.hand.concealed);
+  const normalizedMelds = (entry.hand.melds ?? [])
+    .map(normalizeMeld)
+    .filter((meld): meld is Meld => meld !== null);
+  const normalizedWaits = normalizeStoredWaits(entry.hand.waits);
+  const legacyWaitCategories = normalizeLegacyWaits(entry.hand.wait);
+  const resolvedWaits =
+    normalizedWaits ??
+    (legacyWaitCategories.length > 0
+      ? {
+          kind: 'legacy',
+          tiles: [],
+          categories: legacyWaitCategories,
+        }
+      : detectHandWaits({
+          eventType: entry.context.eventType,
+          hand: {
+            concealed: normalizedConcealed,
+            melds: normalizedMelds,
+            ...(normalizedWinningTile ? { winningTile: normalizedWinningTile } : {}),
+          },
+        }));
 
   return {
     ...entry,
@@ -298,13 +390,11 @@ export const normalizeAnalysisEntry = (entry: AnalysisEntry): AnalysisEntry => {
       isDealer: entry.context.seatWind === 'East' ? true : entry.context.isDealer,
     },
     hand: {
-      concealed: normalizeTileCodes(entry.hand.concealed),
-      melds: (entry.hand.melds ?? [])
-        .map(normalizeMeld)
-        .filter((meld): meld is Meld => meld !== null),
+      concealed: normalizedConcealed,
+      melds: normalizedMelds,
       ...(normalizedWinningTile ? { winningTile: normalizedWinningTile } : {}),
       ...(normalizedWinningTileSource ? { winningTileSource: normalizedWinningTileSource } : {}),
-      wait: normalizedWait,
+      ...(resolvedWaits ? { waits: resolvedWaits } : {}),
     },
     dora: {
       doraIndicators: normalizeTileCodes(entry.dora.doraIndicators),

--- a/src/utils/waits.test.ts
+++ b/src/utils/waits.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+import type { AnalysisEventType, TileCode } from '../types/analysis';
+import { parseHandNotation } from './handNotation';
+import { detectHandWaits } from './waits';
+
+const detectFromNotation = (eventType: AnalysisEventType, notation: string) => {
+  const result = parseHandNotation(notation);
+  if (!result.success) {
+    throw new Error(result.error.message);
+  }
+
+  return detectHandWaits({
+    eventType,
+    hand: {
+      concealed: result.hand.concealed,
+      melds: result.hand.melds,
+      ...(result.hand.tsumo
+        ? { winningTile: result.hand.tsumo }
+        : result.hand.ron
+          ? { winningTile: result.hand.ron.tile }
+          : {}),
+    },
+  });
+};
+
+const toWaitMap = (waits: ReturnType<typeof detectHandWaits>) => {
+  return Object.fromEntries(
+    (waits?.tiles ?? []).map((waitTile) => {
+      return [waitTile.tile, waitTile.categories];
+    }),
+  ) as Record<TileCode, string[]>;
+};
+
+describe('detectHandWaits', () => {
+  it('detects the issue example as a ryanmen wait after removing the winning tile', () => {
+    const waits = detectFromNotation('win', 'm123456s123z22p231_');
+
+    expect(waits?.kind).toBe('auto');
+    expect(toWaitMap(waits)).toEqual({
+      '1p': ['ryanmen'],
+      '4p': ['ryanmen'],
+    });
+  });
+
+  it('detects penchan waits', () => {
+    const waits = detectFromNotation('tenpai-draw', 'm123456s123z22p89');
+    expect(toWaitMap(waits)).toEqual({
+      '7p': ['penchan'],
+    });
+  });
+
+  it('detects kanchan waits', () => {
+    const waits = detectFromNotation('tenpai-draw', 'm123456s123z22p24');
+    expect(toWaitMap(waits)).toEqual({
+      '3p': ['kanchan'],
+    });
+  });
+
+  it('detects shabo waits', () => {
+    const waits = detectFromNotation('tenpai-draw', 'm123456s123p11z22');
+    expect(toWaitMap(waits)).toEqual({
+      '1p': ['shabo'],
+      '2z': ['shabo'],
+    });
+  });
+
+  it('detects tanki waits', () => {
+    const waits = detectFromNotation('tenpai-draw', 'm123456s123p789z1');
+    expect(toWaitMap(waits)).toEqual({
+      '1z': ['tanki'],
+    });
+  });
+
+  it('detects nobetan waits', () => {
+    const waits = detectFromNotation('tenpai-draw', 'm2345s123p123z111');
+    expect(toWaitMap(waits)).toEqual({
+      '2m': ['tanki', 'nobetan'],
+      '5m': ['tanki', 'nobetan'],
+    });
+  });
+
+  it('detects sanmen waits', () => {
+    const waits = detectFromNotation('tenpai-draw', 'm23456s123p123z11');
+    expect(toWaitMap(waits)).toEqual({
+      '1m': ['ryanmen', 'sanmen'],
+      '4m': ['ryanmen', 'sanmen'],
+      '7m': ['ryanmen', 'sanmen'],
+    });
+  });
+
+  it('classifies irregular three-sided waits as irregular', () => {
+    const waits = detectFromNotation('tenpai-draw', 'm55567789p678z11');
+    expect(toWaitMap(waits)).toEqual({
+      '5m': ['ryanmen', 'shabo', 'irregular'],
+      '8m': ['kanchan', 'ryanmen', 'irregular'],
+      '1z': ['shabo', 'irregular'],
+    });
+  });
+
+  it('classifies kokushi waits as irregular', () => {
+    const waits = detectFromNotation('tenpai-draw', 'm19p19s19z1234567');
+
+    expect(waits?.tiles).toHaveLength(13);
+    expect(waits?.tiles.every((waitTile) => waitTile.categories.includes('irregular'))).toBe(true);
+  });
+
+  it('detects waits for open hands with melds', () => {
+    const waits = detectFromNotation('tenpai-draw', 'm123456p23z22,z111-');
+    expect(toWaitMap(waits)).toEqual({
+      '1p': ['ryanmen'],
+      '4p': ['ryanmen'],
+    });
+  });
+
+  it('returns unresolved when the hand cannot be analysed safely', () => {
+    const waits = detectFromNotation('win', 'm123456s123z22p23');
+    expect(waits).toEqual({
+      kind: 'unresolved',
+      tiles: [],
+      categories: [],
+    });
+  });
+
+  it('does not remove a matching concealed tile when the winning tile is already excluded', () => {
+    const waits = detectFromNotation('win', 'm123456s123p111z22_');
+
+    expect(toWaitMap(waits)).toEqual({
+      '2z': ['tanki'],
+    });
+  });
+});

--- a/src/utils/waits.ts
+++ b/src/utils/waits.ts
@@ -1,0 +1,440 @@
+import type {
+  AnalysisEventType,
+  AnalysisHand,
+  AnalysisWaitTile,
+  AnalysisWaits,
+  TileCode,
+  WaitCategory,
+} from '../types/analysis';
+import { TILE_CODES, isRedFive, normalizeTileCode } from './tiles';
+
+const STANDARD_TILE_CODES = TILE_CODES.filter((tile) => !isRedFive(tile));
+const TILE_INDEX = new Map(STANDARD_TILE_CODES.map((tile, index) => [tile, index]));
+const KOKUSHI_INDICES = [0, 8, 9, 17, 18, 26, 27, 28, 29, 30, 31, 32, 33];
+
+const unique = <T>(values: T[]): T[] => {
+  return [...new Set(values)];
+};
+
+const toCanonicalTile = (tile: TileCode): TileCode => {
+  return normalizeTileCode(tile);
+};
+
+const toTileIndex = (tile: TileCode): number => {
+  const index = TILE_INDEX.get(toCanonicalTile(tile));
+  if (index === undefined) {
+    throw new Error(`Unknown tile code: ${tile}`);
+  }
+
+  return index;
+};
+
+const fromTileIndex = (index: number): TileCode => {
+  return STANDARD_TILE_CODES[index];
+};
+
+const getTileSuit = (index: number): 'm' | 'p' | 's' | 'z' => {
+  return fromTileIndex(index)[1] as 'm' | 'p' | 's' | 'z';
+};
+
+const getTileRank = (index: number): number => {
+  return Number.parseInt(fromTileIndex(index)[0], 10);
+};
+
+const isHonorIndex = (index: number): boolean => {
+  return getTileSuit(index) === 'z';
+};
+
+const isSameSuit = (left: number, right: number): boolean => {
+  return getTileSuit(left) === getTileSuit(right);
+};
+
+const removeOneMatchingTile = (tiles: TileCode[], tile: TileCode): TileCode[] => {
+  const target = toCanonicalTile(tile);
+  let removed = false;
+
+  return tiles.filter((currentTile) => {
+    if (!removed && toCanonicalTile(currentTile) === target) {
+      removed = true;
+      return false;
+    }
+
+    return true;
+  });
+};
+
+const buildTileCounts = (tiles: TileCode[]): number[] => {
+  const counts = Array.from({ length: STANDARD_TILE_CODES.length }, () => 0);
+
+  for (const tile of tiles) {
+    counts[toTileIndex(tile)] += 1;
+  }
+
+  return counts;
+};
+
+const allCountsAreEmpty = (counts: number[]): boolean => {
+  return counts.every((count) => count === 0);
+};
+
+const classifySequenceRole = (startIndex: number, candidatePosition: 0 | 1 | 2): WaitCategory => {
+  if (candidatePosition === 1) {
+    return 'kanchan';
+  }
+
+  const startRank = getTileRank(startIndex);
+
+  if (
+    (startRank === 1 && candidatePosition === 2) ||
+    (startRank === 7 && candidatePosition === 0)
+  ) {
+    return 'penchan';
+  }
+
+  return 'ryanmen';
+};
+
+const collectWinningRoles = (
+  counts: number[],
+  groupsRemaining: number,
+  candidateIndex: number,
+  candidateRole: WaitCategory | undefined,
+  roles: Set<WaitCategory>,
+): void => {
+  if (groupsRemaining === 0) {
+    if (candidateRole && allCountsAreEmpty(counts)) {
+      roles.add(candidateRole);
+    }
+    return;
+  }
+
+  const firstIndex = counts.findIndex((count) => count > 0);
+  if (firstIndex === -1) {
+    return;
+  }
+
+  const firstCount = counts[firstIndex];
+
+  if (firstCount >= 3) {
+    counts[firstIndex] -= 3;
+
+    if (!candidateRole && firstIndex === candidateIndex) {
+      if (firstCount > 3) {
+        collectWinningRoles(counts, groupsRemaining - 1, candidateIndex, undefined, roles);
+      }
+      collectWinningRoles(counts, groupsRemaining - 1, candidateIndex, 'shabo', roles);
+    } else {
+      collectWinningRoles(counts, groupsRemaining - 1, candidateIndex, candidateRole, roles);
+    }
+
+    counts[firstIndex] += 3;
+  }
+
+  if (!isHonorIndex(firstIndex) && getTileRank(firstIndex) <= 7) {
+    const secondIndex = firstIndex + 1;
+    const thirdIndex = firstIndex + 2;
+
+    if (
+      counts[secondIndex] > 0 &&
+      counts[thirdIndex] > 0 &&
+      isSameSuit(firstIndex, secondIndex) &&
+      isSameSuit(firstIndex, thirdIndex)
+    ) {
+      const candidateCount = counts[candidateIndex];
+      let candidatePosition: 0 | 1 | 2 | null = null;
+
+      if (firstIndex === candidateIndex) {
+        candidatePosition = 0;
+      } else if (secondIndex === candidateIndex) {
+        candidatePosition = 1;
+      } else if (thirdIndex === candidateIndex) {
+        candidatePosition = 2;
+      }
+
+      counts[firstIndex] -= 1;
+      counts[secondIndex] -= 1;
+      counts[thirdIndex] -= 1;
+
+      if (!candidateRole && candidatePosition !== null) {
+        if (candidateCount > 1) {
+          collectWinningRoles(counts, groupsRemaining - 1, candidateIndex, undefined, roles);
+        }
+        collectWinningRoles(
+          counts,
+          groupsRemaining - 1,
+          candidateIndex,
+          classifySequenceRole(firstIndex, candidatePosition),
+          roles,
+        );
+      } else {
+        collectWinningRoles(counts, groupsRemaining - 1, candidateIndex, candidateRole, roles);
+      }
+
+      counts[firstIndex] += 1;
+      counts[secondIndex] += 1;
+      counts[thirdIndex] += 1;
+    }
+  }
+};
+
+const collectStandardCategories = (
+  baseCounts: number[],
+  candidateIndex: number,
+  meldCount: number,
+): WaitCategory[] => {
+  const counts = [...baseCounts];
+  counts[candidateIndex] += 1;
+
+  const groupsNeeded = 4 - meldCount;
+  if (groupsNeeded < 0) {
+    return [];
+  }
+
+  const roles = new Set<WaitCategory>();
+
+  for (let pairIndex = 0; pairIndex < counts.length; pairIndex += 1) {
+    const pairCount = counts[pairIndex];
+    if (pairCount < 2) {
+      continue;
+    }
+
+    counts[pairIndex] -= 2;
+
+    if (pairIndex === candidateIndex) {
+      if (pairCount > 2) {
+        collectWinningRoles(counts, groupsNeeded, candidateIndex, undefined, roles);
+      }
+      collectWinningRoles(counts, groupsNeeded, candidateIndex, 'tanki', roles);
+    } else {
+      collectWinningRoles(counts, groupsNeeded, candidateIndex, undefined, roles);
+    }
+
+    counts[pairIndex] += 2;
+  }
+
+  return [...roles];
+};
+
+const isSevenPairsWait = (
+  baseCounts: number[],
+  candidateIndex: number,
+  meldCount: number,
+): boolean => {
+  if (meldCount > 0) {
+    return false;
+  }
+
+  const counts = [...baseCounts];
+  counts[candidateIndex] += 1;
+
+  return counts.every((count) => count === 0 || count === 2);
+};
+
+const isKokushiWait = (
+  baseCounts: number[],
+  candidateIndex: number,
+  meldCount: number,
+): boolean => {
+  if (meldCount > 0) {
+    return false;
+  }
+
+  const counts = [...baseCounts];
+  counts[candidateIndex] += 1;
+
+  let pairFound = false;
+
+  for (let index = 0; index < counts.length; index += 1) {
+    const count = counts[index];
+    const isKokushiTile = KOKUSHI_INDICES.includes(index);
+
+    if (!isKokushiTile && count > 0) {
+      return false;
+    }
+
+    if (isKokushiTile) {
+      if (count === 0) {
+        return false;
+      }
+
+      if (count >= 2) {
+        pairFound = true;
+      }
+    }
+  }
+
+  return pairFound;
+};
+
+const sortTileEntries = (tiles: AnalysisWaitTile[]): AnalysisWaitTile[] => {
+  return [...tiles].sort((left, right) => toTileIndex(left.tile) - toTileIndex(right.tile));
+};
+
+const hasConsecutiveBlock = (
+  counts: number[],
+  suit: 'm' | 'p' | 's',
+  startRank: number,
+  endRank: number,
+): boolean => {
+  for (let rank = startRank; rank <= endRank; rank += 1) {
+    const tile = `${rank}${suit}` as TileCode;
+    if (counts[toTileIndex(tile)] === 0) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+const decorateComplexCategories = (
+  counts: number[],
+  tiles: AnalysisWaitTile[],
+): AnalysisWaitTile[] => {
+  const sortedTiles = sortTileEntries(tiles);
+  const tileIndices = sortedTiles.map((tile) => toTileIndex(tile.tile));
+
+  if (sortedTiles.length === 2) {
+    const [firstIndex, secondIndex] = tileIndices;
+    const firstSuit = getTileSuit(firstIndex);
+    const secondSuit = getTileSuit(secondIndex);
+    const firstRank = getTileRank(firstIndex);
+    const secondRank = getTileRank(secondIndex);
+    const bothTanki = sortedTiles.every((tile) => tile.categories.includes('tanki'));
+
+    if (
+      bothTanki &&
+      firstSuit === secondSuit &&
+      firstSuit !== 'z' &&
+      secondRank - firstRank === 3 &&
+      hasConsecutiveBlock(counts, firstSuit, firstRank, secondRank)
+    ) {
+      return sortedTiles.map((tile) => ({
+        ...tile,
+        categories: unique([...tile.categories, 'nobetan']),
+      }));
+    }
+  }
+
+  if (sortedTiles.length === 3) {
+    const [firstIndex, secondIndex, thirdIndex] = tileIndices;
+    const suit = getTileSuit(firstIndex);
+    const firstRank = getTileRank(firstIndex);
+    const secondRank = getTileRank(secondIndex);
+    const thirdRank = getTileRank(thirdIndex);
+
+    if (
+      suit !== 'z' &&
+      getTileSuit(secondIndex) === suit &&
+      getTileSuit(thirdIndex) === suit &&
+      secondRank - firstRank === 3 &&
+      thirdRank - secondRank === 3 &&
+      hasConsecutiveBlock(counts, suit, firstRank + 1, thirdRank - 1)
+    ) {
+      return sortedTiles.map((tile) => ({
+        ...tile,
+        categories: unique([...tile.categories, 'sanmen']),
+      }));
+    }
+
+    return sortedTiles.map((tile) => ({
+      ...tile,
+      categories: unique([...tile.categories, 'irregular']),
+    }));
+  }
+
+  if (sortedTiles.length > 3) {
+    return sortedTiles.map((tile) => ({
+      ...tile,
+      categories: unique([...tile.categories, 'irregular']),
+    }));
+  }
+
+  return sortedTiles;
+};
+
+const hasAnyHandTiles = ({
+  concealed,
+  melds,
+  winningTile,
+}: Pick<AnalysisHand, 'concealed' | 'melds' | 'winningTile'>): boolean => {
+  return concealed.length > 0 || melds.length > 0 || winningTile !== undefined;
+};
+
+export const detectHandWaits = ({
+  eventType,
+  hand,
+}: {
+  eventType: AnalysisEventType;
+  hand: Pick<AnalysisHand, 'concealed' | 'melds' | 'winningTile'>;
+}): AnalysisWaits | undefined => {
+  if (!hasAnyHandTiles(hand)) {
+    return undefined;
+  }
+
+  const meldCount = hand.melds.length;
+  const expectedClosedTileCount = (4 - meldCount) * 3 + 1;
+  let concealedTiles = hand.concealed.map(toCanonicalTile);
+
+  if (eventType !== 'tenpai-draw') {
+    if (!hand.winningTile) {
+      return { kind: 'unresolved', tiles: [], categories: [] };
+    }
+
+    if (concealedTiles.length === expectedClosedTileCount + 1) {
+      concealedTiles = removeOneMatchingTile(concealedTiles, hand.winningTile);
+    }
+  }
+
+  if (expectedClosedTileCount < 1 || concealedTiles.length !== expectedClosedTileCount) {
+    return { kind: 'unresolved', tiles: [], categories: [] };
+  }
+
+  const counts = buildTileCounts(concealedTiles);
+  if (counts.some((count) => count > 4)) {
+    return { kind: 'unresolved', tiles: [], categories: [] };
+  }
+
+  const waitTiles: AnalysisWaitTile[] = [];
+
+  for (const candidateTile of STANDARD_TILE_CODES) {
+    const candidateIndex = toTileIndex(candidateTile);
+    if (counts[candidateIndex] >= 4) {
+      continue;
+    }
+
+    const categories = new Set<WaitCategory>(
+      collectStandardCategories(counts, candidateIndex, meldCount),
+    );
+
+    if (isSevenPairsWait(counts, candidateIndex, meldCount)) {
+      categories.add('tanki');
+    }
+
+    if (isKokushiWait(counts, candidateIndex, meldCount)) {
+      categories.add('irregular');
+    }
+
+    if (categories.size > 0) {
+      waitTiles.push({
+        tile: candidateTile,
+        categories: [...categories],
+      });
+    }
+  }
+
+  if (waitTiles.length === 0) {
+    return { kind: 'unresolved', tiles: [], categories: [] };
+  }
+
+  const normalizedTiles = decorateComplexCategories(counts, waitTiles).map((tile) => ({
+    ...tile,
+    categories: unique(tile.categories),
+  }));
+  const categories = unique(normalizedTiles.flatMap((tile) => tile.categories));
+
+  return {
+    kind: 'auto',
+    tiles: normalizedTiles,
+    categories,
+  };
+};


### PR DESCRIPTION
## 概要
- 分析メモの牌姿記載から待ち牌と待ち形を自動判定できるようにします
- 既存の分析データとの互換性を保ちながら、保存データを今後の分析に使いやすい構造へ移行します
- AnalysisDetailModal の待ち同期で発生していたテストフリーズと、PR 前に見つかった lint / auth 再読込まわりの回帰も合わせて解消します

## 変更内容
- 待ち牌判定ロジックを `src/utils/waits.ts` に追加し、両面・三面・辺張・嵌張・シャボ・単騎・延べ単騎・変則を分類
- 分析メモの hand データに構造化された waits を追加し、legacy wait からの正規化と Firestore 保存時の互換処理を実装
- AnalysisDetailModal / HandInputSection / HandNotationInput で待ち表示と保存ロジックを統合し、保存済みデータの保持条件を整理
- 待ち判定・モーダル挙動・Firestore 保存・auth 再ログイン時の再読込をカバーするテストを追加
- lint clean のために関連 hooks / settings 導線 / ScoreBoard の state 同期を調整

## テスト計画
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test`

Closes #137