### PR TITLE
ルーム状態の永続化構造と認証境界を整理

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -31,6 +31,13 @@ service cloud.firestore {
 
       // Delete: Only Host can delete (not strictly implemented in UI but good practice)
       allow delete: if request.auth != null && resource.data.hostId == request.auth.uid;
+
+      match /state/{documentId} {
+        allow read: if request.auth != null;
+        allow create, update: if request.auth != null
+          && request.auth.uid in get(/databases/$(database)/documents/rooms/$(roomId)).data.playerIds;
+        allow delete: if false;
+      }
     }
 
     // Competitions Collection Rules

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,6 @@
-import { signInAnonymously } from 'firebase/auth';
-import { Suspense, lazy, useEffect, useState } from 'react';
+import { Suspense, lazy } from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
-import { useSnackbar } from './contexts/SnackbarContext';
-import { auth } from './services/firebase';
+import { useAuth } from './contexts/useAuth';
 
 import { DashboardSkeleton } from './components/skeletons/DashboardSkeleton';
 import { HistorySkeleton } from './components/skeletons/HistorySkeleton';
@@ -62,30 +60,9 @@ const UserSettingsPage = lazy(() =>
 );
 
 function App() {
-  const [init, setInit] = useState(false);
-  const { showSnackbar } = useSnackbar();
+  const { authReady } = useAuth();
 
-  useEffect(() => {
-    const unsubscribe = auth.onAuthStateChanged((user) => {
-      if (user) {
-        setInit(true);
-      } else {
-        signInAnonymously(auth)
-          .then(() => {
-            // init state will be handled by the next onAuthStateChanged emission
-          })
-          .catch((error) => {
-            console.error('Auth failed', error);
-            showSnackbar('認証に失敗しました。リロードしてください。', { position: 'top' });
-            setInit(true);
-          });
-      }
-    });
-
-    return () => unsubscribe();
-  }, [showSnackbar]);
-
-  if (!init) return <TopPageSkeleton />;
+  if (!authReady) return <TopPageSkeleton />;
 
   return (
     <BrowserRouter>

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,0 +1,50 @@
+import { signInAnonymously, signOut, type User } from 'firebase/auth';
+import { useEffect, useMemo, useState, type PropsWithChildren } from 'react';
+import { auth } from '../services/firebase';
+import { AuthContext, type AuthContextValue } from './auth-context';
+import { useSnackbar } from './SnackbarContext';
+
+export const AuthProvider = ({ children }: PropsWithChildren) => {
+  const { showSnackbar } = useSnackbar();
+  const [currentUser, setCurrentUser] = useState<User | null>(auth.currentUser);
+  const [authReady, setAuthReady] = useState(Boolean(auth.currentUser));
+  const [sessionId, setSessionId] = useState(0);
+
+  useEffect(() => {
+    const unsubscribe = auth.onAuthStateChanged((user) => {
+      setSessionId((current) => current + 1);
+
+      if (user) {
+        setCurrentUser(user);
+        setAuthReady(true);
+        return;
+      }
+
+      setCurrentUser(null);
+
+      signInAnonymously(auth)
+        .then(() => {
+          // The next auth state event will mark auth as ready.
+        })
+        .catch((error) => {
+          console.error('Auth failed', error);
+          showSnackbar('認証に失敗しました。リロードしてください。', { position: 'top' });
+          setAuthReady(true);
+        });
+    });
+
+    return () => unsubscribe();
+  }, [showSnackbar]);
+
+  const value = useMemo<AuthContextValue>(() => {
+    return {
+      authReady,
+      currentUser,
+      sessionId,
+      uid: currentUser?.uid ?? null,
+      signOutCurrentUser: () => signOut(auth),
+    };
+  }, [authReady, currentUser, sessionId]);
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};

--- a/src/contexts/auth-context.ts
+++ b/src/contexts/auth-context.ts
@@ -1,0 +1,12 @@
+import { createContext } from 'react';
+import type { User } from 'firebase/auth';
+
+export interface AuthContextValue {
+  authReady: boolean;
+  currentUser: User | null;
+  sessionId: number;
+  uid: string | null;
+  signOutCurrentUser: () => Promise<void>;
+}
+
+export const AuthContext = createContext<AuthContextValue | null>(null);

--- a/src/contexts/useAuth.ts
+++ b/src/contexts/useAuth.ts
@@ -1,0 +1,11 @@
+import { useContext } from 'react';
+import { AuthContext } from './auth-context';
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+
+  return context;
+};

--- a/src/hooks/useAnalysisEntries.test.ts
+++ b/src/hooks/useAnalysisEntries.test.ts
@@ -5,16 +5,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAnalysisEntries } from './useAnalysisEntries';
 
 const mocks = vi.hoisted(() => ({
-  mockAuth: {
-    currentUser: {
-      uid: 'user-1',
-    } as { uid: string } | null,
-  },
-  mockOnAuthStateChanged: vi.fn(),
   mockSubscribeAnalysisEntries: vi.fn(),
+  mockUseAuth: vi.fn(),
 }));
