### PR TITLE
焼き鳥ルール有効時にスコアカードへ🐔バッジを表示する機能を追加

### DIFF
--- a/src/components/features/ScoreBoard.module.css
+++ b/src/components/features/ScoreBoard.module.css
@@ -383,6 +383,14 @@
   background-color: rgba(244, 67, 54, 0.1);
 }
 
+/* Yakitori Badge */
+.yakitoriBadge {
+  flex-shrink: 0;
+  font-size: 14px;
+  line-height: 1;
+  margin-left: var(--spacing-xs);
+}
+
 /* Animations */
 .delta {
   font-family: var(--font-mono);

--- a/src/components/features/ScoreBoard.tsx
+++ b/src/components/features/ScoreBoard.tsx
@@ -23,6 +23,7 @@ export interface ScoreBoardProps {
   onCenterClick?: () => void;
   useChip?: boolean;
   currentUserId?: string;
+  yakitoriPlayerIds?: Set<string>;
 }
 
 export const ScoreBoard = ({
@@ -34,6 +35,7 @@ export const ScoreBoard = ({
   onCenterClick,
   useChip = false,
   currentUserId,
+  yakitoriPlayerIds,
 }: ScoreBoardProps) => {
   const [displayScores, setDisplayScores] = useState<Record<string, number>>(() =>
     createDisplayScoreMap(players),
@@ -149,7 +151,7 @@ export const ScoreBoard = ({
               isDealer={getIsDealer(player)}
               onDisplayScoreChange={handleDisplayScoreChange}
               rank={playerRanks[player.id]}
-              // displayMode removed as it is handled via CSS Grid areas now
+              isYakitori={yakitoriPlayerIds?.has(player.id) ?? false}
             />
           </div>
         ))}
@@ -167,6 +169,7 @@ const PlayerRow = ({
   isDealer,
   onDisplayScoreChange,
   rank,
+  isYakitori,
 }: {
   player: Player;
   lastEvent?: LastEvent;
@@ -176,6 +179,7 @@ const PlayerRow = ({
   isDealer?: boolean;
   onDisplayScoreChange: (playerId: string, score: number) => void;
   rank?: number;
+  isYakitori?: boolean;
 }) => {
   const [displayScore, setDisplayScore] = useState(player.score);
   const [delta, setDelta] = useState<{ value: number; type: 'hand' | 'stick' | 'simple' } | null>(
@@ -382,6 +386,7 @@ const PlayerRow = ({
                 : '北'}
         </div>
         <div className={styles.playerName}>{player.name}</div>
+        {isYakitori && <div className={styles.yakitoriBadge}>🐔</div>}
       </div>
 
       {/* Body: Score + Deltas */}

--- a/src/pages/CompetitionTablePage.tsx
+++ b/src/pages/CompetitionTablePage.tsx
@@ -38,6 +38,7 @@ import { useRoomSoundEffects } from '../hooks/useRoomSoundEffects';
 import { auth } from '../services/firebase';
 import { getAnalysisEventType } from '../utils/analysis';
 import { buildRoomAnalysisEvents } from '../utils/analysisEvents';
+import { getWinnerIdSetFromLogs } from '../utils/resultCalculator';
 import styles from './CompetitionTablePage.module.css';
 
 const WIND_LABELS: Record<string, string> = {
@@ -153,6 +154,20 @@ export const CompetitionTablePage = () => {
 
     return buildRoomAnalysisEvents(room, myPlayerId);
   }, [myPlayerId, room]);
+
+  const yakitoriPlayerIds = useMemo(() => {
+    if (!room?.settings.yakitoriEnabled) {
+      return undefined;
+    }
+    const winnerIds = getWinnerIdSetFromLogs(room.currentLogs ?? []);
+    const yakitoriIds = new Set<string>();
+    for (const player of room.players) {
+      if (!winnerIds.has(player.id)) {
+        yakitoriIds.add(player.id);
+      }
+    }
+    return yakitoriIds;
+  }, [room]);
 
   const promptAnalysisForHand = useCallback(
     (selection: AnalysisModalSelection) => {
@@ -346,6 +361,7 @@ export const CompetitionTablePage = () => {
           onRiichi={matchGame.handleRiichi}
           onCenterClick={handleCenterClick}
           useChip={room.settings.useChip}
+          yakitoriPlayerIds={yakitoriPlayerIds}
         />
 
         <SoundEffectToggle

--- a/src/pages/MatchPage.tsx
+++ b/src/pages/MatchPage.tsx
@@ -30,7 +30,11 @@ import { getAnalysisEventType } from '../utils/analysis';
 import { buildRoomAnalysisEvents } from '../utils/analysisEvents';
 import { processHandEnd } from '../utils/gameLogic';
 import { generateId } from '../utils/id';
-import { calculateFinalScores, distributeRemainingRiichiSticks } from '../utils/resultCalculator';
+import {
+  calculateFinalScores,
+  distributeRemainingRiichiSticks,
+  getWinnerIdSetFromLogs,
+} from '../utils/resultCalculator';
 import { calculateRyukyokuScore } from '../utils/scoreCalculator';
 import { calculateTransaction } from '../utils/scoreDiff';
 import { isReadOnlyFinishedCompetitionRoom } from '../utils/historyRoomStatus';
@@ -86,6 +90,20 @@ export const MatchPage = () => {
 
     return buildRoomAnalysisEvents(room, myPlayerId);
   }, [myPlayerId, room]);
+
+  const yakitoriPlayerIds = useMemo(() => {
+    if (!room?.settings.yakitoriEnabled) {
+      return undefined;
+    }
+    const winnerIds = getWinnerIdSetFromLogs(room.currentLogs ?? []);
+    const yakitoriIds = new Set<string>();
+    for (const player of room.players) {
+      if (!winnerIds.has(player.id)) {
+        yakitoriIds.add(player.id);
+      }
+    }
+    return yakitoriIds;
+  }, [room]);
 
   const promptAnalysisForHand = (handLog: HandLog, playersSnapshot: Player[]) => {
     if (!room || !getAnalysisEventType(handLog, myPlayerId)) {
@@ -942,6 +960,7 @@ export const MatchPage = () => {
         }}
         onCenterClick={handleCenterClick}
         useChip={room.settings.useChip}
+        yakitoriPlayerIds={yakitoriPlayerIds}
       />
 
       {/* Undo Button */}

--- a/src/utils/resultCalculator.ts
+++ b/src/utils/resultCalculator.ts
@@ -14,7 +14,7 @@ export interface CalculateFinalScoresOptions {
   handLogs?: HandLog[];
 }
 
-const getWinnerIdSetFromLogs = (handLogs: HandLog[]): Set<string> => {
+export const getWinnerIdSetFromLogs = (handLogs: HandLog[]): Set<string> => {
   return handLogs.reduce<Set<string>>((winnerIds, log) => {
     if (log.result.type !== 'Win') {
       return winnerIds;


### PR DESCRIPTION
## 概要

- 焼き鳥ルールが有効な対局中、まだ和了していないプレイヤーのスコアカードに 🐔 バッジを表示する機能を追加
- 対局中に誰がまだ和了していないか一目で確認できるようになり、焼き鳥ルールの視認性を向上

## 変更内容

### utils

- `src/utils/resultCalculator.ts`: `getWinnerIdSetFromLogs` を export に変更し、外部から利用可能に

### component

- `src/components/features/ScoreBoard.tsx`: `yakitoriPlayerIds` prop を追加、PlayerRow に `isYakitori` prop を追加し、ヘッダーに 🐔 バッジを表示
- `src/components/features/ScoreBoard.module.css`: `.yakitoriBadge` スタイルを追加

### pages

- `src/pages/MatchPage.tsx`: `yakitoriPlayerIds` を計算して ScoreBoard に渡す
- `src/pages/CompetitionTablePage.tsx`: 同上

## テスト計画

- [x] npm run lint
- [x] npm run build
- [x] npm run test（59 files / 527 tests passed）
- [ ] 受入テスト（焼き鳥ルール有効ルームで和了前後のバッジ表示を手動確認）

## 影響画面

- MatchPage (`/room/:roomId`)
- CompetitionTablePage (`/competitions/:id/tables/:tableId`)

Closes #152
