### PR TITLE
Chrome印刷時の大会レポート背景を修正

### DIFF
--- a/src/pages/CompetitionReportPage.module.css
+++ b/src/pages/CompetitionReportPage.module.css
@@ -198,6 +198,12 @@
 }
 
 @media print {
+  :global(html),
+  :global(body) {
+    background: #fff !important;
+    color: #000;
+  }
+
   .container {
     background: #fff;
     color: #000;
@@ -210,13 +216,22 @@
   }
 
   .tableWrapper {
-    background: #fff;
+    /*
+     * Chrome can extend this scroll container's dark screen background to the
+     * bottom of the printed page. Remove the wrapper box when printing.
+     */
+    display: contents;
   }
 
   .table th {
     background: #eee;
     color: #000;
     border-bottom: 2px solid #333;
+    position: static;
+  }
+
+  .table {
+    min-width: 0;
   }
 
   .table td {
@@ -253,6 +268,16 @@
     background: #eee;
     color: #000;
     border: 1px solid #ccc;
+  }
+
+  /* Avoid Chrome's print rendering issue with a wrapping flex box in a table cell. */
+  .tagList {
+    display: block;
+  }
+
+  .tag {
+    display: inline-block;
+    margin: 0 var(--spacing-xs) var(--spacing-xs) 0;
   }
 
   .zebraEven td {


### PR DESCRIPTION
## 概要

Chrome で大会レポートを印刷した際、卓別サマリ以降に暗い背景が出力される問題を修正します。

## 原因

アプリ全体のダークテーマ用 `body` 背景色が印刷時にも残っており、レポート本体の外側やページ末尾に出力されていました。

## 変更内容

- 印刷時に `html` と `body` の背景色を白へ明示的に上書き
- 印刷用テーブルから横スクロール用のラッパー、固定ヘッダー、最小幅を取り除く
- 参加者タグを印刷時のみインライン配置に変更

## ユーザーへの影響

大会レポートを Chrome から PDF/印刷しても、卓別サマリの下部やページ余白が黒く出力されません。

## 確認

- `npm run build`