### PR TITLE
大会卓の席順と局進行時の風を修正

### DIFF
--- a/src/hooks/useCompetitionMatch.ts
+++ b/src/hooks/useCompetitionMatch.ts
@@ -17,6 +17,8 @@ import type {
 import {
   buildGameSettingsFromCompetition,
   buildPlayersFromParticipants,
+  orderPlayersBySeatAssignment,
+  restorePlayerWindsFromSeatAssignment,
 } from '../utils/competitionDefaults';
 import { generateId } from '../utils/id';
 import { useCompetition } from './useCompetition';
@@ -51,12 +53,35 @@ export const useCompetitionMatch = (
   const table = useMemo(() => tables.find((t) => t.id === tableId), [tables, tableId]);
 
   const roomId = table?.currentRoomId || '';
-  const { room, loading: roomLoading, updateState } = useRoom(roomId);
+  const { room: subscribedRoom, loading: roomLoading, updateState } = useRoom(roomId);
 
   const tableParticipants = useMemo(
     () => participants.filter((p) => table?.playerIds.includes(p.id)),
     [participants, table?.playerIds],
   );
+
+  const room = useMemo(() => {
+    if (!subscribedRoom || !table) return subscribedRoom;
+
+    const orderedPlayers = orderPlayersBySeatAssignment(
+      subscribedRoom.players,
+      tableParticipants,
+      table.seatAssignment ?? {},
+    );
+    const normalizedPlayers = restorePlayerWindsFromSeatAssignment(
+      orderedPlayers,
+      tableParticipants,
+      table.seatAssignment ?? {},
+      subscribedRoom.round.number,
+    );
+    const isAlreadyNormalized = normalizedPlayers.every(
+      (player, index) =>
+        player.id === subscribedRoom.players[index]?.id &&
+        player.wind === subscribedRoom.players[index]?.wind,
+    );
+
+    return isAlreadyNormalized ? subscribedRoom : { ...subscribedRoom, players: normalizedPlayers };
+  }, [subscribedRoom, table, tableParticipants]);
 
   const canManage = useMemo(() => {
     if (!uid || !competition) return false;

--- a/src/hooks/useMatchGame.ts
+++ b/src/hooks/useMatchGame.ts
@@ -12,6 +12,7 @@ import {
   createScoreChangeLastEvent,
   getSoundEffectCueFromResults,
 } from '../utils/soundEffects';
+import { rotatePlayerWinds } from '../utils/wind';
 
 interface UseMatchGameOptions {
   room: RoomState | null;
@@ -130,18 +131,6 @@ export const useMatchGame = ({ room, updateState }: UseMatchGameOptions): UseMat
     setIsTransitioning(true);
     setTimeout(() => setShowFinishedModal(true), 3000);
   }, []);
-
-  const rotateWinds = (players: Player[], isRenchan: boolean): Player[] => {
-    if (isRenchan) return players;
-    const windOrder: Player['wind'][] = ['East', 'South', 'West', 'North'];
-    const currentEastIdx = players.findIndex((p) => p.wind === 'East');
-    if (currentEastIdx === -1) return players;
-    const nextEastIdx = (currentEastIdx + 1) % players.length;
-    return players.map((p, idx) => {
-      const rel = (idx - nextEastIdx + players.length) % players.length;
-      return { ...p, wind: windOrder[rel] };
-    });
-  };
 
   const handleScoreConfirm = useCallback(
     async (
@@ -284,7 +273,7 @@ export const useMatchGame = ({ room, updateState }: UseMatchGameOptions): UseMat
       // Wind rotation
       const isRenchan =
         nextState.nextRound.wind === round.wind && nextState.nextRound.number === round.number;
-      const nextPlayersWithWind = rotateWinds(newPlayers, isRenchan);
+      const nextPlayersWithWind = rotatePlayerWinds(newPlayers, isRenchan);
 
       if (nextState.isGameOver) triggerGameEndTransition();
 
@@ -373,7 +362,7 @@ export const useMatchGame = ({ room, updateState }: UseMatchGameOptions): UseMat
       const isRenchan =
         nextState.nextRound.wind === room.round.wind &&
         nextState.nextRound.number === room.round.number;
-      const nextPlayersWithWind = rotateWinds(newPlayers, isRenchan);
+      const nextPlayersWithWind = rotatePlayerWinds(newPlayers, isRenchan);
 
       if (nextState.isGameOver) triggerGameEndTransition();
 

--- a/src/utils/competitionDefaults.test.ts
+++ b/src/utils/competitionDefaults.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import type { CompetitionParticipant, CompetitionSettings, SeatAssignment } from '../types';
+import type { CompetitionParticipant, CompetitionSettings, Player, SeatAssignment } from '../types';
 import {
   buildGameSettingsFromCompetition,
   buildPlayersFromParticipants,
   DEFAULT_COMPETITION_SETTINGS,
+  orderPlayersBySeatAssignment,
+  restorePlayerWindsFromSeatAssignment,
 } from './competitionDefaults';
 import { DEFAULT_NO_FU_FIXED_POINTS } from './gameSettings';
 
@@ -203,6 +205,26 @@ describe('buildPlayersFromParticipants', () => {
     });
   });
 
+  it('should order players counterclockwise by their assigned seats', () => {
+    const participants = [
+      makeParticipant('tomoaki', 'ともあき'),
+      makeParticipant('kondo', '近藤'),
+      makeParticipant('takahashi', '高橋'),
+      makeParticipant('ohara', '小原'),
+    ];
+    const seatAssignment: SeatAssignment = {
+      tomoaki: 'East',
+      takahashi: 'South',
+      kondo: 'West',
+      ohara: 'North',
+    };
+
+    const result = buildPlayersFromParticipants(participants, seatAssignment, 25000);
+
+    expect(result.map((player) => player.name)).toEqual(['ともあき', '高橋', '近藤', '小原']);
+    expect(result.map((player) => player.wind)).toEqual(['East', 'South', 'West', 'North']);
+  });
+
   it('should use participant id when userId is undefined (guest players)', () => {
     const participants = [makeParticipant('guest-1', 'Guest')];
     const seatAssignment: SeatAssignment = { 'guest-1': 'East' };
@@ -242,5 +264,112 @@ describe('buildPlayersFromParticipants', () => {
       expect(p.isRiichi).toBe(false);
       expect(p.chip).toBe(0);
     });
+  });
+});
+
+describe('orderPlayersBySeatAssignment', () => {
+  const makeParticipant = (id: string, name: string): CompetitionParticipant => ({
+    id,
+    name,
+    isGuest: true,
+    status: 'playing',
+    role: 'player',
+    joinedAt: Date.now(),
+  });
+  const makePlayer = (id: string, name: string, wind: Player['wind']): Player => ({
+    id,
+    name,
+    score: 25000,
+    isRiichi: false,
+    wind,
+    chip: 0,
+  });
+
+  it('restores physical seat order for an existing room with legacy player order', () => {
+    const participants = [
+      makeParticipant('tomoaki', 'ともあき'),
+      makeParticipant('kondo', '近藤'),
+      makeParticipant('takahashi', '高橋'),
+      makeParticipant('ohara', '小原'),
+    ];
+    const players = [
+      makePlayer('tomoaki', 'ともあき', 'East'),
+      makePlayer('kondo', '近藤', 'West'),
+      makePlayer('takahashi', '高橋', 'South'),
+      makePlayer('ohara', '小原', 'North'),
+    ];
+    const seatAssignment: SeatAssignment = {
+      tomoaki: 'East',
+      takahashi: 'South',
+      kondo: 'West',
+      ohara: 'North',
+    };
+
+    const result = orderPlayersBySeatAssignment(players, participants, seatAssignment);
+
+    expect(result.map((player) => player.name)).toEqual(['ともあき', '高橋', '近藤', '小原']);
+  });
+
+  it('restores East 2 winds from the initial seats for a progressed legacy room', () => {
+    const participants = [
+      makeParticipant('tomoaki', 'ともあき'),
+      makeParticipant('kondo', '近藤'),
+      makeParticipant('takahashi', '高橋'),
+      makeParticipant('ohara', '小原'),
+    ];
+    const players = [
+      makePlayer('tomoaki', 'ともあき', 'North'),
+      makePlayer('kondo', '近藤', 'East'),
+      makePlayer('takahashi', '高橋', 'West'),
+      makePlayer('ohara', '小原', 'South'),
+    ];
+    const seatAssignment: SeatAssignment = {
+      tomoaki: 'East',
+      takahashi: 'South',
+      kondo: 'West',
+      ohara: 'North',
+    };
+
+    const result = restorePlayerWindsFromSeatAssignment(players, participants, seatAssignment, 2);
+
+    expect(Object.fromEntries(result.map((player) => [player.name, player.wind]))).toEqual({
+      ともあき: 'North',
+      近藤: 'South',
+      高橋: 'East',
+      小原: 'West',
+    });
+  });
+
+  it('keeps unmapped room players after players with assigned seats', () => {
+    const participant = makeParticipant('known', 'Known');
+    const unknownPlayer = makePlayer('unknown', 'Unknown', 'East');
+    const knownPlayer = makePlayer('known', 'Known', 'South');
+
+    const result = orderPlayersBySeatAssignment([unknownPlayer, knownPlayer], [participant], {
+      known: 'South',
+    });
+
+    expect(result).toEqual([knownPlayer, unknownPlayer]);
+  });
+
+  it('leaves empty and unmapped wind data unchanged', () => {
+    const emptyPlayers: Player[] = [];
+    expect(restorePlayerWindsFromSeatAssignment(emptyPlayers, [], {}, 1)).toBe(emptyPlayers);
+
+    const participant = makeParticipant('known', 'Known');
+    const knownPlayer = makePlayer('known', 'Known', 'East');
+    const unknownPlayer = makePlayer('unknown', 'Unknown', 'South');
+    const players = [knownPlayer, unknownPlayer];
+
+    const result = restorePlayerWindsFromSeatAssignment(
+      players,
+      [participant],
+      { known: 'East' },
+      1,
+    );
+
+    expect(result).toEqual(players);
+    expect(result[0]).toBe(knownPlayer);
+    expect(result[1]).toBe(unknownPlayer);
   });
 });

--- a/src/utils/competitionDefaults.ts
+++ b/src/utils/competitionDefaults.ts
@@ -11,6 +11,7 @@ import {
   normalizeYakitoriEnabled,
   normalizeYakitoriPoint,
 } from './gameSettings';
+import { WIND_ORDER } from './wind';
 
 export const DEFAULT_COMPETITION_SETTINGS: CompetitionSettings = {
   length: 'Hanchan',
@@ -62,12 +63,59 @@ export const buildGameSettingsFromCompetition = (
   };
 };
 
+export const orderPlayersBySeatAssignment = (
+  players: Player[],
+  participants: CompetitionParticipant[],
+  seatAssignment: SeatAssignment,
+): Player[] => {
+  const participantByPlayerId = new Map(
+    participants.map((participant) => [participant.userId ?? participant.id, participant]),
+  );
+
+  return [...players].sort((a, b) => {
+    const participantA = participantByPlayerId.get(a.id);
+    const participantB = participantByPlayerId.get(b.id);
+    const windA = participantA ? seatAssignment[participantA.id] : undefined;
+    const windB = participantB ? seatAssignment[participantB.id] : undefined;
+    const indexA = windA ? WIND_ORDER.indexOf(windA) : WIND_ORDER.length;
+    const indexB = windB ? WIND_ORDER.indexOf(windB) : WIND_ORDER.length;
+    return indexA - indexB;
+  });
+};
+
+export const restorePlayerWindsFromSeatAssignment = (
+  players: Player[],
+  participants: CompetitionParticipant[],
+  seatAssignment: SeatAssignment,
+  roundNumber: number,
+): Player[] => {
+  const activeWinds = WIND_ORDER.slice(0, players.length);
+  if (activeWinds.length === 0) return players;
+
+  const participantByPlayerId = new Map(
+    participants.map((participant) => [participant.userId ?? participant.id, participant]),
+  );
+  const dealerRotations = Math.max(0, Math.trunc(roundNumber) - 1) % activeWinds.length;
+
+  return players.map((player) => {
+    const participant = participantByPlayerId.get(player.id);
+    const initialWind = participant ? seatAssignment[participant.id] : undefined;
+    const initialWindIndex = initialWind ? activeWinds.indexOf(initialWind) : -1;
+    if (initialWindIndex === -1) return player;
+
+    const currentWindIndex =
+      (initialWindIndex - dealerRotations + activeWinds.length) % activeWinds.length;
+    const wind = activeWinds[currentWindIndex];
+    return player.wind === wind ? player : { ...player, wind };
+  });
+};
+
 export const buildPlayersFromParticipants = (
   participants: CompetitionParticipant[],
   seatAssignment: SeatAssignment,
   startPoint: number,
-): Player[] =>
-  participants.map((p) => ({
+): Player[] => {
+  const players = participants.map((p) => ({
     id: p.userId ?? p.id,
     name: p.name,
     score: startPoint,
@@ -75,3 +123,6 @@ export const buildPlayersFromParticipants = (
     wind: seatAssignment[p.id] ?? 'East',
     chip: 0,
   }));
+
+  return orderPlayersBySeatAssignment(players, participants, seatAssignment);
+};

--- a/src/utils/wind.test.ts
+++ b/src/utils/wind.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { WIND_LABELS, WIND_ORDER, windToKanji } from './wind';
+import type { Player } from '../types';
+import { rotatePlayerWinds, WIND_LABELS, WIND_ORDER, windToKanji } from './wind';
 
 describe('windToKanji', () => {
   it('converts East to 東', () => {
@@ -32,5 +33,56 @@ describe('WIND_LABELS', () => {
 describe('WIND_ORDER', () => {
   it('is East, South, West, North', () => {
     expect(WIND_ORDER).toEqual(['East', 'South', 'West', 'North']);
+  });
+});
+
+describe('rotatePlayerWinds', () => {
+  const makePlayer = (id: string, wind: Player['wind']): Player => ({
+    id,
+    name: id,
+    score: 25000,
+    isRiichi: false,
+    wind,
+    chip: 0,
+  });
+
+  it('rotates each 4-player wind independently of array order', () => {
+    const players = [
+      makePlayer('tomoaki', 'East'),
+      makePlayer('kondo', 'West'),
+      makePlayer('takahashi', 'South'),
+      makePlayer('ohara', 'North'),
+    ];
+
+    const result = rotatePlayerWinds(players, false);
+
+    expect(Object.fromEntries(result.map((player) => [player.id, player.wind]))).toEqual({
+      tomoaki: 'North',
+      kondo: 'South',
+      takahashi: 'East',
+      ohara: 'West',
+    });
+  });
+
+  it('uses the three-player wind cycle without assigning North', () => {
+    const players = [
+      makePlayer('west', 'West'),
+      makePlayer('east', 'East'),
+      makePlayer('south', 'South'),
+    ];
+
+    const result = rotatePlayerWinds(players, false);
+
+    expect(Object.fromEntries(result.map((player) => [player.id, player.wind]))).toEqual({
+      west: 'South',
+      east: 'West',
+      south: 'East',
+    });
+  });
+
+  it('does not rotate winds during a dealer continuation', () => {
+    const players = [makePlayer('east', 'East'), makePlayer('south', 'South')];
+
+    expect(rotatePlayerWinds(players, true)).toBe(players);
   });
 });

--- a/src/utils/wind.ts
+++ b/src/utils/wind.ts
@@ -1,3 +1,4 @@
+import type { Player } from '../types';
 import type { Wind } from '../types/analysis';
 
 export const WIND_LABELS: Record<Wind, string> = {
@@ -8,6 +9,19 @@ export const WIND_LABELS: Record<Wind, string> = {
 };
 
 export const WIND_ORDER: Wind[] = ['East', 'South', 'West', 'North'];
+
+export const rotatePlayerWinds = (players: Player[], isRenchan: boolean): Player[] => {
+  if (isRenchan) return players;
+
+  const activeWinds = WIND_ORDER.slice(0, players.length);
+  return players.map((player) => {
+    const currentWindIndex = activeWinds.indexOf(player.wind);
+    if (currentWindIndex === -1) return player;
+
+    const nextWindIndex = (currentWindIndex - 1 + activeWinds.length) % activeWinds.length;
+    return { ...player, wind: activeWinds[nextWindIndex] };
+  });
+};
 
 export const windToKanji = (wind: string): string => {
   return WIND_LABELS[wind as Wind] ?? wind;


### PR DESCRIPTION
## 概要

大会卓で設定した初期席と、対局画面の物理的な席順・局進行後の風が一致しない不具合を修正します。

## 原因

大会参加者の取得順をそのまま `players` 配列として保存していました。一方、対局画面と親交代ロジックはこの配列を東・南・西・北の物理席順として扱っていたため、参加者の取得順が席設定と異なると表示と風送りの両方が崩れていました。

## 変更内容

- 対局開始時のプレイヤー配列を席設定の東・南・西・北順に正規化
- 既に作成・進行している大会卓も、初期席と現在局数から物理席順と現在の風を復元
- 親交代を配列インデックスではなく各プレイヤーの現在の風から計算
- 三麻では北を割り当てない3人用の風巡回を維持
- 報告ケースと後方互換ケースの回帰テストを追加

## ユーザーへの影響

以下の初期席は反時計回りに正しく表示されます。

- 東: ともあき
- 南: 高橋
- 西: 近藤
- 北: 小原

東2局では、高橋が東、近藤が南として表示されます。既存の進行中卓も再作成せずに読み込み時に補正されます。

## 検証

- `npm test`: 60 files passed / 542 tests passed / 5 skipped
- `npm run build`: 成功
- ESLint: 成功
- Prettier check: 成功
- 変更対象ユーティリティの分岐カバレッジ: 87.5%