### PR TITLE
対局を進めない100点単位の任意点数移動に対応

### DIFF
--- a/src/components/features/AdjustmentModal.module.css
+++ b/src/components/features/AdjustmentModal.module.css
@@ -104,6 +104,15 @@
   border-color: var(--color-primary);
 }
 
+.customInput[aria-invalid='true'] {
+  border-color: var(--color-danger);
+}
+
+.validationMessage {
+  color: var(--color-danger);
+  font-size: var(--font-size-s);
+}
+
 .descriptionInput {
   width: 100%;
   padding: var(--spacing-s) var(--spacing-m);

--- a/src/components/features/AdjustmentModal.test.tsx
+++ b/src/components/features/AdjustmentModal.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Player } from '../../types';
+import { AdjustmentModal } from './AdjustmentModal';
+
+afterEach(() => {
+  cleanup();
+});
+
+const players: Player[] = [
+  { id: 'p1', name: 'Alice', score: 25000, isRiichi: false, wind: 'East', chip: 0 },
+  { id: 'p2', name: 'Bob', score: 25000, isRiichi: false, wind: 'South', chip: 0 },
+];
+
+const selectParticipants = () => {
+  fireEvent.click(screen.getAllByRole('button', { name: 'Alice' })[0]);
+  fireEvent.click(screen.getAllByRole('button', { name: 'Bob' })[1]);
+};
+
+describe('AdjustmentModal', () => {
+  it('submits an arbitrary amount in 100-point increments', () => {
+    const onConfirm = vi.fn();
+    render(<AdjustmentModal isOpen onClose={vi.fn()} players={players} onConfirm={onConfirm} />);
+    selectParticipants();
+
+    const amountInput = screen.getByRole('spinbutton', { name: '一人あたりの点数' });
+    expect(amountInput.getAttribute('min')).toBe('100');
+    expect(amountInput.getAttribute('step')).toBe('100');
+
+    fireEvent.change(amountInput, { target: { value: '500' } });
+    fireEvent.click(screen.getByRole('button', { name: '確定' }));
+
+    expect(onConfirm).toHaveBeenCalledWith({
+      payerId: 'p1',
+      receiverIds: ['p2'],
+      amount: 500,
+      description: undefined,
+    });
+  });
+
+  it('does not allow an amount outside 100-point increments', () => {
+    const onConfirm = vi.fn();
+    render(<AdjustmentModal isOpen onClose={vi.fn()} players={players} onConfirm={onConfirm} />);
+    selectParticipants();
+
+    const amountInput = screen.getByRole('spinbutton', { name: '一人あたりの点数' });
+    fireEvent.change(amountInput, { target: { value: '150' } });
+
+    expect(amountInput.getAttribute('aria-invalid')).toBe('true');
+    expect(screen.getByText('100点単位で入力してください')).not.toBeNull();
+    expect(screen.getByRole('button', { name: '確定' }).hasAttribute('disabled')).toBe(true);
+    expect(onConfirm).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: '1,000' }));
+    expect(screen.queryByText('100点単位で入力してください')).toBeNull();
+    expect((amountInput as HTMLInputElement).value).toBe('');
+  });
+
+  it('resets the transfer when cancelled', () => {
+    const onClose = vi.fn();
+    render(<AdjustmentModal isOpen onClose={onClose} players={players} onConfirm={vi.fn()} />);
+    selectParticipants();
+    fireEvent.change(screen.getByRole('spinbutton', { name: '一人あたりの点数' }), {
+      target: { value: '500' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'キャンセル' }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('button', { name: '確定' }).hasAttribute('disabled')).toBe(true);
+  });
+});

--- a/src/components/features/AdjustmentModal.tsx
+++ b/src/components/features/AdjustmentModal.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react';
+import { useId, useState } from 'react';
 import type { Player } from '../../types';
-import type { AdjustmentParams } from '../../utils/adjustment';
+import { isValidAdjustmentAmount, type AdjustmentParams } from '../../utils/adjustment';
 import { Button } from '../ui/Button';
 import { Modal } from '../ui/Modal';
 import styles from './AdjustmentModal.module.css';
