### PR TITLE
fix: 分析メモの牌数警告基準を修正

### DIFF
--- a/src/components/features/AnalysisDetailModal.test.tsx
+++ b/src/components/features/AnalysisDetailModal.test.tsx
@@ -2,7 +2,7 @@
 
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { AnalysisEntry } from '../../types';
+import type { AnalysisEntry, Meld } from '../../types';
 import { AnalysisDetailModal } from './AnalysisDetailModal';
 
 afterEach(() => {
@@ -354,6 +354,99 @@ describe('AnalysisDetailModal', () => {
     await waitFor(() => {
       expect(handleSave).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it('does not warn when 13 concealed tiles and a matching winning tile make 14 tiles', () => {
+    render(
+      <AnalysisDetailModal
+        isOpen
+        mode="create"
+        entry={createAnalysisEntry(
+          {},
+          {
+            hand: {
+              concealed: [
+                '1m',
+                '2m',
+                '3m',
+                '4m',
+                '5m',
+                '6m',
+                '1p',
+                '2p',
+                '3p',
+                '1s',
+                '2s',
+                '3s',
+                '1z',
+              ],
+              melds: [],
+              winningTile: '1z',
+              winningTileSource: 'tsumo',
+            },
+          },
+        )}
+        onClose={() => undefined}
+        onSave={() => Promise.resolve()}
+      />,
+    );
+
+    expect(screen.queryByText(/牌数が .* 枚です/)).toBeNull();
+  });
+
+  it.each<[string, Meld]>([
+    ['minkan', { kind: 'minkan', tiles: ['1z', '1z', '1z', '1z'], from: 'shimocha' }],
+    ['ankan', { kind: 'ankan', tiles: ['1z', '1z', '1z', '1z'] }],
+    ['kakan', { kind: 'kakan', tiles: ['1z', '1z', '1z', '1z'], from: 'shimocha' }],
+  ])('uses 15 tiles as the warning threshold after one %s', (_kind, meld) => {
+    render(
+      <AnalysisDetailModal
+        isOpen
+        mode="create"
+        entry={createAnalysisEntry(
+          {},
+          {
+            hand: {
+              concealed: ['1m', '2m', '3m', '4m', '5m', '6m', '1p', '2p', '3p', '1s'],
+              melds: [meld],
+              winningTile: '1s',
+              winningTileSource: 'tsumo',
+            },
+          },
+        )}
+        onClose={() => undefined}
+        onSave={() => Promise.resolve()}
+      />,
+    );
+
+    expect(screen.queryByText(/牌数が .* 枚です/)).toBeNull();
+  });
+
+  it('increases the warning threshold for every kan', () => {
+    render(
+      <AnalysisDetailModal
+        isOpen
+        mode="create"
+        entry={createAnalysisEntry(
+          {},
+          {
+            hand: {
+              concealed: ['1m', '2m', '3m', '4m', '5m', '6m', '1p'],
+              melds: [
+                { kind: 'ankan', tiles: ['1z', '1z', '1z', '1z'] },
+                { kind: 'minkan', tiles: ['2z', '2z', '2z', '2z'], from: 'kamicha' },
+              ],
+              winningTile: '1p',
+              winningTileSource: 'tsumo',
+            },
+          },
+        )}
+        onClose={() => undefined}
+        onSave={() => Promise.resolve()}
+      />,
+    );
+
+    expect(screen.queryByText(/牌数が .* 枚です/)).toBeNull();
   });
 
   it('allows deleting in edit mode', async () => {

--- a/src/components/features/AnalysisDetailModal.tsx
+++ b/src/components/features/AnalysisDetailModal.tsx
@@ -99,11 +99,7 @@ const getEntryIdentity = (entry: AnalysisEntry) => {
 const getTileCount = (entry: AnalysisEntry) => {
   const meldTileCount = entry.hand.melds.reduce((total, meld) => total + meld.tiles.length, 0);
   const winningTileCount =
-    entry.context.eventType === 'tenpai-draw' ||
-    !entry.hand.winningTile ||
-    entry.hand.concealed.includes(entry.hand.winningTile)
-      ? 0
-      : 1;
+    entry.context.eventType !== 'tenpai-draw' && entry.hand.winningTile ? 1 : 0;
 
   return entry.hand.concealed.length + meldTileCount + winningTileCount;
 };
@@ -111,7 +107,10 @@ const getTileCount = (entry: AnalysisEntry) => {
 const getWarnings = (entry: AnalysisEntry): string[] => {
   const warnings: string[] = [];
   const tileCount = getTileCount(entry);
-  const expectedTileCount = entry.context.eventType === 'tenpai-draw' ? 13 : 14;
+  const kanCount = entry.hand.melds.filter(
+    (meld) => meld.kind === 'minkan' || meld.kind === 'ankan' || meld.kind === 'kakan',
+  ).length;
+  const expectedTileCount = (entry.context.eventType === 'tenpai-draw' ? 13 : 14) + kanCount;
 
   if (tileCount === 0) {
     warnings.push('手牌が未入力です');


### PR DESCRIPTION
## 概要

分析メモの牌数警告が、正しい和了形でも表示される問題を修正します。

## 変更内容

- ツモ・ロンの和了牌を手牌と同種でも別の1枚として数える
- 警告の基準枚数を、和了時は `14 + カン回数`、テンパイ流局時は `13 + カン回数` とする
- 明槓・暗槓・加槓、および複数回のカンを対象に回帰テストを追加
- テスト用手牌を実際に成立する単騎待ちへ調整

## 原因

和了牌と同じ牌種が手牌に含まれる場合、和了牌を重複とみなして加算していませんでした。また、カンによって実牌数が増えても警告基準が14枚のままでした。

## 影響

正しい14枚の和了形、およびカン1回ごとに1枚増える正しい牌数では、不要な警告が表示されなくなります。

## 検証

- `npm test`（63ファイル、573テスト成功、5件スキップ）
- `npm run build`
- 対象ファイルのESLint
- 対象ファイルのPrettierチェック