### PR TITLE
Modalコンポーネントのwidth指定時にmax-widthが上書きされない問題を修正

### DIFF
--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -146,7 +146,7 @@ export const Modal = ({ isOpen, onClose, title, children, width }: ModalProps) =
         ref={modalRef}
         className={`${styles.modal} ${!isOpen ? styles.modalClosing : ''}`}
         onClick={(e) => e.stopPropagation()}
-        style={{ width: width }}
+        style={width ? { width, maxWidth: width } : undefined}
         role="dialog"
         aria-modal="true"
         aria-labelledby={title ? titleId : undefined}


### PR DESCRIPTION
## 概要

- 分析メモ詳細モーダル（`AnalysisDetailModal`）で `width` prop を指定しても、CSS の `max-width: 500px` に制限されてドラセクションのレイアウトが崩れる問題を修正
- `Modal` コンポーネントに `width` prop が渡された場合、インラインスタイルで `maxWidth` も同じ値に設定し CSS の制限を上書きする

## 変更内容

### component

- `src/components/ui/Modal.tsx`: `width` prop 指定時にインラインスタイルで `maxWidth` も同値を設定するよう変更

### 変更前後

```tsx
// Before
style={{ width: width }}

// After
style={width ? { width, maxWidth: width } : undefined}
```

## 影響範囲

- `AnalysisDetailModal` (width="min(960px, calc(100vw - 16px))") → 960px まで広がり、ドラセクションのレイアウト崩れが解消
- `MatchFinishedModal` (width="300px") → 300px < 500px のため影響なし
- width 未指定のモーダル → style=undefined のため従来通り max-width: 500px 適用

## テスト計画

- [x] npm run lint
- [x] npm run build
- [x] npm run test（56 files / 511 tests passed, 5 skipped）
- [ ] 受入テスト: viewport 768px 以上で分析メモ詳細モーダルのドラセクションが崩れないことを確認

Closes #143
