### PR TITLE
Upgrade React to version 19.2.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@dnd-kit/utilities": "^3.2.2",
         "chart.js": "^4.5.1",
         "firebase": "^12.14.0",
-        "react": "^19.2.6",
+        "react": "^19.2.7",
         "react-chartjs-2": "^5.3.1",
         "react-dom": "^19.2.7",
         "react-qr-code": "^2.0.21",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "chart.js": "^4.5.1",
     "firebase": "^12.14.0",
-    "react": "^19.2.6",
+    "react": "^19.2.7",
     "react-chartjs-2": "^5.3.1",
     "react-dom": "^19.2.7",
     "react-qr-code": "^2.0.21",


### PR DESCRIPTION
## 概要

Upgrade React and React DOM to version 19.2.7 in package.json and package-lock.json.

## 変更内容

###

Updated the React and React DOM versions.

## テスト計画

- [x] npm run lint
- [x] npm run build
- [x] npm run test（ files / tests passed）
- [x] 受入テスト（手動確認項目を記載）