@@ -15,6 +15,8 @@ interface AdjustmentModalProps {
 const AMOUNT_PRESETS = [1000, 2000, 3000, 4000, 8000, 12000];
 
 export const AdjustmentModal = ({ isOpen, onClose, players, onConfirm }: AdjustmentModalProps) => {
+  const amountInputId = useId();
+  const amountErrorId = useId();
   const [payerId, setPayerId] = useState<string | null>(null);
   const [receiverIds, setReceiverIds] = useState<string[]>([]);
   const [amount, setAmount] = useState<number>(0);
@@ -45,12 +47,13 @@ export const AdjustmentModal = ({ isOpen, onClose, players, onConfirm }: Adjustm
 
   const handleCustomAmountChange = (value: string) => {
     setCustomAmount(value);
-    const parsed = parseInt(value, 10);
-    setAmount(Number.isFinite(parsed) && parsed > 0 ? parsed : 0);
+    setAmount(value === '' ? 0 : Number(value));
   };
 
   const effectiveAmount = amount;
-  const isValid = payerId !== null && receiverIds.length > 0 && effectiveAmount > 0;
+  const hasInvalidCustomAmount = customAmount !== '' && !isValidAdjustmentAmount(effectiveAmount);
+  const isValid =
+    payerId !== null && receiverIds.length > 0 && isValidAdjustmentAmount(effectiveAmount);
 
   const handleConfirm = () => {
     if (!isValid || !payerId) return;
@@ -106,7 +109,9 @@ export const AdjustmentModal = ({ isOpen, onClose, players, onConfirm }: Adjustm
 
         {/* Amount */}
         <div className={styles.amountSection}>
-          <span className={styles.sectionLabel}>一人あたりの点数</span>
+          <label className={styles.sectionLabel} htmlFor={amountInputId}>
+            一人あたりの点数
+          </label>
           <div className={styles.presetGrid}>
             {AMOUNT_PRESETS.map((preset) => (
               <button
@@ -120,13 +125,23 @@ export const AdjustmentModal = ({ isOpen, onClose, players, onConfirm }: Adjustm
             ))}
           </div>
           <input
+            id={amountInputId}
             type="number"
             inputMode="numeric"
+            min={100}
+            step={100}
             className={styles.customInput}
-            placeholder="カスタム点数"
+            placeholder="100点単位で入力"
             value={customAmount}
             onChange={(e) => handleCustomAmountChange(e.target.value)}
+            aria-invalid={hasInvalidCustomAmount}
+            aria-describedby={hasInvalidCustomAmount ? amountErrorId : undefined}
           />
+          {hasInvalidCustomAmount && (
+            <span id={amountErrorId} className={styles.validationMessage} role="alert">
+              100点単位で入力してください
+            </span>
+          )}
         </div>
 
         {/* Description */}

--- a/src/hooks/useMatchGame.test.ts
+++ b/src/hooks/useMatchGame.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { RoomState } from '../types';
+import { createDefaultRoomSettings } from '../utils/roomDefaults';
+import { useMatchGame } from './useMatchGame';
+
+afterEach(() => {
+  cleanup();
+});
+
+const createRoom = (): RoomState => ({
+  id: 'ROOM01',
+  hostId: 'p1',
+  status: 'playing',
+  round: {
+    wind: 'South',
+    number: 3,
+    honba: 2,
+    riichiSticks: 1,
+  },
+  players: [
+    { id: 'p1', name: 'Alice', score: 100, isRiichi: true, wind: 'East', chip: 2 },
+    { id: 'p2', name: 'Bob', score: 24900, isRiichi: false, wind: 'South', chip: -2 },
+    { id: 'p3', name: 'Carol', score: 25000, isRiichi: false, wind: 'West', chip: 0 },
+    { id: 'p4', name: 'Dave', score: 25000, isRiichi: false, wind: 'North', chip: 0 },
+  ],
+  playerIds: ['p1', 'p2', 'p3', 'p4'],
+  settings: {
+    ...createDefaultRoomSettings('4ma'),
+    useTobi: true,
+  },
+  history: [],
+  currentLogs: [],
+  gameResults: [],
+});
+
+describe('useMatchGame handleAdjustment', () => {
+  it('only transfers points and records history without advancing or ending the hand', async () => {
+    const room = createRoom();
+    const persistedUpdates: Partial<RoomState>[] = [];
+    const updateState = vi.fn(async (updates: Partial<RoomState>) => {
+      persistedUpdates.push(updates);
+    });
+    const { result } = renderHook(() => useMatchGame({ room, updateState }));
+
+    await act(async () => {
+      await result.current.handleAdjustment({
+        payerId: 'p1',
+        receiverIds: ['p2'],
+        amount: 200,
+        description: 'テスト移動',
+      });
+    });
+
+    expect(updateState).toHaveBeenCalledTimes(1);
+    const [updates] = persistedUpdates;
+
+    expect(
+      updates.players?.map(({ id, score, isRiichi, wind, chip }) => ({
+        id,
+        score,
+        isRiichi,
+        wind,
+        chip,
+      })),
+    ).toEqual([
+      { id: 'p1', score: -100, isRiichi: true, wind: 'East', chip: 2 },
+      { id: 'p2', score: 25100, isRiichi: false, wind: 'South', chip: -2 },
+      { id: 'p3', score: 25000, isRiichi: false, wind: 'West', chip: 0 },
+      { id: 'p4', score: 25000, isRiichi: false, wind: 'North', chip: 0 },
+    ]);
+    expect(updates).not.toHaveProperty('round');
+    expect(updates).not.toHaveProperty('status');
+    expect(updates).not.toHaveProperty('gameResults');
+    expect(updates.currentLogs?.at(-1)?.result).toMatchObject({
+      type: 'Adjustment',
+      description: 'テスト移動',
+      scoreDeltas: { p1: -200, p2: 200 },
+    });
+    expect(updates.history).toHaveLength(1);
+    expect(updates.history?.[0]).toMatchObject({
+      status: 'playing',
+      round: room.round,
+      players: room.players,
+    });
+  });
+});

--- a/src/hooks/useMatchGame.ts
+++ b/src/hooks/useMatchGame.ts
@@ -427,27 +427,14 @@ export const useMatchGame = ({ room, updateState }: UseMatchGameOptions): UseMat
 
       const nextLogs = [...(room.currentLogs || []), handLog];
 
-      // Tobi (Bankruptcy) check
-      const isBankruptcy = room.settings.useTobi && newPlayers.some((p) => p.score < 0);
-      let nextGameResults = room.gameResults || [];
-      if (isBankruptcy) {
-        const result = calculateFinalScores(newPlayers, room.settings, generateId(12), {
-          handLogs: nextLogs,
-        });
-        result.logs = nextLogs;
-        nextGameResults = [...nextGameResults, result];
-        triggerGameEndTransition();
-      }
-
       await updateState({
         players: newPlayers,
         history: newHistory as RoomState[],
         lastEvent,
-        currentLogs: isBankruptcy ? [] : nextLogs,
-        ...(isBankruptcy ? { status: 'finished' as const, gameResults: nextGameResults } : {}),
+        currentLogs: nextLogs,
       });
     },
-    [room, updateState, triggerGameEndTransition],
+    [room, updateState],
   );
 
   const handleStartGame = useCallback(async () => {

--- a/src/utils/adjustment.test.ts
+++ b/src/utils/adjustment.test.ts
@@ -46,6 +46,70 @@ describe('applyAdjustment', () => {
     expect(result.newPlayers.find((p) => p.id === 'p4')!.score).toBe(25000);
   });
 
+  it('allows a 100-point transfer', () => {
+    const result = applyAdjustment(createPlayers(), round, {
+      payerId: 'p1',
+      receiverIds: ['p2'],
+      amount: 100,
+    });
+
+    expect(result.scoreDeltas).toMatchObject({ p1: -100, p2: 100 });
+  });
+
+  it.each([
+    { label: 'zero', amount: 0 },
+    { label: 'negative', amount: -100 },
+    { label: 'less than 100 points', amount: 50 },
+    { label: 'not a 100-point increment', amount: 150 },
+    { label: 'fractional', amount: 100.5 },
+    { label: 'not finite', amount: Number.POSITIVE_INFINITY },
+  ])('rejects an amount that is $label', ({ amount }) => {
+    expect(() =>
+      applyAdjustment(createPlayers(), round, {
+        payerId: 'p1',
+        receiverIds: ['p2'],
+        amount,
+      }),
+    ).toThrow('点数は100点単位の正の整数で指定してください');
+  });
+
+  it.each([
+    {
+      label: 'the payer is unknown',
+      params: { payerId: 'unknown', receiverIds: ['p2'], amount: 100 },
+    },
+    {
+      label: 'a receiver is unknown',
+      params: { payerId: 'p1', receiverIds: ['unknown'], amount: 100 },
+    },
+    {
+      label: 'there is no receiver',
+      params: { payerId: 'p1', receiverIds: [], amount: 100 },
+    },
+    {
+      label: 'the payer is also a receiver',
+      params: { payerId: 'p1', receiverIds: ['p1'], amount: 100 },
+    },
+    {
+      label: 'a receiver is duplicated',
+      params: { payerId: 'p1', receiverIds: ['p2', 'p2'], amount: 100 },
+    },
+  ])('rejects invalid participants when $label', ({ params }) => {
+    expect(() => applyAdjustment(createPlayers(), round, params)).toThrow();
+  });
+
+  it('rejects a transfer whose total cannot be represented safely', () => {
+    const largestSafe100PointAmount = Math.floor(Number.MAX_SAFE_INTEGER / 100) * 100;
+
+    expect(() =>
+      applyAdjustment(createPlayers(), round, {
+        payerId: 'p1',
+        receiverIds: ['p2', 'p3'],
+        amount: largestSafe100PointAmount,
+      }),
+    ).toThrow('合計点数が大きすぎます');
+  });
+
   it('creates a HandLog with type Adjustment and description', () => {
     const players = createPlayers();
     const result = applyAdjustment(players, round, {

--- a/src/utils/adjustment.ts
+++ b/src/utils/adjustment.ts
@@ -14,11 +14,45 @@ export interface AdjustmentResult {
   scoreDeltas: Record<string, number>;
 }
 
+export const isValidAdjustmentAmount = (amount: number): boolean => {
+  return Number.isSafeInteger(amount) && amount > 0 && amount % 100 === 0;
+};
+
+const validateAdjustment = (players: Player[], params: AdjustmentParams): void => {
+  const playerIds = new Set(players.map((player) => player.id));
+
+  if (!isValidAdjustmentAmount(params.amount)) {
+    throw new Error('点数は100点単位の正の整数で指定してください');
+  }
+  if (!playerIds.has(params.payerId)) {
+    throw new Error('支払い元が対局者に含まれていません');
+  }
+  if (params.receiverIds.length === 0) {
+    throw new Error('受取先を1人以上指定してください');
+  }
+
+  const uniqueReceiverIds = new Set(params.receiverIds);
+  if (uniqueReceiverIds.size !== params.receiverIds.length) {
+    throw new Error('受取先を重複して指定できません');
+  }
+  if (uniqueReceiverIds.has(params.payerId)) {
+    throw new Error('支払い元を受取先に指定できません');
+  }
+  if (params.receiverIds.some((receiverId) => !playerIds.has(receiverId))) {
+    throw new Error('受取先が対局者に含まれていません');
+  }
+  if (!Number.isSafeInteger(params.amount * params.receiverIds.length)) {
+    throw new Error('合計点数が大きすぎます');
+  }
+};
+
 export const applyAdjustment = (
   players: Player[],
   round: RoomState['round'],
   params: AdjustmentParams,
 ): AdjustmentResult => {
+  validateAdjustment(players, params);
+
   const { payerId, receiverIds, amount, description } = params;
   const totalDeduction = amount * receiverIds.length;
 


### PR DESCRIPTION
## 概要

対局中の点数調整を、100点単位の任意点数を安全にやり取りできる操作として明確化しました。

## 変更内容

- カスタム点数入力を100点単位にし、不正値を画面上で表示して確定不可に変更
- ドメイン層でも正数・100点単位・安全な整数・対局者ID・受取先重複を検証
- 点数移動で持ち点が負になってもトビ終了判定を発火しないよう変更
- 点数以外の局・本場・供託・親・立直状態・対局ステータスを更新しないことをテストで固定
- 点数移動ログとUndo用スナップショットは従来どおり保存

## 確認内容

- `npm run lint`
- `npm run test:coverage`（63ファイル、568件成功、5件スキップ）
- `npm run build`
- `git diff --check`

Closes #181