### PR TITLE
分析牌表示の牌画像を Front.svg 合成前提の描画に修正

### DIFF
--- a/docs/detailed-analysing.md
+++ b/docs/detailed-analysing.md
@@ -42,7 +42,7 @@
 
 ### 3.1 Firestore コレクション
 
-```
+```text
 userAnalyses/{uid}/entries/{entryId}
 ```
 
@@ -262,7 +262,7 @@ export function deleteAnalysisEntry(uid: string, entryId: string): Promise<void>
 
 [firestore.rules](../firestore.rules) に以下を追記:
 
-```
+```firestore
 match /userAnalyses/{uid} {
   match /entries/{entryId} {
     allow read, write: if request.auth != null && request.auth.uid == uid;

--- a/docs/detailed-analysing.md
+++ b/docs/detailed-analysing.md
@@ -219,13 +219,14 @@ export type WaitShape =
 
 ## 5. 牌表示方針
 
-- Phase 1 では外部 SVG アセットは導入せず、`src/components/ui/TileImage.tsx` で牌コードから牌面を描画する CSS ベースの UI コンポーネントを採用する。
-- この方針により、追加の画像ライセンス表記や `docs/credits.md` の新設は不要とする。
+- 牌表示は `public/img/tiles/{light,dark}` 配下の SVG アセットを利用し、`Front.svg` を土台に対象牌の SVG を重ねて 1 枚の牌として描画する。
+- 追加の画像ライセンス表記や `docs/credits.md` の新設は不要とする。
 - 共通コンポーネント `src/components/ui/TileImage.tsx`:
-  - props: `code: TileCode`, `size?: 'sm' | 'md' | 'lg'`, `selected?: boolean`, `onClick?: () => void`
-  - CSS Modules + `src/visuals/tokens.css` のサイズトークンを使用。
+- - props: `code: TileCode`, `size?: 'sm' | 'md' | 'lg'`, `theme?: 'light' | 'dark'`, `selected?: boolean`, `onClick?: () => void`
+- - 外側の要素だけがアクセシブルな 1 枚の牌として振る舞い、内側の `Front.svg` と牌面 SVG は装飾レイヤーとして扱う。
+- - CSS Modules + `src/visuals/tokens.css` のサイズトークンを使用し、各画面は直接 `img` を組み立てない。
 - 牌セレクタ用の配列ヘルパは `src/utils/tiles.ts` にまとめる。
-- 将来的に実画像アセットへ差し替える場合も、各画面からは `TileImage` を経由して利用することで差分を局所化する。
+- SVG パス解決も `src/utils/tiles.ts` に集約し、各画面からは `TileImage` を経由して利用することで差分を局所化する。
 
 ## 6. データアクセス層
 

--- a/docs/issue-139-reflection.md
+++ b/docs/issue-139-reflection.md
@@ -1,0 +1,95 @@
+# Issue #139 振り返り
+
+## 1. 概要
+
+- 対象Issue: #139
+- 要約: 牌 SVG を Front.svg 合成前提で正しく描画できるようにし、analysis 配下で分散していたローカル img 描画を TileImage に集約した対応である。
+- 対象範囲: analysis 画面の牌画像描画、共通 UI コンポーネント、関連テスト、補足ドキュメントである。
+- 結果: PR ブロッカー 0、npm run lint pass、npm run build pass、npm run test pass である。/analysis ページ表示確認は実施済みである。
+
+## 2. 背景と目的
+
+- 背景: Issue #139 は「牌 SVG を Front.svg 合成前提で正しく描画する」ことを目的とした対応である。analysis 配下ではローカル img 描画の実装が分散しており、牌画像描画の共通化が必要であった。
+- 影響: 牌画像描画の正確性と UI の一貫性に関わる対応であり、analysis 画面の表示品質に影響する領域である。Issue 本文の詳細な発生経緯と受け入れ条件は未確認である。
+- 目的:
+  - TileImage を Front.svg と牌面 SVG の合成描画に対応させること。
+  - analysis 配下のローカル img 描画を共通化し、表示ロジックの分散を減らすこと。
+  - 関連ユーティリティ、UI、テストを更新し、主要検証を通過させること。
+
+## 3. 実装内容とポイント
+
+- 変更ファイル/モジュール:
+  - docs/detailed-analysing.md
+  - src/utils/tiles.ts
+  - src/utils/tiles.test.ts
+  - src/components/ui/TileImage.tsx
+  - src/components/ui/TileImage.module.css
+  - src/components/ui/TileImage.test.tsx
+  - src/components/features/analysis/HandNotationInput.tsx
+  - src/components/features/analysis/HandNotationInput.module.css
+  - src/components/features/analysis/HandInputSection.test.tsx
+  - src/components/features/analysis/DoraNotationInput.tsx
+  - src/components/features/analysis/DoraNotationInput.module.css
+  - src/components/features/analysis/DoraNotationInput.test.tsx
+  - src/components/features/AnalysisDetailModal.test.tsx
+- 主な実装:
+  1. TileImage を Front.svg と牌面 SVG を組み合わせる描画方式へ変更した。
+  2. analysis 配下で行っていたローカル img 描画を TileImage に寄せ、共通の描画経路へ統一した。
+  3. 牌画像描画の変更に合わせて tiles ユーティリティと関連テスト、analysis 配下コンポーネントのテスト、補足ドキュメントを更新した。
+- 設計判断:
+  - 牌画像描画の責務を TileImage に集約する方針を採用した。analysis 配下のローカル img 描画を共通化するためである。
+  - UI 側で個別に画像を扱うのではなく、共通コンポーネントとユーティリティの組み合わせで描画する構成を採用した。描画方式の変更点を局所化するためである。
+  - 不採用案とその理由は未確認である。
+
+## 4. レビュー指摘と対応
+
+| 区分     | 内容                                                                         | 判定     | 対応                                                                                       |
+| -------- | ---------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------ |
+| 必須対応 | PR ブロッカーに該当する指摘                                                  | 対応不要 | レビュー結果は PR ブロッカー 0 である。                                                    |
+| 任意課題 | dark テーマの実行経路が未接続である。                                        | 未対応   | 非ブロッカーとして継続課題に残した。                                                       |
+| 任意課題 | AnalysisDetailModal の create/edit/view を実ブラウザで統合確認できていない。 | 未対応   | ローカルに分析エントリがなく、実ブラウザ操作は未確認のままとした。非ブロッカー扱いである。 |
+
+- 最終判定: PR ブロッカー なしである。
+
+## 5. 検証結果
+
+- lint: pass。npm run lint を実行し、通過した。
+- typecheck: pass。npm run build に含まれる tsc -b が通過している。
+- build: pass。npm run build を実行し、通過した。
+- test (unit/integration): pass。npm run test を実行し、494 tests passed であった。
+- e2e: 未確認。専用の E2E 実行結果は確認できていない。
+- 手動確認: /analysis ページ表示は確認済みである。AnalysisDetailModal の実ブラウザ操作は、ローカルに分析エントリがないため未確認である。
+- 補足: dark テーマの実行経路未接続と AnalysisDetailModal の create/edit/view の実ブラウザ統合確認不足は非ブロッカーとして扱った。
+
+## 6. 学びと改善アクション
+
+- 学び:
+  - 牌画像描画の責務を共通コンポーネントへ寄せることで、描画方式の変更を analysis 配下へ横展開しやすくなる。
+  - SVG 合成前提の表示変更では、ユーティリティ更新と UI テスト更新を合わせて行うことで差分の妥当性を確認しやすい。
+- 改善アクション:
+  1. dark テーマ側でも TileImage の描画経路が実行される条件を整理し、確認手順またはテストを追加する。
+  2. AnalysisDetailModal の create/edit/view を実ブラウザで確認できる分析エントリを用意し、統合確認を実施する。
+  3. 必要であれば typecheck を独立した検証項目として記録し、検証結果の粒度をそろえる。
+
+## 7. 残課題
+
+- dark テーマの実行経路は未接続であり、今回のスコープでは未確認のままである。
+- AnalysisDetailModal の create/edit/view は実ブラウザでの統合確認が未完了である。
+- Issue 本文の詳細な受け入れ条件は本資料作成時点で未確認である。
+
+## 8. 参照
+
+- docs/reflection-document-spec-v1.md
+- docs/detailed-analysing.md
+- src/utils/tiles.ts
+- src/utils/tiles.test.ts
+- src/components/ui/TileImage.tsx
+- src/components/ui/TileImage.module.css
+- src/components/ui/TileImage.test.tsx
+- src/components/features/analysis/HandNotationInput.tsx
+- src/components/features/analysis/HandNotationInput.module.css
+- src/components/features/analysis/HandInputSection.test.tsx
+- src/components/features/analysis/DoraNotationInput.tsx
+- src/components/features/analysis/DoraNotationInput.module.css
+- src/components/features/analysis/DoraNotationInput.test.tsx
+- src/components/features/AnalysisDetailModal.test.tsx

--- a/src/components/features/AnalysisDetailModal.test.tsx
+++ b/src/components/features/AnalysisDetailModal.test.tsx
@@ -507,6 +507,40 @@ describe('AnalysisDetailModal', () => {
     expect(screen.getByText('保存済み')).toBeTruthy();
   });
 
+  it('renders hand and dora previews with composite tile layers in view mode', () => {
+    render(
+      <AnalysisDetailModal
+        isOpen
+        mode="view"
+        entry={createAnalysisEntry(
+          {},
+          {
+            hand: {
+              concealed: ['1m', '2m', '3m'],
+              melds: [],
+              winningTile: '4m',
+              waits: {
+                kind: 'auto',
+                categories: ['ryanmen'],
+                tiles: [{ tile: '1p', categories: ['ryanmen'] }],
+              },
+            },
+            dora: {
+              doraIndicators: ['0p'],
+            },
+          },
+        )}
+        onClose={() => undefined}
+      />,
+    );
+
+    const handTile = screen.getByRole('img', { name: '1萬' });
+    const doraTile = screen.getByRole('img', { name: '赤5筒' });
+
+    expect(handTile.querySelectorAll('img')).toHaveLength(2);
+    expect(doraTile.querySelectorAll('img')).toHaveLength(2);
+  });
+
   it('shows category-only legacy waits in view mode', () => {
     render(
       <AnalysisDetailModal

--- a/src/components/features/analysis/DoraNotationInput.module.css
+++ b/src/components/features/analysis/DoraNotationInput.module.css
@@ -63,12 +63,6 @@
   border-radius: var(--border-radius-m);
 }
 
-.tileImg {
-  height: 40px;
-  width: auto;
-  display: block;
-}
-
 .emptyPreview {
   color: var(--color-text-secondary);
   font-size: var(--font-size-s);

--- a/src/components/features/analysis/DoraNotationInput.test.tsx
+++ b/src/components/features/analysis/DoraNotationInput.test.tsx
@@ -1,0 +1,21 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DoraNotationInput } from './DoraNotationInput';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('DoraNotationInput', () => {
+  it('renders preview tiles through the shared composite tile UI', () => {
+    render(<DoraNotationInput value={['1m', '0p']} label="ドラ表示牌" onChange={vi.fn()} />);
+
+    const firstTile = screen.getByRole('img', { name: '1萬' });
+    const redTile = screen.getByRole('img', { name: '赤5筒' });
+
+    expect(firstTile.querySelectorAll('img')).toHaveLength(2);
+    expect(redTile.querySelectorAll('img')).toHaveLength(2);
+  });
+});

--- a/src/components/features/analysis/DoraNotationInput.tsx
+++ b/src/components/features/analysis/DoraNotationInput.tsx
@@ -1,11 +1,11 @@
 import { useCallback, useState } from 'react';
 import type { TileCode } from '../../../types';
-import { getTileLabel, getTileSvgPath } from '../../../utils/tiles';
 import {
   type TileListParseResult,
   formatTileListNotation,
   parseTileListNotation,
 } from '../../../utils/handNotation';
+import { TileImage } from '../../ui/TileImage';
 import styles from './DoraNotationInput.module.css';
 
 interface DoraNotationInputProps {
@@ -15,15 +15,6 @@ interface DoraNotationInputProps {
   readOnly?: boolean;
   onChange: (tiles: TileCode[]) => void;
 }
-
-const TileSvg = ({ code }: { code: TileCode }) => (
-  <img
-    className={styles.tileImg}
-    src={getTileSvgPath(code, 'light')}
-    alt={getTileLabel(code)}
-    draggable={false}
-  />
-);
 
 export const DoraNotationInput = ({
   value,
@@ -93,7 +84,7 @@ export const DoraNotationInput = ({
             {notation.trim() === '' ? '未入力' : 'パースエラー'}
           </span>
         ) : (
-          parsedTiles.map((tile, i) => <TileSvg key={`${tile}-${i}`} code={tile} />)
+          parsedTiles.map((tile, i) => <TileImage key={`${tile}-${i}`} code={tile} size="sm" />)
         )}
       </div>
     </div>

--- a/src/components/features/analysis/HandInputSection.test.tsx
+++ b/src/components/features/analysis/HandInputSection.test.tsx
@@ -169,6 +169,16 @@ describe('HandInputSection', () => {
     ]);
   });
 
+  it('renders preview tiles with composite svg layers', () => {
+    render(<HandInputSectionHarness />);
+
+    const input = screen.getByRole('textbox', { name: 'MPSZ形式で手牌を入力' });
+    fireEvent.change(input, { target: { value: 'm123' } });
+
+    const tile = screen.getByRole('img', { name: '1萬' });
+    expect(tile.querySelectorAll('img')).toHaveLength(2);
+  });
+
   it('shows a quiet unresolved message when the input cannot be analysed', () => {
     render(<HandInputSectionHarness eventType="win" />);
 

--- a/src/components/features/analysis/HandNotationInput.module.css
+++ b/src/components/features/analysis/HandNotationInput.module.css
@@ -67,12 +67,6 @@
   border-radius: var(--border-radius-m);
 }
 
-.tileImg {
-  height: 40px;
-  width: auto;
-  display: block;
-}
-
 .tileSeparator {
   width: 2px;
   height: 32px;

--- a/src/components/features/analysis/HandNotationInput.tsx
+++ b/src/components/features/analysis/HandNotationInput.tsx
@@ -8,14 +8,14 @@ import type {
   WinningTileSource,
 } from '../../../types';
 import { WAIT_CATEGORY_DEFS } from '../../../types/analysis';
-import { getTileLabel, getTileSvgPath } from '../../../utils/tiles';
+import { getTileLabel, normalizeTileCode } from '../../../utils/tiles';
 import {
   type ParseResult,
   formatHandNotation,
   parseHandNotation,
 } from '../../../utils/handNotation';
 import { detectHandWaits } from '../../../utils/waits';
-import { normalizeTileCode } from '../../../utils/tiles';
+import { TileImage } from '../../ui/TileImage';
 import styles from './HandNotationInput.module.css';
 
 const FROM_LABELS: Record<string, string> = {
@@ -77,19 +77,12 @@ const buildParsedHand = ({
   return parsedHand;
 };
 
-const TileSvg = ({ code }: { code: TileCode }) => (
-  <img
-    className={styles.tileImg}
-    src={getTileSvgPath(code, 'light')}
-    alt={getTileLabel(code)}
-    draggable={false}
-  />
-);
+const TilePreview = ({ code }: { code: TileCode }) => <TileImage code={code} size="sm" />;
 
 const MeldGroupPreview = ({ meld }: { meld: Meld }) => (
   <span className={styles.meldGroup}>
     {meld.tiles.map((tile, i) => (
-      <TileSvg key={`meld-${tile}-${i}`} code={tile} />
+      <TilePreview key={`meld-${tile}-${i}`} code={tile} />
     ))}
     {'from' in meld && meld.from ? (
       <span className={styles.ronMarker}>{FROM_LABELS[meld.from]}</span>
@@ -266,13 +259,13 @@ export const HandNotationInput = ({
         ) : (
           <div className={styles.previewRow}>
             {parsed.hand.concealed.map((tile, i) => (
-              <TileSvg key={`c-${tile}-${i}`} code={tile} />
+              <TilePreview key={`c-${tile}-${i}`} code={tile} />
             ))}
 
             {parsed.hand.tsumo ? (
               <>
                 <span className={styles.tileSeparator} />
-                <TileSvg code={parsed.hand.tsumo} />
+                <TilePreview code={parsed.hand.tsumo} />
                 <span className={styles.tsumoMarker}>ツモ</span>
               </>
             ) : null}
@@ -280,7 +273,7 @@ export const HandNotationInput = ({
             {parsed.hand.ron ? (
               <>
                 <span className={styles.tileSeparator} />
-                <TileSvg code={parsed.hand.ron.tile} />
+                <TilePreview code={parsed.hand.ron.tile} />
                 <span className={styles.ronMarker}>ロン({FROM_LABELS[parsed.hand.ron.from]})</span>
               </>
             ) : null}
@@ -317,7 +310,7 @@ export const HandNotationInput = ({
               {displayedWaits.tiles.map((waitTile) => (
                 <div key={waitTile.tile} className={styles.waitItem}>
                   <div className={styles.waitTileRow}>
-                    <TileSvg code={waitTile.tile} />
+                    <TilePreview code={waitTile.tile} />
                     <span className={styles.waitTileLabel}>{getTileLabel(waitTile.tile)}</span>
                   </div>
                   <div className={styles.waitBadgeRow}>

--- a/src/components/ui/TileImage.module.css
+++ b/src/components/ui/TileImage.module.css
@@ -71,3 +71,12 @@
   object-fit: contain;
   position: absolute;
 }
+
+.frontLayer {
+  transform: scale(1);
+}
+
+.faceLayer {
+  transform: scale(0.85);
+  transform-origin: center;
+}

--- a/src/components/ui/TileImage.module.css
+++ b/src/components/ui/TileImage.module.css
@@ -1,65 +1,42 @@
 .tile {
-  --tile-accent: var(--color-text-secondary);
-  --tile-ink: var(--color-bg-main);
-  --tile-shadow: var(--color-bg-main);
   appearance: none;
-  background: linear-gradient(
-    180deg,
-    color-mix(in srgb, var(--color-text-primary) 96%, transparent),
-    color-mix(in srgb, var(--color-text-primary) 84%, var(--color-bg-card) 16%)
-  );
-  border: 1px solid color-mix(in srgb, var(--tile-accent) 34%, var(--color-bg-main) 66%);
-  border-radius: var(--border-radius-m);
-  box-shadow:
-    0 var(--spacing-xs) var(--spacing-m) color-mix(in srgb, var(--tile-shadow) 24%, transparent),
-    inset 0 1px 0 color-mix(in srgb, var(--color-text-primary) 72%, transparent);
-  color: var(--tile-ink);
+  background: none;
+  border: none;
   display: inline-flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: space-between;
-  font-family: var(--font-main);
-  padding: var(--spacing-xs);
+  flex: 0 0 auto;
+  inline-size: calc(var(--spacing-l) + var(--spacing-m));
+  overflow: visible;
+  padding: 0;
   position: relative;
-  text-align: center;
   text-decoration: none;
   vertical-align: middle;
 }
 
-.tile::before {
-  content: '';
-  position: absolute;
-  top: var(--spacing-xs);
-  left: var(--spacing-xs);
-  right: var(--spacing-xs);
-  height: var(--spacing-xs);
-  border-radius: 999px;
-  background: linear-gradient(
-    90deg,
-    color-mix(in srgb, var(--tile-accent) 88%, var(--color-text-primary) 12%),
-    color-mix(in srgb, var(--tile-accent) 38%, var(--color-text-primary) 62%)
-  );
-  opacity: 0.92;
+.stack {
+  aspect-ratio: 3 / 4;
+  background: color-mix(in srgb, var(--color-text-primary) 12%, transparent);
+  border-radius: calc(var(--border-radius-m) + 2px);
+  box-shadow: 0 var(--spacing-xs) var(--spacing-m) color-mix(in srgb, black 24%, transparent);
+  display: block;
+  inline-size: 100%;
+  overflow: hidden;
+  position: relative;
 }
 
 .clickable {
   cursor: pointer;
   transition:
     transform 0.12s ease,
-    box-shadow 0.12s ease,
-    border-color 0.12s ease;
+    filter 0.12s ease;
 }
 
 .clickable:hover {
   transform: translateY(-1px);
-  box-shadow:
-    0 calc(var(--spacing-xs) + 2px) calc(var(--spacing-m) + 2px)
-      color-mix(in srgb, var(--tile-shadow) 30%, transparent),
-    inset 0 1px 0 color-mix(in srgb, var(--color-text-primary) 72%, transparent);
+  filter: brightness(1.04);
 }
 
 .clickable:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--tile-accent) 74%, var(--color-text-primary) 26%);
+  outline: 2px solid color-mix(in srgb, var(--color-primary) 76%, var(--color-text-primary) 24%);
   outline-offset: 2px;
 }
 
@@ -68,103 +45,29 @@
 }
 
 .selected {
-  border-color: color-mix(in srgb, var(--tile-accent) 72%, var(--color-text-primary) 28%);
-  box-shadow:
-    0 calc(var(--spacing-xs) + 2px) calc(var(--spacing-m) + 4px)
-      color-mix(in srgb, var(--tile-shadow) 34%, transparent),
-    0 0 0 2px color-mix(in srgb, var(--tile-accent) 20%, transparent),
-    inset 0 1px 0 color-mix(in srgb, var(--color-text-primary) 72%, transparent);
+  filter: drop-shadow(0 0 0.35rem color-mix(in srgb, var(--color-primary) 35%, transparent));
+}
+
+.pressed {
+  transform: translateY(1px);
 }
 
 .sm {
-  width: calc(var(--spacing-xl) + var(--spacing-m));
-  height: calc(var(--spacing-xl) * 2 + var(--spacing-xs));
+  inline-size: calc(var(--spacing-l) + var(--spacing-m));
 }
 
 .md {
-  width: calc(var(--spacing-xl) + var(--spacing-l));
-  height: calc(var(--spacing-xl) * 2 + var(--spacing-m));
+  inline-size: calc(var(--spacing-xl) + var(--spacing-m));
 }
 
 .lg {
-  width: calc(var(--spacing-xl) * 2);
-  height: calc(var(--spacing-xl) * 2 + var(--spacing-l));
+  inline-size: calc(var(--spacing-xl) * 2);
 }
 
-.manzu {
-  --tile-accent: var(--color-danger);
-  --tile-ink: var(--color-danger);
-  --tile-shadow: var(--color-bg-main);
-}
-
-.pinzu {
-  --tile-accent: var(--color-info);
-  --tile-ink: var(--color-info);
-  --tile-shadow: var(--color-bg-main);
-}
-
-.souzu {
-  --tile-accent: var(--color-success);
-  --tile-ink: var(--color-success);
-  --tile-shadow: var(--color-bg-main);
-}
-
-.honor {
-  --tile-accent: var(--color-text-secondary);
-  --tile-ink: var(--color-bg-main);
-  --tile-shadow: var(--color-bg-main);
-}
-
-.header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--spacing-xs);
-  padding-top: calc(var(--spacing-xs) + 2px);
-  width: 100%;
-}
-
-.cornerValue,
-.cornerLabel,
-.footerValue,
-.footerLabel {
-  color: inherit;
-  font-size: var(--font-size-xs);
-  font-weight: var(--font-weight-bold);
-  line-height: 1;
-}
-
-.cornerLabel,
-.footerLabel {
-  color: color-mix(in srgb, var(--tile-ink) 70%, var(--color-text-secondary) 30%);
-}
-
-.footerLabel {
-  font-size: calc(var(--font-size-xs) - 1px);
-  padding-bottom: 1px;
-}
-
-.symbol {
-  color: inherit;
-  font-size: calc(var(--font-size-xl) + 6px);
-  font-weight: var(--font-weight-bold);
-  line-height: 1;
-}
-
-.honorSymbol {
-  font-size: calc(var(--font-size-xl) + 10px);
-}
-
-.redBadge {
-  background: color-mix(in srgb, var(--color-danger) 18%, var(--color-text-primary) 82%);
-  border-radius: 999px;
-  color: var(--color-danger);
-  font-size: calc(var(--font-size-xs) - 1px);
-  font-weight: var(--font-weight-bold);
-  line-height: 1;
-  padding: 2px var(--spacing-xs);
-}
-
-.redValue {
-  color: var(--color-danger);
+.layer {
+  block-size: 100%;
+  inline-size: 100%;
+  inset: 0;
+  object-fit: contain;
+  position: absolute;
 }

--- a/src/components/ui/TileImage.test.tsx
+++ b/src/components/ui/TileImage.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { TileImage } from './TileImage';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('TileImage', () => {
+  it('renders a composite tile with front and face svg layers', () => {
+    render(<TileImage code="1m" ariaLabel="一萬テスト" />);
+
+    const tile = screen.getByRole('img', { name: '一萬テスト' });
+    const layers = tile.querySelectorAll('img');
+
+    expect(layers).toHaveLength(2);
+    expect(layers[0].getAttribute('src')).toContain('/img/tiles/light/Front.svg');
+    expect(layers[1].getAttribute('src')).toContain('/img/tiles/light/Man1.svg');
+    expect(layers[0].getAttribute('alt')).toBe('');
+    expect(layers[1].getAttribute('alt')).toBe('');
+  });
+
+  it('keeps button semantics while using the same composite layers', () => {
+    const handleClick = vi.fn();
+
+    render(<TileImage code="0p" ariaLabel="赤五筒テスト" onClick={handleClick} pressed disabled />);
+
+    const button = screen.getByRole('button', { name: '赤五筒テスト' });
+    const layers = button.querySelectorAll('img');
+
+    expect(button.getAttribute('aria-pressed')).toBe('true');
+    expect(button.getAttribute('disabled')).not.toBeNull();
+    expect(layers).toHaveLength(2);
+    expect(layers[1].getAttribute('src')).toContain('/img/tiles/light/Pin5-Dora.svg');
+
+    fireEvent.click(button);
+
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/ui/TileImage.tsx
+++ b/src/components/ui/TileImage.tsx
@@ -1,10 +1,11 @@
 import type { TileCode } from '../../types/analysis';
-import { getTileMetadata } from '../../utils/tiles';
+import { getTileImageAssetPaths, getTileMetadata, type TileTheme } from '../../utils/tiles';
 import styles from './TileImage.module.css';
 
 interface TileImageProps {
   code: TileCode;
   size?: 'sm' | 'md' | 'lg';
+  theme?: TileTheme;
   selected?: boolean;
   pressed?: boolean;
   onClick?: () => void;
@@ -20,6 +21,7 @@ const joinClassNames = (...values: Array<string | false | null | undefined>): st
 export const TileImage = ({
   code,
   size = 'md',
+  theme = 'light',
   selected = false,
   pressed,
   onClick,
@@ -28,38 +30,22 @@ export const TileImage = ({
   className,
 }: TileImageProps) => {
   const tile = getTileMetadata(code);
+  const assetPaths = getTileImageAssetPaths(code, theme);
   const tileClassName = joinClassNames(
     styles.tile,
     styles[size],
-    styles[tile.group],
     selected && styles.selected,
+    pressed && styles.pressed,
     onClick && styles.clickable,
     className,
   );
+  const accessibleLabel = ariaLabel ?? tile.label;
 
   const content = (
-    <>
-      <span className={styles.header}>
-        {!tile.isHonor ? (
-          <span className={joinClassNames(styles.cornerValue, tile.isRed && styles.redValue)}>
-            {tile.rankLabel}
-          </span>
-        ) : (
-          <span className={styles.cornerLabel}>字牌</span>
-        )}
-        {tile.isRed ? <span className={styles.redBadge}>赤</span> : null}
-      </span>
-      <span className={joinClassNames(styles.symbol, tile.isHonor && styles.honorSymbol)}>
-        {tile.symbol}
-      </span>
-      {!tile.isHonor ? (
-        <span className={joinClassNames(styles.footerValue, tile.isRed && styles.redValue)}>
-          {tile.rankLabel}
-        </span>
-      ) : (
-        <span className={styles.footerLabel}>{tile.label}</span>
-      )}
-    </>
+    <span className={styles.stack}>
+      <img className={styles.layer} src={assetPaths.frontPath} alt="" aria-hidden="true" />
+      <img className={styles.layer} src={assetPaths.facePath} alt="" aria-hidden="true" />
+    </span>
   );
 
   if (onClick) {
@@ -67,7 +53,7 @@ export const TileImage = ({
       <button
         type="button"
         className={tileClassName}
-        aria-label={ariaLabel ?? tile.label}
+        aria-label={accessibleLabel}
         aria-pressed={pressed}
         title={tile.label}
         onClick={onClick}
@@ -79,7 +65,7 @@ export const TileImage = ({
   }
 
   return (
-    <span className={tileClassName} role="img" aria-label={tile.label} title={tile.label}>
+    <span className={tileClassName} role="img" aria-label={accessibleLabel} title={tile.label}>
       {content}
     </span>
   );

--- a/src/components/ui/TileImage.tsx
+++ b/src/components/ui/TileImage.tsx
@@ -43,8 +43,18 @@ export const TileImage = ({
 
   const content = (
     <span className={styles.stack}>
-      <img className={styles.layer} src={assetPaths.frontPath} alt="" aria-hidden="true" />
-      <img className={styles.layer} src={assetPaths.facePath} alt="" aria-hidden="true" />
+      <img
+        className={joinClassNames(styles.layer, styles.frontLayer)}
+        src={assetPaths.frontPath}
+        alt=""
+        aria-hidden="true"
+      />
+      <img
+        className={joinClassNames(styles.layer, styles.faceLayer)}
+        src={assetPaths.facePath}
+        alt=""
+        aria-hidden="true"
+      />
     </span>
   );
 

--- a/src/utils/tiles.test.ts
+++ b/src/utils/tiles.test.ts
@@ -3,6 +3,7 @@ import {
   TILE_CODES,
   TILE_GROUPS,
   createMeldDraft,
+  getTileImageAssetPaths,
   getTileMetadata,
   isRedFive,
   isTileCode,
@@ -102,6 +103,21 @@ describe('tiles', () => {
     expect(createMeldDraft('ankan')).toEqual({
       kind: 'ankan',
       tiles: ['1m', '1m', '1m', '1m'],
+    });
+  });
+
+  it('resolves composite tile asset paths for light and dark themes', () => {
+    expect(getTileImageAssetPaths('1m')).toEqual({
+      frontPath: '/img/tiles/light/Front.svg',
+      facePath: '/img/tiles/light/Man1.svg',
+    });
+    expect(getTileImageAssetPaths('7z')).toEqual({
+      frontPath: '/img/tiles/light/Front.svg',
+      facePath: '/img/tiles/light/Chun.svg',
+    });
+    expect(getTileImageAssetPaths('0p', 'dark')).toEqual({
+      frontPath: '/img/tiles/dark/Front.svg',
+      facePath: '/img/tiles/dark/Pin5-Dora.svg',
     });
   });
 

--- a/src/utils/tiles.ts
+++ b/src/utils/tiles.ts
@@ -2,6 +2,12 @@ import type { Meld, TileCode } from '../types/analysis';
 
 export type TileGroupId = 'manzu' | 'pinzu' | 'souzu' | 'honor';
 export type TileFaceSymbol = '萬' | '筒' | '索' | '東' | '南' | '西' | '北' | '白' | '發' | '中';
+export type TileTheme = 'light' | 'dark';
+
+export interface TileImageAssetPaths {
+  frontPath: string;
+  facePath: string;
+}
 
 export interface TilePalette {
   id: TileGroupId;
@@ -292,7 +298,7 @@ const SUIT_SVG_PREFIX: Record<string, string> = {
   s: 'Sou',
 };
 
-export const getTileSvgPath = (tileCode: TileCode, theme: 'light' | 'dark' = 'light'): string => {
+export const getTileSvgPath = (tileCode: TileCode, theme: TileTheme = 'light'): string => {
   if (tileCode.endsWith('z')) {
     const name = HONOR_SVG_NAMES[tileCode];
     return `/img/tiles/${theme}/${name}.svg`;
@@ -308,4 +314,14 @@ export const getTileSvgPath = (tileCode: TileCode, theme: 'light' | 'dark' = 'li
   const suit = tileCode[1] as 'm' | 'p' | 's';
   const prefix = SUIT_SVG_PREFIX[suit];
   return `/img/tiles/${theme}/${prefix}${rank}.svg`;
+};
+
+export const getTileImageAssetPaths = (
+  tileCode: TileCode,
+  theme: TileTheme = 'light',
+): TileImageAssetPaths => {
+  return {
+    frontPath: `/img/tiles/${theme}/Front.svg`,
+    facePath: getTileSvgPath(tileCode, theme),
+  };
 };


### PR DESCRIPTION
## 概要

- 分析画面の牌画像描画を Front.svg と牌面 SVG の合成方式へ切り替え、入力欄と詳細表示で同じ TileImage を使うように統一しました。
- 牌画像アセットの参照ユーティリティとテストを追加し、分析 UI の牌表示がローカル画像依存にならないよう整理しました。

## 変更内容

### component

- src/components/ui/TileImage.tsx: Front.svg と牌面 SVG を重ねて描画する実装へ差し替え、共通表示コンポーネントとして利用できるよう更新
- src/components/ui/TileImage.module.css: 合成描画に合わせてスタイルを整理し、従来の画像依存スタイルを削除
- src/components/features/analysis/HandNotationInput.tsx: ローカル img 描画を TileImage に置き換え
- src/components/features/analysis/DoraNotationInput.tsx: ドラ表示牌の描画を TileImage に統一
- src/components/features/AnalysisDetailModal.test.tsx: 分析詳細モーダル内の牌表示差し替えに対応する検証を追加
- src/components/features/analysis/HandInputSection.test.tsx: 手牌入力セクションの牌表示検証を追加
- src/components/features/analysis/DoraNotationInput.test.tsx: ドラ表示牌の共通描画コンポーネント利用に合わせてテストを追加

### utils

- src/utils/tiles.ts: getTileImageAssetPaths を追加し、Front.svg と牌面 SVG のパス解決を共通化
- src/utils/tiles.test.ts: 牌画像アセット解決のテストを追加

### test

- src/components/ui/TileImage.test.tsx: 合成描画とアセット参照のテストを追加

### docs

- docs/detailed-analysing.md: 分析画面の牌画像表示実装に関する説明を更新
- docs/issue-139-reflection.md: Issue #139 の振り返りを追加

## テスト計画

- [x] npm run lint
- [x] npm run build
- [x] npm run test（55 files / 494 tests passed, 5 skipped）
- [x] /analysis ページ表示確認
- [ ] AnalysisDetailModal の実ブラウザ操作確認（ローカルに分析エントリがなく未確認）

Closes #139