-
-let authStateCallback: ((user: { uid: string } | null) => void) | null = null;
 
 const createAnalysisEntry = (id: string) => ({
   id,
@@ -59,12 +52,8 @@ const createAnalysisEntry = (id: string) => ({
   updatedAt: 2000,
 });
 
-vi.mock('firebase/auth', () => ({
-  onAuthStateChanged: (...args: unknown[]) => mocks.mockOnAuthStateChanged(...args),
-}));
-
-vi.mock('../services/firebase', () => ({
-  auth: mocks.mockAuth,
+vi.mock('../contexts/useAuth', () => ({
+  useAuth: () => mocks.mockUseAuth(),
 }));
 
 vi.mock('../services/analysisService', () => ({
@@ -72,14 +61,13 @@ vi.mock('../services/analysisService', () => ({
 }));
 
 describe('useAnalysisEntries', () => {
+  let authState = { authReady: true, sessionId: 1, uid: 'user-1' as string | null };
+
   beforeEach(() => {
-    mocks.mockAuth.currentUser = { uid: 'user-1' };
     mocks.mockSubscribeAnalysisEntries.mockReset();
-    mocks.mockOnAuthStateChanged.mockReset();
-    mocks.mockOnAuthStateChanged.mockImplementation((_auth, callback) => {
-      authStateCallback = callback;
-      callback(mocks.mockAuth.currentUser);
-      return vi.fn();
+    authState = { authReady: true, sessionId: 1, uid: 'user-1' };
+    mocks.mockUseAuth.mockImplementation(() => {
+      return authState;
     });
   });
 
@@ -107,11 +95,7 @@ describe('useAnalysisEntries', () => {
   });
 
   it('stays empty when the user is signed out', async () => {
-    mocks.mockAuth.currentUser = null;
-    mocks.mockOnAuthStateChanged.mockImplementation((_auth, callback) => {
-      callback(null);
-      return vi.fn();
-    });
+    authState = { authReady: true, sessionId: 2, uid: null };
 
     const { result } = renderHook(() => useAnalysisEntries());
 
@@ -131,13 +115,14 @@ describe('useAnalysisEntries', () => {
       return vi.fn();
     });
 
-    const { result } = renderHook(() => useAnalysisEntries());
+    const { result, rerender } = renderHook(() => useAnalysisEntries());
 
     await waitFor(() => {
       expect(result.current.entries).toEqual(streamedEntries);
     });
 
-    authStateCallback?.(null);
+    authState = { authReady: true, sessionId: 2, uid: null };
+    rerender();
 
     await waitFor(() => {
       expect(result.current.uid).toBeNull();

--- a/src/hooks/useAnalysisEntries.ts
+++ b/src/hooks/useAnalysisEntries.ts
@@ -1,8 +1,7 @@
-import { onAuthStateChanged } from 'firebase/auth';
 import { useEffect, useState } from 'react';
+import { useAuth } from '../contexts/useAuth';
 import type { AnalysisEntry } from '../types/analysis';
 import { subscribeAnalysisEntries } from '../services/analysisService';
-import { auth } from '../services/firebase';
 
 interface UseAnalysisEntriesResult {
   uid: string | null;
@@ -11,25 +10,9 @@ interface UseAnalysisEntriesResult {
 }
 
 export const useAnalysisEntries = (): UseAnalysisEntriesResult => {
-  const [uid, setUid] = useState<string | null>(auth.currentUser?.uid ?? null);
+  const { authReady, uid } = useAuth();
   const [entries, setEntries] = useState<AnalysisEntry[]>([]);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (user) => {
-      setEntries([]);
-      setUid(user?.uid ?? null);
-
-      if (!user) {
-        setLoading(false);
-        return;
-      }
-
-      setLoading(true);
-    });
-
-    return () => unsubscribe();
-  }, []);
+  const [entriesOwnerUid, setEntriesOwnerUid] = useState<string | null>(null);
 
   useEffect(() => {
     if (!uid) {
@@ -38,15 +21,17 @@ export const useAnalysisEntries = (): UseAnalysisEntriesResult => {
 
     const unsubscribe = subscribeAnalysisEntries(uid, (nextEntries) => {
       setEntries(nextEntries);
-      setLoading(false);
+      setEntriesOwnerUid(uid);
     });
 
     return () => unsubscribe();
   }, [uid]);
 
+  const loading = authReady && uid !== null && entriesOwnerUid !== uid;
+
   return {
     uid,
-    entries: uid ? entries : [],
+    entries: uid && entriesOwnerUid === uid ? entries : [],
     loading,
   };
 };

--- a/src/hooks/useAnalysisEntry.test.ts
+++ b/src/hooks/useAnalysisEntry.test.ts
@@ -6,19 +6,12 @@ import { useAnalysisEntry } from './useAnalysisEntry';
 import type { AnalysisSource } from '../types/analysis';
 
 const mocks = vi.hoisted(() => ({
-  mockAuth: {
-    currentUser: {
-      uid: 'user-1',
-    } as { uid: string } | null,
-  },
-  mockOnAuthStateChanged: vi.fn(),
   mockDeleteAnalysisEntry: vi.fn(),
   mockFindAnalysisEntryByHandLog: vi.fn(),
   mockGetAnalysisEntry: vi.fn(),
   mockSaveAnalysisEntry: vi.fn(),
+  mockUseAuth: vi.fn(),
 }));
-
-let authStateCallback: ((user: { uid: string } | null) => void) | null = null;
 
 const createAnalysisEntry = (id = 'entry-1') => ({
   id,
@@ -63,12 +56,8 @@ const createAnalysisEntry = (id = 'entry-1') => ({
   updatedAt: 2000,
 });
 
-vi.mock('firebase/auth', () => ({
-  onAuthStateChanged: (...args: unknown[]) => mocks.mockOnAuthStateChanged(...args),
-}));
-
-vi.mock('../services/firebase', () => ({
-  auth: mocks.mockAuth,
+vi.mock('../contexts/useAuth', () => ({
+  useAuth: () => mocks.mockUseAuth(),
 }));
 
 vi.mock('../services/analysisService', () => ({
@@ -79,17 +68,16 @@ vi.mock('../services/analysisService', () => ({
 }));
 
 describe('useAnalysisEntry', () => {
+  let authState = { authReady: true, sessionId: 1, uid: 'user-1' as string | null };
+
   beforeEach(() => {
-    mocks.mockAuth.currentUser = { uid: 'user-1' };
+    authState = { authReady: true, sessionId: 1, uid: 'user-1' };
     mocks.mockDeleteAnalysisEntry.mockReset();
     mocks.mockFindAnalysisEntryByHandLog.mockReset();
     mocks.mockGetAnalysisEntry.mockReset();
     mocks.mockSaveAnalysisEntry.mockReset();
-    mocks.mockOnAuthStateChanged.mockReset();
-    mocks.mockOnAuthStateChanged.mockImplementation((_auth, callback) => {
-      authStateCallback = callback;
-      callback(mocks.mockAuth.currentUser);
-      return vi.fn();
+    mocks.mockUseAuth.mockImplementation(() => {
+      return authState;
     });
   });
 
@@ -305,7 +293,7 @@ describe('useAnalysisEntry', () => {
     const entry = createAnalysisEntry();
     mocks.mockGetAnalysisEntry.mockResolvedValue(entry);
 
-    const { result } = renderHook(() => useAnalysisEntry({ entryId: 'entry-1' }));
+    const { result, rerender } = renderHook(() => useAnalysisEntry({ entryId: 'entry-1' }));
 
     await waitFor(() => {
       expect(result.current.analysisEntry).toEqual(entry);
@@ -318,7 +306,8 @@ describe('useAnalysisEntry', () => {
       });
     });
 
-    authStateCallback?.(null);
+    authState = { authReady: true, sessionId: 2, uid: null };
+    rerender();
 
     await waitFor(() => {
       expect(result.current.uid).toBeNull();
@@ -342,23 +331,21 @@ describe('useAnalysisEntry', () => {
         }),
     );
 
-    const { result } = renderHook(() => useAnalysisEntry({ entryId: 'entry-1' }));
+    const { result, rerender } = renderHook(() => useAnalysisEntry({ entryId: 'entry-1' }));
 
     await waitFor(() => {
       expect(result.current.analysisEntry).toEqual(firstEntry);
     });
 
-    act(() => {
-      authStateCallback?.(null);
-    });
+    authState = { authReady: true, sessionId: 2, uid: null };
+    rerender();
 
     await waitFor(() => {
       expect(result.current.uid).toBeNull();
     });
 
-    act(() => {
-      authStateCallback?.({ uid: 'user-1' });
-    });
+    authState = { authReady: true, sessionId: 3, uid: 'user-1' };
+    rerender();
 
     expect(result.current.loading).toBe(true);
     expect(result.current.analysisEntry).toBeNull();

--- a/src/hooks/useAnalysisEntry.ts
+++ b/src/hooks/useAnalysisEntry.ts
@@ -1,12 +1,11 @@
-import { onAuthStateChanged } from 'firebase/auth';
 import { useEffect, useMemo, useState } from 'react';
+import { useAuth } from '../contexts/useAuth';
 import {
   deleteAnalysisEntry as removeAnalysisEntry,
   findAnalysisEntryByHandLog,
   getAnalysisEntry,
   saveAnalysisEntry as persistAnalysisEntry,
 } from '../services/analysisService';
-import { auth } from '../services/firebase';
 import type { AnalysisEntry, AnalysisSource } from '../types/analysis';
 
 interface UseAnalysisEntryOptions {
@@ -85,27 +84,14 @@ export const useAnalysisEntry = ({
   const sourceKey = getSourceKey(source);
   const targetKey = entryId ?? sourceKey;
   const stableSource = useMemo(() => getSourceFromKey(sourceKey), [sourceKey]);
-  const [uid, setUid] = useState<string | null>(auth.currentUser?.uid ?? null);
-  const [authReady, setAuthReady] = useState(false);
-  const [authGeneration, setAuthGeneration] = useState(0);
+  const { authReady, sessionId, uid } = useAuth();
   const [analysisEntry, setAnalysisEntry] = useState<AnalysisEntry | null>(null);
   const [draftAnalysisEntry, setDraftAnalysisEntry] = useState<AnalysisEntry | null>(null);
   const [loadedTargetKey, setLoadedTargetKey] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
 
-  useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (user) => {
-      setUid(user?.uid ?? null);
-      setAuthGeneration((current) => current + 1);
-      setAuthReady(true);
-    });
-
-    return () => unsubscribe();
-  }, []);
-
-  const activeTargetKey =
-    authReady && uid && targetKey ? `${authGeneration}:${uid}:${targetKey}` : null;
+  const activeTargetKey = authReady && uid && targetKey ? `${sessionId}:${uid}:${targetKey}` : null;
   const loading = !authReady
     ? Boolean(targetKey)
     : activeTargetKey !== null && loadedTargetKey !== activeTargetKey;

--- a/src/hooks/useCompetitionMatch.ts
+++ b/src/hooks/useCompetitionMatch.ts
@@ -1,11 +1,11 @@
 import { useCallback, useMemo } from 'react';
+import { useAuth } from '../contexts/useAuth';
 import {
   dissolveTable as dissolveTableService,
   saveCompetitionGameResult,
   startNextTableMatch,
   startTableMatch,
 } from '../services/competitionService';
-import { auth } from '../services/firebase';
 import { createRoom } from '../services/roomService';
 import type {
   CompetitionParticipant,
@@ -45,6 +45,7 @@ export const useCompetitionMatch = (
   competitionId: string,
   tableId: string,
 ): UseCompetitionMatchReturn => {
+  const { currentUser, uid } = useAuth();
   const { competition, participants, tables, loading: compLoading } = useCompetition(competitionId);
 
   const table = useMemo(() => tables.find((t) => t.id === tableId), [tables, tableId]);
@@ -58,10 +59,9 @@ export const useCompetitionMatch = (
   );
 
   const canManage = useMemo(() => {
-    const uid = auth.currentUser?.uid;
     if (!uid || !competition) return false;
     return competition.organizerId === uid || competition.coOrganizerIds.includes(uid);
-  }, [competition]);
+  }, [competition, uid]);
 
   const gameSettings = useMemo(() => {
     if (!competition || !table) return null;
@@ -80,7 +80,7 @@ export const useCompetitionMatch = (
 
   const startMatch = useCallback(async () => {
     if (!competition || !table || !gameSettings) return;
-    const currentUid = auth.currentUser?.uid;
+    const currentUid = currentUser?.uid;
     if (!currentUid) return;
 
     const seatAssignment = table.seatAssignment ?? {};
@@ -99,7 +99,7 @@ export const useCompetitionMatch = (
       extraPlayerIds: [currentUid],
     });
     await startTableMatch(competitionId, tableId, newRoomId, table.playerIds);
-  }, [competition, table, gameSettings, tableParticipants, competitionId, tableId]);
+  }, [competition, table, gameSettings, tableParticipants, competitionId, tableId, currentUser]);
 
   const saveResult = useCallback(
     async (gameResult: GameResult) => {
@@ -142,7 +142,7 @@ export const useCompetitionMatch = (
             wind: windOrder[idx] || 'North',
           }));
 
-      const currentUid = auth.currentUser?.uid;
+      const currentUid = currentUser?.uid;
       const newRoomId = generateId(8);
       await createRoom(newRoomId, basePlayers, gameSettings, undefined, {
         competitionId,
@@ -153,7 +153,7 @@ export const useCompetitionMatch = (
       });
       await startNextTableMatch(competitionId, tableId, newRoomId, (table.gameCount || 0) + 1);
     },
-    [room, gameSettings, table, competitionId, tableId],
+    [room, gameSettings, table, competitionId, tableId, currentUser],
   );
 
   const dissolveTable = useCallback(async () => {

--- a/src/hooks/useCompetitions.ts
+++ b/src/hooks/useCompetitions.ts
@@ -1,28 +1,28 @@
 import { useEffect, useState } from 'react';
-import { onAuthStateChanged } from 'firebase/auth';
+import { useAuth } from '../contexts/useAuth';
 import { getUserCompetitions } from '../services/competitionService';
-import { auth } from '../services/firebase';
 import type { Competition } from '../types';
 
 export const useCompetitions = () => {
+  const { authReady, uid } = useAuth();
   const [competitions, setCompetitions] = useState<Competition[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [loadedUid, setLoadedUid] = useState<string | null>(null);
 
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (user) => {
-      if (!user) {
-        setLoading(false);
-        return;
-      }
-      getUserCompetitions(user.uid)
-        .then((data) => {
-          setCompetitions(data);
-          setLoading(false);
-        })
-        .catch(() => setLoading(false));
-    });
-    return () => unsubscribe();
-  }, []);
+    if (!authReady || !uid) {
+      return;
+    }
 
-  return { competitions, loading };
+    getUserCompetitions(uid)
+      .then((data) => {
+        setCompetitions(data);
+        setLoadedUid(uid);
+      })
+      .catch(() => setLoadedUid(uid));
+  }, [authReady, uid]);
+
+  return {
+    competitions: uid && loadedUid === uid ? competitions : [],
+    loading: authReady && uid !== null && loadedUid !== uid,
+  };
 };

--- a/src/hooks/useDashboardStats.ts
+++ b/src/hooks/useDashboardStats.ts
@@ -1,0 +1,133 @@
+import { useMemo } from 'react';
+import type { GameResult, HandLog } from '../types';
+import { useAuth } from '../contexts/useAuth';
+import { useRoomHistory } from './useRoomHistory';
+
+export interface DashboardStats {
+  periodGames: number;
+  totalGames: number;
+  averageRank: number;
+  rankHistory: { rank: number; date: number }[];
+  validHands: number;
+  winCount: number;
+  dealInCount: number;
+  riichiCount: number;
+  totalWinPoints: number;
+  totalDealInPoints: number;
+  winsAfterRiichi: number;
+  dealInsAfterRiichi: number;
+}
+
+const EMPTY_STATS: DashboardStats = {
+  periodGames: 0,
+  totalGames: 0,
+  averageRank: 0,
+  rankHistory: [],
+  validHands: 0,
+  winCount: 0,
+  dealInCount: 0,
+  riichiCount: 0,
+  totalWinPoints: 0,
+  totalDealInPoints: 0,
+  winsAfterRiichi: 0,
+  dealInsAfterRiichi: 0,
+};
+
+export const useDashboardStats = () => {
+  const { uid } = useAuth();
+  const { rooms, loading, error } = useRoomHistory();
+
+  const stats = useMemo<DashboardStats | null>(() => {
+    if (!uid) {
+      return null;
+    }
+
+    let totalGames = 0;
+    let totalRank = 0;
+    const rankHistory: { rank: number; date: number }[] = [];
+
+    let validHands = 0;
+    let winCount = 0;
+    let dealInCount = 0;
+    let riichiCount = 0;
+    let totalWinPoints = 0;
+    let totalDealInPoints = 0;
+    let winsAfterRiichi = 0;
+    let dealInsAfterRiichi = 0;
+
+    const allGames: GameResult[] = rooms.flatMap((room) => room.gameResults ?? []);
+    allGames.sort((left, right) => right.timestamp - left.timestamp);
+
+    allGames.forEach((game) => {
+      totalGames += 1;
+      const myResult = game.scores.find((score) => score.playerId === uid);
+      if (myResult) {
+        totalRank += myResult.rank;
+        rankHistory.push({
+          rank: myResult.rank,
+          date: game.timestamp,
+        });
+      }
+
+      (game.logs ?? []).forEach((log: HandLog) => {
+        const result = log.result;
+        if (result.type === 'Adjustment') {
+          return;
+        }
+
+        validHands += 1;
+        const scoreDelta = result.scoreDeltas[uid] || 0;
+        const riichiIds = result.riichiPlayerIds || [];
+        const didRiichi = riichiIds.includes(uid);
+
+        if (didRiichi) {
+          riichiCount += 1;
+        }
+
+        if (result.type === 'Win') {
+          const isWinner = result.winners?.some((winner) => winner.id === uid);
+          const isLoser = result.loserId === uid;
+
+          if (isWinner) {
+            winCount += 1;
+            if (scoreDelta > 0) {
+              totalWinPoints += scoreDelta;
+            }
+            if (didRiichi) {
+              winsAfterRiichi += 1;
+            }
+          }
+
+          if (isLoser) {
+            dealInCount += 1;
+            totalDealInPoints += Math.abs(scoreDelta);
+            if (didRiichi) {
+              dealInsAfterRiichi += 1;
+            }
+          }
+        }
+      });
+    });
+
+    return {
+      periodGames: totalGames,
+      totalGames,
+      averageRank: totalGames > 0 ? totalRank / totalGames : 0,
+      rankHistory,
+      validHands,
+      winCount,
+      dealInCount,
+      riichiCount,
+      totalWinPoints,
+      totalDealInPoints,
+      winsAfterRiichi,
+      dealInsAfterRiichi,
+    };
+  }, [rooms, uid]);
+
+  return {
+    stats: uid ? (stats ?? EMPTY_STATS) : null,
+    loading,
+    error,
+  };
+};

--- a/src/hooks/useMatchGame.ts
+++ b/src/hooks/useMatchGame.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { getRoomSnapshot } from '../services/roomService';
 import type { GameResult, HandLog, Player, RoomState, ScorePayment } from '../types';
 import { type AdjustmentParams, applyAdjustment } from '../utils/adjustment';
 import { processHandEnd } from '../utils/gameLogic';
@@ -153,9 +154,7 @@ export const useMatchGame = ({ room, updateState }: UseMatchGameOptions): UseMat
     ) => {
       if (!room) return null;
 
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { history: _h, ...currentStateSnapshot } = room;
-      const newHistory = [...(room.history || []), currentStateSnapshot];
+      const newHistory = [...(room.history || []), getRoomSnapshot(room)];
 
       const { players, round } = room;
       const playerIds = players.map((p) => p.id);
@@ -310,9 +309,7 @@ export const useMatchGame = ({ room, updateState }: UseMatchGameOptions): UseMat
     async (tenpaiIds: string[]) => {
       if (!room) return null;
 
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { history: _h, ...currentStateSnapshot } = room;
-      const newHistory = [...(room.history || []), currentStateSnapshot];
+      const newHistory = [...(room.history || []), getRoomSnapshot(room)];
 
       const mode = room.settings.mode || '4ma';
       const notenIds = room.players.filter((p) => !tenpaiIds.includes(p.id)).map((p) => p.id);
@@ -405,9 +402,7 @@ export const useMatchGame = ({ room, updateState }: UseMatchGameOptions): UseMat
   const handleRiichi = useCallback(
     async (playerId: string) => {
       if (!room) return;
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { history: _h, ...snapshot } = room;
-      const newHistory = [...(room.history || []), snapshot];
+      const newHistory = [...(room.history || []), getRoomSnapshot(room)];
       const newPlayers = room.players.map((p) =>
         p.id === playerId ? { ...p, score: p.score - 1000, isRiichi: true } : p,
       );
@@ -425,9 +420,7 @@ export const useMatchGame = ({ room, updateState }: UseMatchGameOptions): UseMat
   const handleAdjustment = useCallback(
     async (params: AdjustmentParams) => {
       if (!room) return;
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { history: _h, ...snapshot } = room;
-      const newHistory = [...(room.history || []), snapshot];
+      const newHistory = [...(room.history || []), getRoomSnapshot(room)];
 
       const { newPlayers, handLog, scoreDeltas } = applyAdjustment(
         room.players,

--- a/src/hooks/useRoomHistory.ts
+++ b/src/hooks/useRoomHistory.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+import { useAuth } from '../contexts/useAuth';
+import { getUserRoomHistory } from '../services/roomService';
+import type { RoomState } from '../types';
+
+export const useRoomHistory = () => {
+  const { authReady, uid } = useAuth();
+  const [rooms, setRooms] = useState<RoomState[]>([]);
+  const [loadedUid, setLoadedUid] = useState<string | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+  const [errorUid, setErrorUid] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!authReady || !uid) {
+      return;
+    }
+
+    getUserRoomHistory(uid)
+      .then((history) => {
+        setRooms(history);
+        setLoadedUid(uid);
+        setError(null);
+        setErrorUid(uid);
+      })
+      .catch((nextError) => {
+        setError(nextError instanceof Error ? nextError : new Error(String(nextError)));
+        setLoadedUid(uid);
+        setErrorUid(uid);
+      });
+  }, [authReady, uid]);
+
+  return {
+    rooms: uid && loadedUid === uid ? rooms : [],
+    loading: authReady && uid !== null && loadedUid !== uid,
+    error: uid && errorUid === uid ? error : null,
+  };
+};

--- a/src/hooks/useUserSettings.test.ts
+++ b/src/hooks/useUserSettings.test.ts
@@ -7,7 +7,7 @@ import { useUserSettings } from './useUserSettings';
 
 const mockSubscribeToUserSettings = vi.fn();
 const mockSaveUserSettings = vi.fn();
-const mockOnAuthStateChanged = vi.fn();
+const mockUseAuth = vi.fn();
 
 const createUserSettings = (overrides: Partial<UserSettings> = {}): UserSettings => ({
   displayName: '',
@@ -65,16 +65,8 @@ const createUserSettings = (overrides: Partial<UserSettings> = {}): UserSettings
   ...overrides,
 });
 
-vi.mock('firebase/auth', () => ({
-  onAuthStateChanged: (...args: unknown[]) => mockOnAuthStateChanged(...args),
-}));
-
-vi.mock('../services/firebase', () => ({
-  auth: {
-    currentUser: {
-      uid: 'user-1',
-    },
-  },
+vi.mock('../contexts/useAuth', () => ({
+  useAuth: () => mockUseAuth(),
 }));
 
 vi.mock('../services/userSettingsService', () => ({
@@ -83,17 +75,15 @@ vi.mock('../services/userSettingsService', () => ({
 }));
 
 describe('useUserSettings', () => {
-  let authStateCallback: ((user: { uid: string } | null) => void) | null = null;
+  let authState = { authReady: true, sessionId: 1, uid: 'user-1' as string | null };
 
   beforeEach(() => {
     localStorage.clear();
     mockSaveUserSettings.mockReset();
     mockSubscribeToUserSettings.mockReset();
-    mockOnAuthStateChanged.mockReset();
-    mockOnAuthStateChanged.mockImplementation((_auth, callback) => {
-      authStateCallback = callback;
-      callback({ uid: 'user-1' });
-      return vi.fn();
+    authState = { authReady: true, sessionId: 1, uid: 'user-1' };
+    mockUseAuth.mockImplementation(() => {
+      return authState;
     });
   });
 
@@ -178,15 +168,14 @@ describe('useUserSettings', () => {
       return vi.fn();
     });
 
-    const { result } = renderHook(() => useUserSettings());
+    const { result, rerender } = renderHook(() => useUserSettings());
 
     await waitFor(() => {
       expect(result.current.userSettings.displayName).toBe('初回設定');
     });
 
-    act(() => {
-      authStateCallback?.(null);
-    });
+    authState = { authReady: true, sessionId: 2, uid: null };
+    rerender();
 
     await waitFor(() => {
       expect(result.current.uid).toBeNull();
@@ -197,9 +186,8 @@ describe('useUserSettings', () => {
       return vi.fn();
     });
 
-    act(() => {
-      authStateCallback?.({ uid: 'user-1' });
-    });
+    authState = { authReady: true, sessionId: 3, uid: 'user-1' };
+    rerender();
 
     expect(result.current.loading).toBe(true);
     expect(result.current.userSettings.displayName).toBe('初回設定');

--- a/src/hooks/useUserSettings.ts
+++ b/src/hooks/useUserSettings.ts
@@ -1,7 +1,6 @@
-import { onAuthStateChanged } from 'firebase/auth';
 import { useEffect, useState, type Dispatch, type SetStateAction } from 'react';
+import { useAuth } from '../contexts/useAuth';
 import type { UserSettings } from '../types';
-import { auth } from '../services/firebase';
 import {
   saveUserSettings as persistUserSettings,
   subscribeToUserSettings,
@@ -24,24 +23,12 @@ interface UseUserSettingsResult {
 
 export const useUserSettings = (): UseUserSettingsResult => {
   const defaultSettings = createDefaultUserSettings();
-  const [uid, setUid] = useState<string | null>(auth.currentUser?.uid ?? null);
-  const [authReady, setAuthReady] = useState(false);
-  const [authGeneration, setAuthGeneration] = useState(0);
+  const { authReady, sessionId, uid } = useAuth();
   const [userSettings, setUserSettings] = useState<UserSettings>(() => defaultSettings);
-  const [loadedSettingsKey, setLoadedSettingsKey] = useState<string | null>(null);
+  const [loadedSettingsKey, setLoadedSettingsKey] = useState<string | null>(uid);
   const [saving, setSaving] = useState(false);
 
-  useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (user) => {
-      setUid(user?.uid ?? null);
-      setAuthGeneration((current) => current + 1);
-      setAuthReady(true);
-    });
-
-    return () => unsubscribe();
-  }, []);
-
-  const activeSettingsKey = authReady && uid ? `${authGeneration}:${uid}` : null;
+  const activeSettingsKey = authReady && uid ? `${sessionId}:${uid}` : null;
 
   useEffect(() => {
     if (!uid || !activeSettingsKey) {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,12 +3,15 @@ import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './visuals/global.css';
 
+import { AuthProvider } from './contexts/AuthContext';
 import { SnackbarProvider } from './contexts/SnackbarContext';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <SnackbarProvider>
-      <App />
+      <AuthProvider>
+        <App />
+      </AuthProvider>
     </SnackbarProvider>
   </StrictMode>,
 );

--- a/src/pages/CompetitionDashboardPage.tsx
+++ b/src/pages/CompetitionDashboardPage.tsx
@@ -10,6 +10,7 @@ import { TableDetailModal } from '../components/features/TableDetailModal';
 import { TableList } from '../components/features/TableList';
 import { Button } from '../components/ui/Button';
 import { ConfirmationDialog } from '../components/ui/ConfirmationDialog';
+import { useAuth } from '../contexts/useAuth';
 import { useSnackbar } from '../contexts/SnackbarContext';
 import { useCompetition } from '../hooks/useCompetition';
 import {
@@ -20,7 +21,6 @@ import {
   removeParticipant,
   updateCompetition,
 } from '../services/competitionService';
-import { auth } from '../services/firebase';
 import type { CompetitionParticipant, CompetitionSettings, CompetitionStatus } from '../types';
 import { generateId } from '../utils/id';
 import { formatUmaDisplay } from '../utils/uma';
@@ -42,6 +42,7 @@ const STATUS_CONFIRM_MESSAGES: Partial<Record<CompetitionStatus, string>> = {
 };
 
 export const CompetitionDashboardPage = () => {
+  const { uid: currentUserId } = useAuth();
   const { id } = useParams<{ id: string }>();
   const { competition, participants, tables, loading } = useCompetition(id || '');
   const { showSnackbar } = useSnackbar();
@@ -55,7 +56,6 @@ export const CompetitionDashboardPage = () => {
   const [isCreateTableOpen, setIsCreateTableOpen] = useState(false);
   const [selectedTableId, setSelectedTableId] = useState<string | null>(null);
 
-  const currentUserId = auth.currentUser?.uid;
   const isOrganizer = competition?.organizerId === currentUserId;
   const isCoOrganizer = competition?.coOrganizerIds.includes(currentUserId ?? '') ?? false;
   const canManage = isOrganizer || isCoOrganizer;
@@ -263,7 +263,7 @@ export const CompetitionDashboardPage = () => {
         </div>
         <ParticipantList
           participants={participants}
-          currentUserId={currentUserId}
+          currentUserId={currentUserId ?? undefined}
           isOrganizer={isOrganizer}
           onAppointCoOrganizer={handleAppointCoOrganizer}
           onRemoveCoOrganizer={handleRemoveCoOrganizer}

--- a/src/pages/CompetitionJoinPage.tsx
+++ b/src/pages/CompetitionJoinPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { CompetitionStatusBadge } from '../components/features/CompetitionStatusBadge';
 import { Button } from '../components/ui/Button';
 import { Input } from '../components/ui/Input';
+import { useAuth } from '../contexts/useAuth';
 import { useSnackbar } from '../contexts/SnackbarContext';
 import {
   addParticipant,
@@ -10,10 +11,10 @@ import {
   subscribeToCompetition,
   verifyPasscode,
 } from '../services/competitionService';
-import { auth } from '../services/firebase';
 import type { Competition } from '../types';
 
 export const CompetitionJoinPage = () => {
+  const { currentUser } = useAuth();
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const { showSnackbar } = useSnackbar();
@@ -49,7 +50,6 @@ export const CompetitionJoinPage = () => {
 
   const handleJoin = async () => {
     if (!id || !competition) return;
-    const currentUser = auth.currentUser;
     if (!currentUser) {
       showSnackbar('認証エラーが発生しました。リロードしてください。', { position: 'top' });
       return;

--- a/src/pages/CompetitionNewPage.test.tsx
+++ b/src/pages/CompetitionNewPage.test.tsx
@@ -12,6 +12,7 @@ const mockAddParticipant = vi.fn();
 const mockGenerateId = vi.fn(() => 'comp-1234567890');
 const mockHashPasscode = vi.fn();
 const mockUseUserSettings = vi.fn();
+const mockUseAuth = vi.fn();
 
 const createUserSettings = (overrides: Partial<UserSettings> = {}): UserSettings => ({
   displayName: '',
@@ -81,13 +82,8 @@ vi.mock('../services/competitionService', () => ({
   addParticipant: (...args: unknown[]) => mockAddParticipant(...args),
 }));
 
-vi.mock('../services/firebase', () => ({
-  auth: {
-    currentUser: {
-      uid: 'user-1',
-      isAnonymous: false,
-    },
-  },
+vi.mock('../contexts/useAuth', () => ({
+  useAuth: () => mockUseAuth(),
 }));
 
 vi.mock('../hooks/useUserSettings', () => ({
@@ -110,6 +106,12 @@ beforeEach(() => {
   mockAddParticipant.mockReset();
   mockHashPasscode.mockReset();
   mockHashPasscode.mockResolvedValue('hashed-passcode');
+  mockUseAuth.mockReturnValue({
+    currentUser: {
+      uid: 'user-1',
+      isAnonymous: false,
+    },
+  });
   mockUseUserSettings.mockReturnValue({
     userSettings: createUserSettings(),
     loading: false,

--- a/src/pages/CompetitionNewPage.tsx
+++ b/src/pages/CompetitionNewPage.tsx
@@ -1,16 +1,17 @@
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { CompetitionForm } from '../components/features/CompetitionForm';
+import { useAuth } from '../contexts/useAuth';
 import { useSnackbar } from '../contexts/SnackbarContext';
 import { useUserSettings } from '../hooks/useUserSettings';
 import { addParticipant, createCompetition } from '../services/competitionService';
-import { auth } from '../services/firebase';
 import type { CompetitionSettings } from '../types';
 import { hashPasscode } from '../utils/hash';
 import { generateId } from '../utils/id';
 import { writeStoredPlayerName } from '../utils/userSettings';
 
 export const CompetitionNewPage = () => {
+  const { currentUser } = useAuth();
   const navigate = useNavigate();
   const { showSnackbar } = useSnackbar();
   const { userSettings, loading: userSettingsLoading } = useUserSettings();
@@ -26,7 +27,6 @@ export const CompetitionNewPage = () => {
     organizerDisplayName: string;
     settings: CompetitionSettings;
   }) => {
-    const currentUser = auth.currentUser;
     if (!currentUser) {
       showSnackbar('認証エラーが発生しました。リロードしてください。', { position: 'top' });
       return;

--- a/src/pages/CompetitionTablePage.tsx
+++ b/src/pages/CompetitionTablePage.tsx
@@ -30,12 +30,12 @@ import { SoundEffectToggle } from '../components/features/SoundEffectToggle';
 import { Button } from '../components/ui/Button';
 import { ConfirmationDialog } from '../components/ui/ConfirmationDialog';
 import { Modal } from '../components/ui/Modal';
+import { useAuth } from '../contexts/useAuth';
 import { useSnackbar } from '../contexts/SnackbarContext';
 import { useAnalysisEntries } from '../hooks/useAnalysisEntries';
 import { useCompetitionMatch } from '../hooks/useCompetitionMatch';
 import { useMatchGame } from '../hooks/useMatchGame';
 import { useRoomSoundEffects } from '../hooks/useRoomSoundEffects';
-import { auth } from '../services/firebase';
 import { getAnalysisEventType } from '../utils/analysis';
 import { buildRoomAnalysisEvents } from '../utils/analysisEvents';
 import { getWinnerIdSetFromLogs } from '../utils/resultCalculator';
@@ -93,6 +93,7 @@ const SortableSeatItem = ({ pid, name, windLabel }: SortableSeatItemProps) => {
 };
 
 export const CompetitionTablePage = () => {
+  const { uid: myPlayerId } = useAuth();
   const { id: competitionId, tableId } = useParams<{ id: string; tableId: string }>();
   const navigate = useNavigate();
   const { showSnackbar } = useSnackbar();
@@ -115,8 +116,6 @@ export const CompetitionTablePage = () => {
 
   const matchGame = useMatchGame({ room, updateState });
   const { isSoundEnabled, setIsSoundEnabled } = useRoomSoundEffects(room?.lastEvent);
-
-  const myPlayerId = auth.currentUser?.uid || '';
 
   // Scoring modal state
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -144,7 +143,7 @@ export const CompetitionTablePage = () => {
       return [];
     }
 
-    return buildRoomAnalysisEvents(room, myPlayerId);
+    return buildRoomAnalysisEvents(room, myPlayerId ?? '');
   }, [myPlayerId, room]);
 
   const yakitoriPlayerIds = useMemo(() => {
@@ -163,7 +162,7 @@ export const CompetitionTablePage = () => {
 
   const promptAnalysisForHand = useCallback(
     (selection: AnalysisModalSelection) => {
-      if (!getAnalysisEventType(selection.handLog, myPlayerId)) {
+      if (!getAnalysisEventType(selection.handLog, myPlayerId ?? '')) {
         return;
       }
 
@@ -348,7 +347,7 @@ export const CompetitionTablePage = () => {
           players={room.players}
           round={room.round}
           lastEvent={room.lastEvent}
-          currentUserId={myPlayerId}
+          currentUserId={myPlayerId ?? undefined}
           onPlayerClick={handlePlayerClick}
           onRiichi={matchGame.handleRiichi}
           onCenterClick={handleCenterClick}
@@ -383,7 +382,7 @@ export const CompetitionTablePage = () => {
           onClose={() => setIsModalOpen(false)}
           players={room.players}
           dealerId={currentDealer?.id || room.players[0]?.id || ''}
-          currentUserId={myPlayerId}
+          currentUserId={myPlayerId ?? undefined}
           initialWinnerId={selectedWinnerId || room.players[0]?.id}
           initialWinType={initialWinType}
           settings={room.settings}

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -9,151 +9,29 @@ import {
   Tooltip,
   type TooltipItem,
 } from 'chart.js';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { Line } from 'react-chartjs-2';
 import { useNavigate } from 'react-router-dom';
 import { DashboardSkeleton } from '../components/skeletons/DashboardSkeleton';
 import { Button } from '../components/ui/Button';
 import { useSnackbar } from '../contexts/SnackbarContext';
-import { auth } from '../services/firebase';
-import { getUserRoomHistory } from '../services/roomService';
-import type { GameResult, HandLog } from '../types';
+import { useDashboardStats } from '../hooks/useDashboardStats';
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend);
-
-interface Stats {
-  periodGames: number;
-  totalGames: number;
-  averageRank: number;
-  rankHistory: { rank: number; date: number }[];
-
-  // Extended Stats (Valid if logs exist)
-  validHands: number;
-  winCount: number;
-  dealInCount: number;
-  riichiCount: number;
-
-  totalWinPoints: number;
-  totalDealInPoints: number;
-
-  winsAfterRiichi: number;
-  dealInsAfterRiichi: number;
-}
 
 export const DashboardPage = () => {
   const navigate = useNavigate();
   const { showSnackbar } = useSnackbar();
-  const [loading, setLoading] = useState(true);
-  const [stats, setStats] = useState<Stats | null>(null);
+  const { stats, loading, error } = useDashboardStats();
 
-  // Re-write of the useEffect logic to be correct
   useEffect(() => {
-    const fetchStats = async () => {
-      const user = auth.currentUser;
-      if (!user) {
-        setLoading(false);
-        return;
-      }
+    if (!error) {
+      return;
+    }
 
-      try {
-        const rooms = await getUserRoomHistory(user.uid);
-        const myId = user.uid;
-
-        let totalGames = 0;
-        let totalRank = 0;
-        const rankHistory: { rank: number; date: number }[] = [];
-
-        let validHands = 0;
-        let winCount = 0;
-        let dealInCount = 0;
-        let riichiCount = 0;
-
-        let totalWinPoints = 0;
-        let totalDealInPoints = 0;
-
-        let winsAfterRiichi = 0;
-        let dealInsAfterRiichi = 0;
-
-        // Collect all games first to sort them
-        const allGames: { game: GameResult; roomId: string }[] = [];
-        rooms.forEach((room) => {
-          if (room.gameResults) {
-            room.gameResults.forEach((game) => {
-              allGames.push({ game, roomId: room.id });
-            });
-          }
-        });
-
-        // Sort by timestamp descending (Newest first, so Newest is on Left of chart)
-        allGames.sort((a, b) => b.game.timestamp - a.game.timestamp);
-
-        allGames.forEach(({ game }) => {
-          totalGames++;
-          const myResult = game.scores.find((s) => s.playerId === myId);
-          if (myResult) {
-            totalRank += myResult.rank;
-            rankHistory.push({
-              rank: myResult.rank,
-              date: game.timestamp,
-            });
-          }
-
-          if (game.logs) {
-            game.logs.forEach((log: HandLog) => {
-              const result = log.result;
-              if (result.type === 'Adjustment') return;
-              validHands++;
-              const scoreDelta = result.scoreDeltas[myId] || 0;
-              const riichiIds = result.riichiPlayerIds || [];
-              const didRiichi = riichiIds.includes(myId);
-
-              if (didRiichi) {
-                riichiCount++;
-              }
-
-              if (result.type === 'Win') {
-                const isWinner = result.winners?.some((w) => w.id === myId);
-                const isLoser = result.loserId === myId;
-
-                if (isWinner) {
-                  winCount++;
-                  if (scoreDelta > 0) totalWinPoints += scoreDelta;
-                  if (didRiichi) winsAfterRiichi++;
-                }
-
-                if (isLoser) {
-                  dealInCount++;
-                  totalDealInPoints += Math.abs(scoreDelta);
-                  if (didRiichi) dealInsAfterRiichi++;
-                }
-              }
-            });
-          }
-        });
-
-        setStats({
-          periodGames: totalGames,
-          totalGames,
-          averageRank: totalGames > 0 ? totalRank / totalGames : 0,
-          rankHistory,
-          validHands,
-          winCount,
-          dealInCount,
-          riichiCount,
-          totalWinPoints,
-          totalDealInPoints,
-          winsAfterRiichi,
-          dealInsAfterRiichi,
-        });
-      } catch (err) {
-        console.error(err);
-        showSnackbar('Failed to load stats');
-      } finally {
-        setLoading(false);
-      }
-    };
-    fetchStats();
-  }, [showSnackbar]);
+    console.error(error);
+    showSnackbar('Failed to load stats');
+  }, [error, showSnackbar]);
 
   if (loading) return <DashboardSkeleton />;
   if (!stats) return <div>No data</div>;

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -1,43 +1,24 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { HistorySkeleton } from '../components/skeletons/HistorySkeleton';
 import { Button } from '../components/ui/Button';
 import { useSnackbar } from '../contexts/SnackbarContext';
-import { auth } from '../services/firebase';
-import { getUserRoomHistory } from '../services/roomService';
-import type { RoomState } from '../types';
+import { useRoomHistory } from '../hooks/useRoomHistory';
 import { canResumeRoomFromHistory } from '../utils/historyRoomStatus';
 
 export const HistoryPage = () => {
   const navigate = useNavigate();
   const { showSnackbar } = useSnackbar();
-  const [rooms, setRooms] = useState<RoomState[]>([]);
-  const [loading, setLoading] = useState(true);
+  const { rooms, loading, error } = useRoomHistory();
 
   useEffect(() => {
-    const fetchHistory = async () => {
-      const user = auth.currentUser;
-      if (!user) {
-        setLoading(false);
-        return;
-      }
+    if (!error) {
+      return;
+    }
 
-      try {
-        const history = await getUserRoomHistory(user.uid);
-        // Sort by likely recency (if we had timestamp, but we'll trust generic order for MVP or simple reverse)
-        // Actually history return from roomService is just array.
-        // We'll reverse it assuming append order or just display as is.
-        setRooms(history);
-      } catch (err) {
-        console.error(err);
-        showSnackbar('Failed to load history');
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchHistory();
-  }, [showSnackbar]);
+    console.error(error);
+    showSnackbar('Failed to load history');
+  }, [error, showSnackbar]);
 
   if (loading) return <HistorySkeleton />;
 

--- a/src/pages/MatchPage.tsx
+++ b/src/pages/MatchPage.tsx
@@ -18,12 +18,12 @@ import { Button } from '../components/ui/Button';
 import { ConfirmationDialog } from '../components/ui/ConfirmationDialog';
 import { Input } from '../components/ui/Input';
 import { Modal } from '../components/ui/Modal';
+import { useAuth } from '../contexts/useAuth';
 import { useSnackbar } from '../contexts/SnackbarContext';
 import { useAnalysisEntries } from '../hooks/useAnalysisEntries';
 import { useMatchGame } from '../hooks/useMatchGame';
 import { useRoom } from '../hooks/useRoom';
 import { useRoomSoundEffects } from '../hooks/useRoomSoundEffects';
-import { auth } from '../services/firebase';
 import type { HandLog, Player, ScorePayment } from '../types';
 import type { AdjustmentParams } from '../utils/adjustment';
 import { getAnalysisEventType } from '../utils/analysis';
@@ -32,15 +32,14 @@ import { isReadOnlyFinishedCompetitionRoom } from '../utils/historyRoomStatus';
 import { getWinnerIdSetFromLogs } from '../utils/resultCalculator';
 
 export const MatchPage = () => {
+  const { uid } = useAuth();
   const { roomId } = useParams<{ roomId: string }>();
   const navigate = useNavigate();
   const { showSnackbar } = useSnackbar();
   const { room, loading, join, updateState } = useRoom(roomId || '');
 
   // Local user ID (Auth)
-  const [myPlayerId] = useState<string>(() => {
-    return auth.currentUser?.uid || '';
-  });
+  const [myPlayerId] = useState<string>(() => uid || '');
   const [joinName, setJoinName] = useState(() => localStorage.getItem('mahjong_player_name') || '');
   const [isJoinModalOpen, setIsJoinModalOpen] = useState(false);
 

--- a/src/pages/TopPage.tsx
+++ b/src/pages/TopPage.tsx
@@ -1,19 +1,19 @@
-import { onAuthStateChanged, signOut, type User } from 'firebase/auth';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { CreateRoomModal } from '../components/CreateRoomModal';
 import { AuthModal } from '../components/features/AuthModal';
 import { Button } from '../components/ui/Button';
 import { Input } from '../components/ui/Input';
+import { useAuth } from '../contexts/useAuth';
 import { useSnackbar } from '../contexts/SnackbarContext';
 import { useUserSettings } from '../hooks/useUserSettings';
-import { auth } from '../services/firebase';
 import { checkRoomExists, createRoom } from '../services/roomService';
 import type { GameSettings, Player } from '../types';
 import { generateId } from '../utils/id';
 import styles from './TopPage.module.css';
 
 export const TopPage = () => {
+  const { currentUser, signOutCurrentUser } = useAuth();
   const navigate = useNavigate();
   const { showSnackbar } = useSnackbar();
   const { userSettings, loading: userSettingsLoading } = useUserSettings();
@@ -21,14 +21,6 @@ export const TopPage = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isAuthModalOpen, setIsAuthModalOpen] = useState(false);
   const [loading, setLoading] = useState(false);
-  const [user, setUser] = useState<User | null>(auth.currentUser);
-
-  useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
-      setUser(currentUser);
-    });
-    return () => unsubscribe();
-  }, []);
 
   const handleCreateRoom = async (
     settings: GameSettings,
@@ -40,7 +32,6 @@ export const TopPage = () => {
     const roomId = generateId(6).toUpperCase();
 
     // Ensure we have a player ID to register as host
-    const currentUser = auth.currentUser;
     if (!currentUser) {
       showSnackbar('認証エラーが発生しました。リロードしてください。', { position: 'top' });
       setLoading(false);
@@ -103,7 +94,7 @@ export const TopPage = () => {
 
   const handleLogout = async () => {
     try {
-      await signOut(auth);
+      await signOutCurrentUser();
       window.location.reload();
     } catch (e) {
       console.error(e);
@@ -122,13 +113,13 @@ export const TopPage = () => {
       }}
     >
       <div style={{ position: 'absolute', top: '20px', right: '20px' }}>
-        {user && user.isAnonymous ? (
+        {currentUser && currentUser.isAnonymous ? (
           <Button variant="secondary" onClick={() => setIsAuthModalOpen(true)} size="small">
             データ引き継ぎ・登録
           </Button>
         ) : (
           <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
-            <span style={{ fontSize: '0.8rem', color: '#aaa' }}>{user?.email}</span>
+            <span style={{ fontSize: '0.8rem', color: '#aaa' }}>{currentUser?.email}</span>
             <Button variant="secondary" onClick={handleLogout} size="small">
               ログアウト
             </Button>

--- a/src/services/migrationService.test.ts
+++ b/src/services/migrationService.test.ts
@@ -7,8 +7,10 @@ import { checkUserHasAnonymousHistory, migrateUserData } from './migrationServic
 // Mock values hoisted
 const mocks = vi.hoisted(() => {
   const mockCommit = vi.fn();
+  const mockBatchSet = vi.fn();
   const mockUpdate = vi.fn();
   const mockWriteBatch = vi.fn(() => ({
+    set: mockBatchSet,
     update: mockUpdate,
     commit: mockCommit,
   }));
@@ -18,6 +20,7 @@ const mocks = vi.hoisted(() => {
   // We can't access non-hoisted variables easily, so we will expose getDocs and mockImplementation later.
 
   return {
+    mockBatchSet,
     mockCommit,
     mockUpdate,
     mockWriteBatch,
@@ -181,12 +184,13 @@ describe('migrationService', () => {
 
       expect(mocks.mockUpdate).toHaveBeenCalledTimes(1);
       const [, updates] = mocks.mockUpdate.mock.calls[0];
+      const [, archiveUpdates] = mocks.mockBatchSet.mock.calls[0];
 
       // playerIds
       expect(updates.playerIds).toEqual(['other', newUid]);
 
       // gameResults
-      const updatedGame = updates.gameResults[0];
+      const updatedGame = archiveUpdates.gameResults[0];
       expect(updatedGame.scores[0].playerId).toBe(newUid);
 
       // logs
@@ -228,9 +232,10 @@ describe('migrationService', () => {
       await migrateUserData(oldUid, newUid);
 
       const [, updates] = mocks.mockUpdate.mock.calls[0];
+      const [, archiveUpdates] = mocks.mockBatchSet.mock.calls[0];
 
       expect(updates.settings.noFuFixedPoints).toEqual(DEFAULT_NO_FU_FIXED_POINTS);
-      expect(updates.gameResults[0].ruleSnapshot.noFuFixedPoints).toEqual(
+      expect(archiveUpdates.gameResults[0].ruleSnapshot.noFuFixedPoints).toEqual(
         DEFAULT_NO_FU_FIXED_POINTS,
       );
     });
@@ -278,8 +283,8 @@ describe('migrationService', () => {
 
       await migrateUserData(oldUid, newUid);
 
-      const [, updates] = mocks.mockUpdate.mock.calls[0];
-      expect(updates.gameResults[0].logs[0].result.loserId).toBe(newUid);
+      const [, archiveUpdates] = mocks.mockBatchSet.mock.calls[0];
+      expect(archiveUpdates.gameResults[0].logs[0].result.loserId).toBe(newUid);
     });
 
     it('should migrate lastEvent deltas', async () => {
@@ -353,19 +358,13 @@ describe('migrationService', () => {
 
       expect(mocks.mockUpdate).toHaveBeenCalledTimes(1);
       const [, updates] = mocks.mockUpdate.mock.calls[0];
+      const [, archiveUpdates] = mocks.mockBatchSet.mock.calls[0];
 
       // hostId migrated
       expect(updates.hostId).toBe(newUid);
 
-      // gameResults should be inclued in updates because we map over it
-      // BUT structurally they might be identical references if not changed?
-      // In our implementation, we map over gameResults.
-      // If gameUpdated is false, we return 'game'.
-      // The `updates.gameResults` will be a NEW array, but containing SAME game objects.
-      // `needsUpdate` is set to true unconditionally if gameResults exists.
-      // So updates.gameResults should be present.
-      expect(updates.gameResults).toBeDefined();
-      expect(updates.gameResults![0]).toEqual({
+      expect(archiveUpdates.gameResults).toBeDefined();
+      expect(archiveUpdates.gameResults[0]).toEqual({
         ...game,
         ruleSnapshot: {
           ...game.ruleSnapshot,
@@ -430,8 +429,8 @@ describe('migrationService', () => {
 
       await migrateUserData(oldUid, newUid);
 
-      const [, updates] = mocks.mockUpdate.mock.calls[0];
-      const updatedLog = updates.gameResults[0].logs[0];
+      const [, archiveUpdates] = mocks.mockBatchSet.mock.calls[0];
+      const updatedLog = archiveUpdates.gameResults[0].logs[0];
       // Winner ID should remain 'other-user'
       expect(updatedLog.result.winners[0].id).toBe(otherUid);
       // The log object itself might be structurally same if no update logic triggered "logUpdated = true"
@@ -490,9 +489,8 @@ describe('migrationService', () => {
 
       await migrateUserData(oldUid, newUid);
 
-      const [, updates] = mocks.mockUpdate.mock.calls[0];
-      // The gameResults array is recreated, but the log inside should be same ref
-      expect(updates.gameResults[0].logs[0]).toEqual(game.logs![0]);
+      const [, archiveUpdates] = mocks.mockBatchSet.mock.calls[0];
+      expect(archiveUpdates.gameResults[0].logs[0]).toEqual(game.logs![0]);
     });
 
     it('migrates user settings when the anonymous user has no room history', async () => {

--- a/src/services/migrationService.ts
+++ b/src/services/migrationService.ts
@@ -18,7 +18,21 @@ import { normalizeUserSettings } from '../utils/userSettings';
 import { db } from './firebase';
 
 const ROOM_COLLECTION = 'rooms';
+const ROOM_ARCHIVE_COLLECTION = 'state';
+const ROOM_ARCHIVE_DOCUMENT = 'archive';
 const USER_SETTINGS_COLLECTION = 'userSettings';
+
+const snapshotExists = (snapshot: { exists?: () => boolean } | null | undefined): boolean => {
+  return typeof snapshot?.exists === 'function' ? snapshot.exists() : false;
+};
+
+const readSnapshotData = <T>(snapshot: { data?: () => T } | null | undefined): T | null => {
+  if (!snapshot || typeof snapshot.data !== 'function') {
+    return null;
+  }
+
+  return snapshot.data();
+};
 
 /**
  * Check if the user has any anonymous data associated with their UID.
@@ -40,7 +54,7 @@ const migrateUserSettings = async (
   const newSettingsRef = doc(db, USER_SETTINGS_COLLECTION, newUid);
   const newSettingsSnapshot = await getDoc(newSettingsRef);
 
-  if (newSettingsSnapshot.exists()) {
+  if (snapshotExists(newSettingsSnapshot)) {
     return;
   }
 
@@ -51,11 +65,11 @@ const migrateUserSettings = async (
           const oldSettingsRef = doc(db, USER_SETTINGS_COLLECTION, oldUid);
           const oldSettingsSnapshot = await getDoc(oldSettingsRef);
 
-          if (!oldSettingsSnapshot.exists()) {
+          if (!snapshotExists(oldSettingsSnapshot)) {
             return null;
           }
 
-          return normalizeUserSettings(oldSettingsSnapshot.data());
+          return normalizeUserSettings(readSnapshotData(oldSettingsSnapshot));
         })();
 
   if (!nextUserSettings) {
@@ -88,12 +102,27 @@ export const migrateUserData = async (
   const batch = writeBatch(db);
   let operationCount = 0;
 
-  snapshot.docs.forEach((roomDoc) => {
+  for (const roomDoc of snapshot.docs) {
     const data = normalizeRoomState(roomDoc.data() as RoomState);
     const roomRef = doc(db, ROOM_COLLECTION, roomDoc.id);
+    const roomArchiveRef = doc(
+      db,
+      ROOM_COLLECTION,
+      roomDoc.id,
+      ROOM_ARCHIVE_COLLECTION,
+      ROOM_ARCHIVE_DOCUMENT,
+    );
+    const roomArchiveSnapshot = await getDoc(roomArchiveRef);
+    const archivedRoomData = snapshotExists(roomArchiveSnapshot)
+      ? readSnapshotData<Pick<RoomState, 'gameResults'>>(
+          roomArchiveSnapshot as { data?: () => Pick<RoomState, 'gameResults'> },
+        )
+      : null;
+    const gameResults = archivedRoomData?.gameResults ?? data.gameResults;
 
     // Prepare updates
     const updates: Partial<RoomState> = {};
+    let archiveGameResults: RoomState['gameResults'] | undefined;
     let needsUpdate = false;
 
     // 1. playerIds
@@ -115,8 +144,8 @@ export const migrateUserData = async (
     }
 
     // 4. gameResults
-    if (data.gameResults && data.gameResults.length > 0) {
-      updates.gameResults = data.gameResults.map((game) => {
+    if (gameResults && gameResults.length > 0) {
+      archiveGameResults = gameResults.map((game) => {
         let gameUpdated = false;
 
         // 4.1 scores
@@ -184,10 +213,6 @@ export const migrateUserData = async (
         return game;
       });
 
-      // Check if actual changes happened in gameResults mapping is implicitly handled by map returning new refs
-      // But we set needsUpdate based on if we touched it.
-      // Optimization: we could track `gameUpdated` flag across the map, but simply setting it here is safe.
-      // Since we reconstruct the whole array if mapped, it's a replacement.
       needsUpdate = true;
     }
 
@@ -214,8 +239,18 @@ export const migrateUserData = async (
         ),
       );
       operationCount++;
+
+      if (archiveGameResults) {
+        batch.set(
+          roomArchiveRef,
+          sanitizeFirestoreData({
+            gameResults: archiveGameResults,
+          }),
+          { merge: true },
+        );
+      }
     }
-  });
+  }
 
   if (operationCount > 0) {
     await batch.commit();

--- a/src/services/roomService.ts
+++ b/src/services/roomService.ts
@@ -1,23 +1,103 @@
 import {
   arrayUnion,
+  collection,
   deleteField,
   doc,
   getDoc,
+  getDocs,
   onSnapshot,
+  query,
   serverTimestamp,
   setDoc,
   updateDoc,
+  where,
 } from 'firebase/firestore';
-import type { GameSettings, Player, RoomState } from '../types';
+import type { GameSettings, Player, RoomSnapshot, RoomState, RoomStateCore } from '../types';
 import {
   normalizeGameSettings,
   normalizeRoomState,
+  normalizeRoomStateCore,
   normalizeRoomStateUpdate,
   sanitizeFirestoreData,
 } from '../utils/gameSettings';
 import { db } from './firebase';
 
 const ROOM_COLLECTION = 'rooms';
+const ROOM_ARCHIVE_COLLECTION = 'state';
+const ROOM_ARCHIVE_DOCUMENT = 'archive';
+const ROOM_ARCHIVE_KEYS = ['history', 'currentLogs', 'gameResults'] as const;
+
+type RoomArchiveState = Pick<RoomState, (typeof ROOM_ARCHIVE_KEYS)[number]>;
+
+const getRoomRef = (roomId: string) => {
+  return doc(db, ROOM_COLLECTION, roomId);
+};
+
+const getRoomArchiveRef = (roomId: string) => {
+  return doc(db, ROOM_COLLECTION, roomId, ROOM_ARCHIVE_COLLECTION, ROOM_ARCHIVE_DOCUMENT);
+};
+
+const mergeRoomState = (
+  roomData: Partial<RoomState> | null,
+  archiveData: Partial<RoomArchiveState> | null,
+): RoomState | null => {
+  if (!roomData) {
+    return null;
+  }
+
+  return normalizeRoomState({
+    ...roomData,
+    history: archiveData?.history ?? roomData.history,
+    currentLogs: archiveData?.currentLogs ?? roomData.currentLogs,
+    gameResults: archiveData?.gameResults ?? roomData.gameResults,
+  } as RoomState);
+};
+
+const splitRoomState = (state: Partial<RoomState>) => {
+  const roomCoreState: Partial<RoomStateCore> = {
+    ...state,
+  };
+  const roomArchiveState: Partial<RoomArchiveState> = {};
+
+  for (const key of ROOM_ARCHIVE_KEYS) {
+    if (!Object.prototype.hasOwnProperty.call(state, key)) {
+      continue;
+    }
+
+    if (key === 'history') {
+      roomArchiveState.history = state.history;
+    }
+    if (key === 'currentLogs') {
+      roomArchiveState.currentLogs = state.currentLogs;
+    }
+    if (key === 'gameResults') {
+      roomArchiveState.gameResults = state.gameResults;
+    }
+
+    delete (roomCoreState as Partial<RoomState>)[key];
+  }
+
+  return { roomCoreState, roomArchiveState };
+};
+
+const buildDeletedFields = (value: Record<string, unknown>) => {
+  return Object.entries(value).reduce<Record<string, unknown>>((result, [key, current]) => {
+    if (current === undefined) {
+      result[key] = deleteField();
+    }
+
+    return result;
+  }, {});
+};
+
+const loadRoomArchive = async (roomId: string): Promise<Partial<RoomArchiveState> | null> => {
+  const archiveSnapshot = await getDoc(getRoomArchiveRef(roomId));
+  if (!archiveSnapshot.exists()) {
+    return null;
+  }
+
+  return archiveSnapshot.data() as Partial<RoomArchiveState>;
+};
 
 export const createRoom = async (
   roomId: string,
@@ -32,7 +112,8 @@ export const createRoom = async (
     extraPlayerIds?: string[];
   },
 ): Promise<void> => {
-  const roomRef = doc(db, ROOM_COLLECTION, roomId);
+  const roomRef = getRoomRef(roomId);
+  const roomArchiveRef = getRoomArchiveRef(roomId);
   const roomSnapshot = await getDoc(roomRef);
   const normalizedSettings = normalizeGameSettings(settings);
 
@@ -40,12 +121,12 @@ export const createRoom = async (
     throw new Error('Room already exists');
   }
 
-  const basePlayerIds = initialPlayers.map((p) => p.id);
+  const basePlayerIds = initialPlayers.map((player) => player.id);
   const allPlayerIds = options?.extraPlayerIds
     ? [...new Set([...basePlayerIds, ...options.extraPlayerIds])]
     : basePlayerIds;
 
-  const initialRoomState: RoomState = {
+  const initialRoomState: RoomStateCore = {
     id: roomId,
     hostId: options?.hostId ?? initialPlayers[0].id,
     status: options?.initialStatus ?? 'waiting',
@@ -63,49 +144,71 @@ export const createRoom = async (
     tableId: options?.tableId,
   };
 
-  // Convert to Firestore data (timestamps etc) if needed, but simple JSON is fine for now
   await setDoc(roomRef, {
     ...sanitizeFirestoreData(initialRoomState),
     createdAt: serverTimestamp(),
     updatedAt: serverTimestamp(),
   });
+  await setDoc(roomArchiveRef, {
+    history: [],
+    currentLogs: [],
+    gameResults: [],
+  });
 };
 
 export const subscribeToRoom = (roomId: string, callback: (room: RoomState | null) => void) => {
-  const roomRef = doc(db, ROOM_COLLECTION, roomId);
+  const roomRef = getRoomRef(roomId);
+  const roomArchiveRef = getRoomArchiveRef(roomId);
 
-  return onSnapshot(
+  let latestRoomState: Partial<RoomState> | null = null;
+  let latestRoomArchive: Partial<RoomArchiveState> | null = null;
+
+  const emit = () => {
+    callback(mergeRoomState(latestRoomState, latestRoomArchive));
+  };
+
+  const unsubscribeRoom = onSnapshot(
     roomRef,
     (snapshot) => {
-      if (snapshot.exists()) {
-        callback(normalizeRoomState(snapshot.data() as RoomState));
-      } else {
-        callback(null);
-      }
+      latestRoomState = snapshot.exists() ? (snapshot.data() as Partial<RoomState>) : null;
+      emit();
     },
     (error) => {
       console.error('Room sync error:', error);
       callback(null);
     },
   );
+
+  const unsubscribeArchive = onSnapshot(
+    roomArchiveRef,
+    (snapshot) => {
+      latestRoomArchive = snapshot.exists() ? (snapshot.data() as Partial<RoomArchiveState>) : null;
+      emit();
+    },
+    (error) => {
+      console.error('Room archive sync error:', error);
+    },
+  );
+
+  return () => {
+    unsubscribeRoom();
+    unsubscribeArchive();
+  };
 };
 
 export const joinRoom = async (roomId: string, player: Player): Promise<void> => {
-  const roomRef = doc(db, ROOM_COLLECTION, roomId);
-  // Transaction or arrayUnion
-  // Ideally check if 4 players already
+  const roomRef = getRoomRef(roomId);
+  const snapshot = await getDoc(roomRef);
+  if (!snapshot.exists()) {
+    throw new Error('Room not found');
+  }
 
-  // Checking current players
-  const snap = await getDoc(roomRef);
-  if (!snap.exists()) throw new Error('Room not found');
-
-  const data = normalizeRoomState(snap.data() as RoomState);
-  if (data.players.some((p) => p.id === player.id)) {
-    // Already joined, maybe update name?
+  const roomCoreState = normalizeRoomStateCore(snapshot.data() as RoomStateCore);
+  if (roomCoreState.players.some((existingPlayer) => existingPlayer.id === player.id)) {
     return;
   }
 
-  if (data.players.length >= (data.settings.mode === '4ma' ? 4 : 3)) {
+  if (roomCoreState.players.length >= (roomCoreState.settings.mode === '4ma' ? 4 : 3)) {
     throw new Error('Room is full');
   }
 
@@ -120,63 +223,69 @@ export const updateRoomState = async (
   roomId: string,
   updates: Partial<RoomState>,
 ): Promise<void> => {
-  const roomRef = doc(db, ROOM_COLLECTION, roomId);
+  const roomRef = getRoomRef(roomId);
+  const roomArchiveRef = getRoomArchiveRef(roomId);
   const normalizedUpdates = normalizeRoomStateUpdate(updates);
-  const deletedFields = Object.entries(normalizedUpdates).reduce<Record<string, unknown>>(
-    (result, [key, value]) => {
-      if (value === undefined) {
-        result[key] = deleteField();
-      }
+  const { roomCoreState, roomArchiveState } = splitRoomState(normalizedUpdates);
 
-      return result;
-    },
-    {},
-  );
-  // Be careful with nested updates in Firestore (dot notation needed for deep fields)
-  // For now, replacing top-level is okay if careful, or use libraries.
-  // However, round.honba update requires `round: { ...old.round, honba: x }` if doing shallow merge.
-  // Let's assume `updates` is properly structured for setDoc({merge:true}) or updateDoc.
+  const roomCoreDeletedFields = buildDeletedFields(roomCoreState as Record<string, unknown>);
+  const roomArchiveDeletedFields = buildDeletedFields(roomArchiveState as Record<string, unknown>);
 
   await updateDoc(roomRef, {
-    ...sanitizeFirestoreData(normalizedUpdates),
-    ...deletedFields,
+    ...sanitizeFirestoreData(roomCoreState),
+    ...roomCoreDeletedFields,
     updatedAt: serverTimestamp(),
   });
+
+  if (Object.keys(roomArchiveState).length > 0) {
+    await setDoc(
+      roomArchiveRef,
+      {
+        ...sanitizeFirestoreData(roomArchiveState),
+        ...roomArchiveDeletedFields,
+      },
+      { merge: true },
+    );
+  }
 };
 
 export const checkRoomExists = async (roomId: string): Promise<boolean> => {
-  const roomRef = doc(db, ROOM_COLLECTION, roomId);
-  const snapshot = await getDoc(roomRef);
+  const snapshot = await getDoc(getRoomRef(roomId));
   return snapshot.exists();
 };
 
-import { collection, getDocs, query, where } from 'firebase/firestore';
-
 export const getUserRoomHistory = async (userId: string): Promise<RoomState[]> => {
   const roomsRef = collection(db, ROOM_COLLECTION);
-  // Note: orderBy with array-contains requires a composite index.
-  // For MVP simplicity and to avoid "index required" errors blocking the user immediately,
-  // we will fetch filter by player and sort client-side,
-  // OR rely on the link error if the user is willing to click it.
-  // Let's try simple filtering first, then sort in memory.
-  const q = query(roomsRef, where('playerIds', 'array-contains', userId));
+  const roomsQuery = query(roomsRef, where('playerIds', 'array-contains', userId));
+  const snapshot = await getDocs(roomsQuery);
 
-  const snapshot = await getDocs(q);
-  const rooms = snapshot.docs.map((doc) => normalizeRoomState(doc.data() as RoomState));
+  const rooms = await Promise.all(
+    snapshot.docs.map(async (roomDocument) => {
+      const roomData = roomDocument.data() as Partial<RoomState>;
+      const roomArchive = await loadRoomArchive(roomDocument.id);
+      return mergeRoomState(roomData, roomArchive);
+    }),
+  );
 
-  // Client-side sort by createdAt (descending)
-  return rooms.sort((a, b) => {
-    // timestamp is an object {seconds, nanoseconds} in Firestore
-    const getSeconds = (val: number | object | undefined): number => {
-      if (typeof val === 'number') return val / 1000;
-      if (val && typeof val === 'object' && 'seconds' in val) {
-        return (val as { seconds: number }).seconds;
-      }
-      return 0;
-    };
+  return rooms
+    .filter((room): room is RoomState => room !== null)
+    .sort((left, right) => {
+      const getSeconds = (value: number | object | undefined): number => {
+        if (typeof value === 'number') {
+          return value / 1000;
+        }
+        if (value && typeof value === 'object' && 'seconds' in value) {
+          return (value as { seconds: number }).seconds;
+        }
+        return 0;
+      };
 
-    const timeA = getSeconds(a.createdAt);
-    const timeB = getSeconds(b.createdAt);
-    return timeB - timeA;
-  });
+      return getSeconds(right.createdAt) - getSeconds(left.createdAt);
+    });
+};
+
+export const getRoomSnapshot = (room: RoomState): RoomSnapshot => {
+  const snapshot = { ...room };
+  delete snapshot.history;
+  return snapshot;
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -108,7 +108,7 @@ export interface GameSettings {
   rate: number; // Settlement rate (e.g. 30, 50, 100)
 }
 
-export interface RoomState {
+export interface RoomStateCore {
   id: string;
   hostId: string;
   roomName?: string;
@@ -124,12 +124,21 @@ export interface RoomState {
   players: Player[];
   playerIds: string[]; // List of UIDs for security rules
   settings: GameSettings;
-  history?: RoomState[];
-  gameResults?: GameResult[];
-  currentLogs?: HandLog[]; // Logs for the current active game (to be moved to gameResults on finish)
   lastEvent?: LastEvent;
   competitionId?: string; // Associated competition ID
   tableId?: string; // Associated table ID within a competition
+}
+
+export interface RoomSnapshot extends RoomStateCore {
+  gameResults?: GameResult[];
+  currentLogs?: HandLog[]; // Logs for the current active game (to be moved to gameResults on finish)
+  lastEvent?: LastEvent;
+}
+
+export interface RoomState extends RoomStateCore {
+  history?: RoomSnapshot[];
+  gameResults?: GameResult[];
+  currentLogs?: HandLog[]; // Logs for the current active game (to be moved to gameResults on finish)
 }
 
 // --- Competition Types ---

--- a/src/utils/gameSettings.ts
+++ b/src/utils/gameSettings.ts
@@ -4,7 +4,9 @@ import type {
   NoFuFixedPointHan,
   NoFuFixedPointValue,
   NoFuFixedPoints,
+  RoomSnapshot,
   RoomState,
+  RoomStateCore,
 } from '../types';
 
 type PartialNoFuFixedPoints = Partial<Record<NoFuFixedPointHan, Partial<NoFuFixedPointValue>>>;
@@ -92,11 +94,25 @@ export const normalizeGameResult = (result: GameResult): GameResult => {
   };
 };
 
-export const normalizeRoomState = (room: RoomState): RoomState => {
+export const normalizeRoomSnapshot = (room: RoomSnapshot): RoomSnapshot => {
   return {
     ...room,
     settings: normalizeGameSettings(room.settings),
-    history: room.history?.map(normalizeRoomState),
+    gameResults: room.gameResults?.map(normalizeGameResult),
+  };
+};
+
+export const normalizeRoomStateCore = (room: RoomStateCore): RoomStateCore => {
+  return {
+    ...room,
+    settings: normalizeGameSettings(room.settings),
+  };
+};
+
+export const normalizeRoomState = (room: RoomState): RoomState => {
+  return {
+    ...normalizeRoomStateCore(room),
+    history: room.history?.map(normalizeRoomSnapshot),
     gameResults: room.gameResults?.map(normalizeGameResult),
   };
 };
@@ -105,7 +121,7 @@ export const normalizeRoomStateUpdate = (updates: Partial<RoomState>): Partial<R
   return {
     ...updates,
     ...(updates.settings ? { settings: normalizeGameSettings(updates.settings) } : {}),
-    ...(updates.history ? { history: updates.history.map(normalizeRoomState) } : {}),
+    ...(updates.history ? { history: updates.history.map(normalizeRoomSnapshot) } : {}),
     ...(updates.gameResults ? { gameResults: updates.gameResults.map(normalizeGameResult) } : {}),
   };
 };


### PR DESCRIPTION
## 概要
- ルーム状態の保存構造を core / archive に分離し、Firestore の肥大化と責務集中を抑えました。
- 認証境界を Context に寄せ、ページやフックから auth singleton へ直接依存する箇所を減らしました。

## 変更内容
### service / types / rules
- `src/types/index.ts`: `RoomStateCore` / `RoomSnapshot` / `RoomState` に分割し、保存モデルと表示モデルを整理しました。
- `src/services/roomService.ts`: `rooms/{id}` と `rooms/{id}/state/archive` を分離し、取得・購読・スナップショット生成を更新しました。
- `firestore.rules`: 分割後の `state` 配下に対するアクセス制御を追加しました。
- `src/services/migrationService.ts`: 既存データの移行処理を新しい保存構造へ対応させました。

### context / hooks / pages
- `src/contexts/AuthContext.tsx` / `src/contexts/auth-context.ts` / `src/contexts/useAuth.ts`: 認証状態を Context 経由に整理しました。
- `src/hooks/useRoomHistory.ts` / `src/hooks/useDashboardStats.ts`: 履歴取得と集計ロジックをページ外へ分離しました。
- `src/hooks/useMatchGame.ts` と各 `src/pages/*`: 新しい auth/context/hook 構成へ追従しました。

### test
- `src/hooks/*.test.ts` / `src/pages/CompetitionNewPage.test.tsx` / `src/services/migrationService.test.ts`: 変更後の挙動に合わせて更新しました。

## テスト計画
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test`（60 files / 534 tests passed）
- [x] ソースレビューで主要ページとルーム保存フローの接続を確認
