### PR TITLE
PDF出力時の対局別詳細の縞背景を復元

### DIFF
--- a/src/pages/CompetitionReportPage.module.css
+++ b/src/pages/CompetitionReportPage.module.css
@@ -280,11 +280,13 @@
     margin: 0 var(--spacing-xs) var(--spacing-xs) 0;
   }
 
-  .zebraEven td {
-    background: #f0f0f0;
-  }
-
   .table tbody tr:hover td {
     background: inherit;
+  }
+
+  .table tbody tr.zebraEven td {
+    background: #f0f0f0;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
   }
 }


### PR DESCRIPTION
## 概要

PDF出力した大会レポートの「対局別詳細」で、卓・対局番号ごとの縞背景が白一色になる回帰を修正します。

## 原因

PR #174 の印刷背景修正後、Chromeの印刷時の色補正によって薄灰色の背景が保持されない場合がありました。また、印刷用のhover解除指定が縞背景より優先されるセレクタになっていました。

## 変更内容

- 印刷時の縞背景セレクタを詳細化し、hover解除指定より優先
- `print-color-adjust: exact` とChrome向けの接頭辞付き指定を追加
- 画面表示のスタイルや卓ごとの対局番号ロジックは変更なし

## 影響

PDF（印刷）出力時に、各卓の対局番号が偶数の行グループを薄灰色で表示し、白背景との縞を復元します。

## 検証

- `npm run build`
- Vitest: 61ファイル、551件成功（5件skip）
- ESLint（対象ページ）
- Chrome 151のヘッドレス印刷でPDFを生成し、A卓・B卓とも対局番号単位の縞背景を視覚確認