### PR TITLE
対局別詳細を卓名・対局番号・順位順に並べ替え

### DIFF
--- a/src/utils/competitionReport.test.ts
+++ b/src/utils/competitionReport.test.ts
@@ -197,6 +197,54 @@ describe('aggregateMatchDetails', () => {
     expect(result[0].chipDiff).toBe(2);
   });
 
+  it('sorts details by table name, game index, and rank', () => {
+    const gameResults: CompetitionGameResult[] = [
+      makeCompGameResult({
+        id: 'cgr-b-1',
+        tableId: 't-b',
+        tableName: 'B卓',
+        timestamp: 1000,
+        result: makeGameResult({
+          scores: [makeScore({ playerId: 'p1', rank: 2 }), makeScore({ playerId: 'p2', rank: 1 })],
+        }),
+        participantIds: ['p1', 'p2'],
+      }),
+      makeCompGameResult({
+        id: 'cgr-a-2',
+        tableId: 't-a',
+        tableName: 'A卓',
+        timestamp: 3000,
+        result: makeGameResult({
+          scores: [makeScore({ playerId: 'p1', rank: 2 }), makeScore({ playerId: 'p2', rank: 1 })],
+        }),
+        participantIds: ['p1', 'p2'],
+      }),
+      makeCompGameResult({
+        id: 'cgr-a-1',
+        tableId: 't-a',
+        tableName: 'A卓',
+        timestamp: 2000,
+        result: makeGameResult({
+          scores: [makeScore({ playerId: 'p1', rank: 3 }), makeScore({ playerId: 'p2', rank: 1 })],
+        }),
+        participantIds: ['p1', 'p2'],
+      }),
+    ];
+
+    const result = aggregateMatchDetails(gameResults, []);
+
+    expect(
+      result.map(({ tableName, gameIndex, rank }) => ({ tableName, gameIndex, rank })),
+    ).toEqual([
+      { tableName: 'A卓', gameIndex: 1, rank: 1 },
+      { tableName: 'A卓', gameIndex: 1, rank: 3 },
+      { tableName: 'A卓', gameIndex: 2, rank: 1 },
+      { tableName: 'A卓', gameIndex: 2, rank: 2 },
+      { tableName: 'B卓', gameIndex: 1, rank: 1 },
+      { tableName: 'B卓', gameIndex: 1, rank: 2 },
+    ]);
+  });
+
   it('re-numbers gameIndex sequentially per table by timestamp', () => {
     const gameResults: CompetitionGameResult[] = [
       makeCompGameResult({

--- a/src/utils/competitionReport.ts
+++ b/src/utils/competitionReport.ts
@@ -165,7 +165,10 @@ export const aggregateMatchDetails = (
     }
   }
 
-  return details;
+  return details.sort(
+    (a, b) =>
+      a.tableName.localeCompare(b.tableName, 'ja') || a.gameIndex - b.gameIndex || a.rank - b.rank,
+  );
 };
 
 export const aggregateTableSummary = (


### PR DESCRIPTION
## 変更内容

対局別詳細の表示・エクスポート用データを、以下の昇順で並べ替えます。

1. 卓名
2. 対局番号
3. 順位

## 原因

集計結果が対局の時刻順・スコア配列順のまま返されていました。

## 確認

- `npm test`（543 passed, 5 skipped）
- `npm run build`
- `npx eslint src/utils/competitionReport.ts src/utils/competitionReport.test.ts`
