### PR TITLE
大会ライブビューに点数変動アニメーションとリーチ表示を追加

### DIFF
--- a/src/components/features/LiveTableTile.module.css
+++ b/src/components/features/LiveTableTile.module.css
@@ -101,6 +101,15 @@
   align-items: center;
   gap: var(--spacing-s);
   padding: var(--spacing-xs) 0;
+  position: relative;
+  border-radius: var(--border-radius-s);
+  transition: background-color 0.2s;
+}
+
+.riichi {
+  background-color: rgba(244, 67, 54, 0.15);
+  box-shadow: inset 3px 0 0 var(--color-danger);
+  padding-inline: var(--spacing-xs);
 }
 
 .wind {
@@ -110,13 +119,32 @@
   text-align: center;
 }
 
+.playerIdentity {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
 .playerName {
   font-size: var(--font-size-m);
   color: var(--color-text-primary);
-  flex: 1;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.riichiBadge {
+  flex-shrink: 0;
+  padding: 1px var(--spacing-xs);
+  border: 1px solid var(--color-danger);
+  border-radius: var(--border-radius-s);
+  background-color: rgba(244, 67, 54, 0.12);
+  color: var(--color-danger);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
+  line-height: 1.4;
 }
 
 .score {

--- a/src/components/features/LiveTableTile.test.tsx
+++ b/src/components/features/LiveTableTile.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useScoreAnimation } from '../../hooks/useScoreAnimation';
+import type { CompetitionTable, RoomState } from '../../types';
+import { LiveTableTile } from './LiveTableTile';
+
+vi.mock('../../hooks/useScoreAnimation', () => ({
+  useScoreAnimation: vi.fn(),
+}));
+
+const mockedUseScoreAnimation = vi.mocked(useScoreAnimation);
+
+const table: CompetitionTable = {
+  id: 'table-1',
+  name: 'A卓',
+  mode: '4ma',
+  status: 'playing',
+  playerIds: ['player-1', 'player-2'],
+  gameCount: 1,
+  createdAt: 1,
+  currentRoomId: 'room-1',
+};
+
+const room: RoomState = {
+  id: 'room-1',
+  hostId: 'player-1',
+  status: 'playing',
+  round: {
+    wind: 'East',
+    number: 1,
+    honba: 0,
+    riichiSticks: 1,
+  },
+  players: [
+    {
+      id: 'player-1',
+      name: '山田',
+      score: 27000,
+      isRiichi: true,
+      wind: 'East',
+      chip: 0,
+    },
+    {
+      id: 'player-2',
+      name: '佐藤',
+      score: 23000,
+      isRiichi: false,
+      wind: 'South',
+      chip: 0,
+    },
+  ],
+  playerIds: ['player-1', 'player-2'],
+  settings: {
+    mode: '4ma',
+    length: 'Hanchan',
+    startPoint: 25000,
+    returnPoint: 30000,
+    uma: [10, 20],
+    hasHonba: true,
+    honbaPoints: 300,
+    tenpaiRenchan: true,
+    useTobi: true,
+    useChip: false,
+    useOka: true,
+    useFuCalculation: true,
+    westExtension: false,
+    rate: 50,
+  },
+  lastEvent: {
+    id: 'event-1',
+    type: 'score_change',
+    deltas: {
+      'player-1': { hand: 3000, sticks: -1000 },
+      'player-2': { hand: -2000, sticks: 0 },
+    },
+  },
+};
+
+describe('LiveTableTile', () => {
+  beforeEach(() => {
+    mockedUseScoreAnimation.mockImplementation(({ playerId, score }) => ({
+      displayScore: score,
+      delta:
+        playerId === 'player-1' ? { value: 3000, type: 'hand' } : { value: -2000, type: 'hand' },
+      isAnimating: playerId === 'player-1',
+    }));
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('uses the match score animation for every live player', () => {
+    render(<LiveTableTile table={table} room={room} participants={[]} />);
+
+    expect(mockedUseScoreAnimation).toHaveBeenCalledWith({
+      playerId: 'player-1',
+      score: 27000,
+      lastEvent: room.lastEvent,
+    });
+    expect(mockedUseScoreAnimation).toHaveBeenCalledWith({
+      playerId: 'player-2',
+      score: 23000,
+      lastEvent: room.lastEvent,
+    });
+    expect(screen.getByText('+3,000')).not.toBeNull();
+    expect(screen.getByText('-2,000')).not.toBeNull();
+    expect(screen.getByText('27,000')).not.toBeNull();
+  });
+
+  it('identifies the player who is currently in riichi', () => {
+    render(<LiveTableTile table={table} room={room} participants={[]} />);
+
+    expect(screen.getByLabelText('山田はリーチ中')).not.toBeNull();
+    expect(screen.getByText('リーチ')).not.toBeNull();
+    expect(screen.queryByLabelText('佐藤はリーチ中')).toBeNull();
+  });
+});

--- a/src/components/features/LiveTableTile.tsx
+++ b/src/components/features/LiveTableTile.tsx
@@ -1,5 +1,6 @@
 import type { CompetitionParticipant, CompetitionTable, RoomState } from '../../types';
 import { windToKanji } from '../../utils/wind';
+import { AnimatedScore } from '../ui/AnimatedScore';
 import styles from './LiveTableTile.module.css';
 
 const STATUS_LABELS: Record<string, string> = {
@@ -23,8 +24,6 @@ const formatRound = (room: RoomState): string => {
   const base = `${wind}${num}局`;
   return honba > 0 ? `${base} ${honba}本場` : base;
 };
-
-const formatScore = (score: number): string => score.toLocaleString('ja-JP');
 
 interface LiveTableTileProps {
   table: CompetitionTable;
@@ -71,10 +70,23 @@ export const LiveTableTile = ({ table, room, participants }: LiveTableTileProps)
       {showRoomInfo ? (
         <div className={styles.players}>
           {room.players.map((player) => (
-            <div key={player.id} className={styles.playerRow}>
+            <div
+              key={player.id}
+              className={`${styles.playerRow} ${player.isRiichi ? styles.riichi : ''}`}
+              aria-label={player.isRiichi ? `${player.name}はリーチ中` : undefined}
+            >
               <span className={styles.wind}>{windToKanji(player.wind)}</span>
-              <span className={styles.playerName}>{player.name}</span>
-              <span className={styles.score}>{formatScore(player.score)}</span>
+              <span className={styles.playerIdentity}>
+                <span className={styles.playerName}>{player.name}</span>
+                {player.isRiichi && <span className={styles.riichiBadge}>リーチ</span>}
+              </span>
+              <AnimatedScore
+                playerId={player.id}
+                score={player.score}
+                lastEvent={room.lastEvent}
+                size="medium"
+                className={styles.score}
+              />
             </div>
           ))}
         </div>

--- a/src/components/features/ScoreBoard.module.css
+++ b/src/components/features/ScoreBoard.module.css
@@ -391,54 +391,6 @@
   margin-left: var(--spacing-xs);
 }
 
-/* Animations */
-.delta {
-  font-family: var(--font-mono);
-  font-size: var(--font-size-l);
-  font-weight: bold;
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  white-space: nowrap;
-  opacity: 0;
-  pointer-events: none;
-  z-index: 20;
-  text-shadow: 0 0 4px rgba(0, 0, 0, 0.8);
-}
-
-.deltaPositive {
-  color: var(--color-success);
-  animation: popInFade 1.5s ease-out forwards;
-}
-
-.deltaNegative {
-  color: var(--color-danger);
-  animation: popInFade 1.5s ease-out forwards;
-}
-
-@keyframes popInFade {
-  0% {
-    opacity: 0;
-    transform: translate(-50%, -40%) scale(0.5);
-  }
-
-  20% {
-    opacity: 1;
-    transform: translate(-50%, -50%) scale(1.2);
-  }
-
-  80% {
-    opacity: 1;
-    transform: translate(-50%, -50%) scale(1);
-  }
-
-  100% {
-    opacity: 0;
-    transform: translate(-50%, -60%);
-  }
-}
-
 @keyframes flashGreen {
   0% {
     background-color: rgba(76, 175, 80, 0);

--- a/src/components/features/ScoreBoard.tsx
+++ b/src/components/features/ScoreBoard.tsx
@@ -1,10 +1,9 @@
-import { useEffect, useRef, useState } from 'react';
-import { useScoreAnimation } from '../../hooks/useScoreAnimation';
+import { useState } from 'react';
 import type { LastEvent, Player, RoomState } from '../../types';
 import { getCurrentPlayerRanks } from '../../utils/resultCalculator';
 import { windToKanji } from '../../utils/wind';
+import { AnimatedScore } from '../ui/AnimatedScore';
 import { Button } from '../ui/Button';
-import { ScoreDisplay } from '../ui/ScoreDisplay';
 import styles from './ScoreBoard.module.css';
 
 const createDisplayScoreMap = (players: Player[]): Record<string, number> => {
@@ -176,22 +175,6 @@ const PlayerRow = ({
   rank?: number;
   isYakitori?: boolean;
 }) => {
-  const { displayScore, delta } = useScoreAnimation({
-    playerId: player.id,
-    score: player.score,
-    lastEvent,
-  });
-
-  const onDisplayScoreChangeRef = useRef(onDisplayScoreChange);
-
-  useEffect(() => {
-    onDisplayScoreChangeRef.current = onDisplayScoreChange;
-  }, [onDisplayScoreChange]);
-
-  useEffect(() => {
-    onDisplayScoreChangeRef.current(player.id, displayScore);
-  }, [displayScore, player.id]);
-
   const canRiichi = player.score >= 1000 && !player.isRiichi;
 
   return (
@@ -211,19 +194,13 @@ const PlayerRow = ({
 
       {/* Body: Score + Deltas */}
       <div className={styles.cardBody}>
-        {delta !== null && (
-          <div
-            key={`${delta.type}-${delta.value}`}
-            className={`${styles.delta} ${delta.value > 0 ? styles.deltaPositive : styles.deltaNegative}`}
-          >
-            {delta.value > 0 ? '+' : delta.value < 0 ? '-' : ''}
-            {Math.abs(delta.value).toLocaleString()}
-          </div>
-        )}
-        <ScoreDisplay
-          score={displayScore}
-          size="large" // CSS overrides this to 2rem
+        <AnimatedScore
+          playerId={player.id}
+          score={player.score}
+          lastEvent={lastEvent}
+          size="large"
           className={styles.playerScore}
+          onDisplayScoreChange={onDisplayScoreChange}
         />
         {rank !== undefined && <div className={styles.playerRank}>{rank}位</div>}
       </div>

--- a/src/components/ui/AnimatedScore.module.css
+++ b/src/components/ui/AnimatedScore.module.css
@@ -1,0 +1,46 @@
+.delta {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-l);
+  font-weight: bold;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  z-index: 20;
+  text-shadow: 0 0 4px rgba(0, 0, 0, 0.8);
+}
+
+.deltaPositive {
+  color: var(--color-success);
+  animation: popInFade 1.5s ease-out forwards;
+}
+
+.deltaNegative {
+  color: var(--color-danger);
+  animation: popInFade 1.5s ease-out forwards;
+}
+
+@keyframes popInFade {
+  0% {
+    opacity: 0;
+    transform: translate(-50%, -40%) scale(0.5);
+  }
+
+  20% {
+    opacity: 1;
+    transform: translate(-50%, -50%) scale(1.2);
+  }
+
+  80% {
+    opacity: 1;
+    transform: translate(-50%, -50%) scale(1);
+  }
+
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -60%);
+  }
+}

--- a/src/components/ui/AnimatedScore.tsx
+++ b/src/components/ui/AnimatedScore.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useRef } from 'react';
+import { useScoreAnimation } from '../../hooks/useScoreAnimation';
+import type { LastEvent } from '../../types';
+import { ScoreDisplay } from './ScoreDisplay';
+import styles from './AnimatedScore.module.css';
+
+interface AnimatedScoreProps {
+  playerId: string;
+  score: number;
+  lastEvent?: LastEvent;
+  size?: 'small' | 'medium' | 'large' | 'jumbo';
+  className?: string;
+  onDisplayScoreChange?: (playerId: string, score: number) => void;
+}
+
+export const AnimatedScore = ({
+  playerId,
+  score,
+  lastEvent,
+  size = 'large',
+  className,
+  onDisplayScoreChange,
+}: AnimatedScoreProps) => {
+  const { displayScore, delta } = useScoreAnimation({ playerId, score, lastEvent });
+  const onDisplayScoreChangeRef = useRef(onDisplayScoreChange);
+
+  useEffect(() => {
+    onDisplayScoreChangeRef.current = onDisplayScoreChange;
+  }, [onDisplayScoreChange]);
+
+  useEffect(() => {
+    onDisplayScoreChangeRef.current?.(playerId, displayScore);
+  }, [displayScore, playerId]);
+
+  return (
+    <>
+      {delta !== null && (
+        <span
+          key={`${delta.type}-${delta.value}`}
+          className={`${styles.delta} ${delta.value > 0 ? styles.deltaPositive : styles.deltaNegative}`}
+        >
+          {delta.value > 0 ? '+' : delta.value < 0 ? '-' : ''}
+          {Math.abs(delta.value).toLocaleString()}
+        </span>
+      )}
+      <ScoreDisplay score={displayScore} size={size} className={className} />
+    </>
+  );
+};


### PR DESCRIPTION
## 概要

大会ライブビューの各卓で、対局画面と同一の点数変動アニメーションを表示し、リーチ中のプレイヤーを明示します。

## 変更内容

- 対局画面の点数アニメーションを共通の `AnimatedScore` コンポーネントへ抽出
- ライブ卓の各プレイヤーにも同じ `useScoreAnimation`、増減表示、キーフレームを適用
- リーチ中のプレイヤー行を強調し、「リーチ」バッジとアクセシブルなラベルを表示
- 点数アニメーションの利用とリーチ表示を検証するコンポーネントテストを追加

## 背景

ライブ卓は更新後の点数を静的に表示しており、ルームの `lastEvent` と `isRiichi` を表示へ反映していませんでした。点数表示を共通化することで、対局画面とライブビューの挙動が乖離しない構成にしています。

## 影響

大会ライブビューの表示のみ拡張します。対局画面は既存アニメーションの実装場所が共通コンポーネントへ移るだけで、見た目と挙動は維持されます。

## 検証

- `npm test`（545件成功、5件skip）
- `npm run build`
- 変更対象への ESLint
- Prettier check
- `npm run test:coverage`（Statements 86.4%、Functions 82.11%、Lines 86.35%）